### PR TITLE
Update block--inline-block--hero-unit.html.twig

### DIFF
--- a/templates/block/block--inline-block--hero-unit.html.twig
+++ b/templates/block/block--inline-block--hero-unit.html.twig
@@ -87,7 +87,7 @@
 			{% endif %}
 			{% set linkColor = content['#block_content'].field_link_color.value %}
 			{# Dont let twig render the links #}
-			<div class="ucb-hero-unit-content">
+			<div class="ucb-hero-unit-content container">
 				<div class="row">
 					{% if content['#block_content'].field_text_align.value == "text-righthalf" %}
 						<div class="col-12 col-md-6"></div>


### PR DESCRIPTION
Added container class back to content to make hero unit text line up with other text

Let me know if the "contained" option is still okay as is. The background image aligns with the text but the content itself has padding