### PR TITLE
Change: People List Page Design

### DIFF
--- a/.github/workflows/draft-release.yml
+++ b/.github/workflows/draft-release.yml
@@ -1,0 +1,16 @@
+name: "Draft new release"
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'The version you want to release.'
+        required: true
+
+
+jobs:
+  draft-new-release:
+    uses: CuBoulder/action-collection/.github/workflows/draft-release.yml@main
+    secrets:
+      envPAT: ${{ secrets.GITHUB_TOKEN }}
+

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -1,0 +1,15 @@
+name: "Publish new release"
+
+on:
+  pull_request:
+    branches:
+      - main
+    types:
+      - closed
+
+jobs:
+  release:
+    uses: CuBoulder/action-collection/.github/workflows/publish-release.yml@main
+    secrets:
+      envPAT: ${{ secrets.GITHUB_TOKEN }}
+

--- a/.github/workflows/update-changelog.yml
+++ b/.github/workflows/update-changelog.yml
@@ -1,0 +1,11 @@
+name: Update changelog on PR merge
+on:
+  pull_request:
+    branches:
+      - main
+    types: closed
+
+jobs:
+  update_changelog:
+    uses: CuBoulder/action-collection/.github/workflows/update-changelog.yml@main
+

--- a/css/ucb-people-list.css
+++ b/css/ucb-people-list.css
@@ -89,6 +89,6 @@ thead.ucb-people-list-table-head {
   background: #ccc;
 }
 
-tbody#ucb-people-list-table-tablebody {
+tbody.ucb-people-list-table-tablebody {
   background: #fafafa;
 }

--- a/css/ucb-people-list.css
+++ b/css/ucb-people-list.css
@@ -1,12 +1,19 @@
 .ucb-list-msg {
-  font-size: 1.25em;
-  font-weight: bolder;
-  text-align: center;
-  display: none;
+	font-size: 1.25em;
+	font-weight: bolder;
+	text-align: center;
 }
 
 .ucb-loading-data {
-  color: #01579b;
+	color: #01579b;
+	text-align: center;
+}  
+
+.ucb-list-msg, .ucb-loading-data {
+	display: block;
+}
+.ucb-list-msg[hidden], .ucb-loading-data[hidden] {
+	display: none;
 }
 
 .ucb-person-card-list {

--- a/css/ucb-people-list.css
+++ b/css/ucb-people-list.css
@@ -130,3 +130,7 @@ tbody.ucb-people-list-table-tablebody {
     color: #222;
     background: #EEEEEE;
 }
+
+.people-list-filter .taxonomy-select {
+	max-width: 150px;
+}

--- a/css/ucb-person.css
+++ b/css/ucb-person.css
@@ -8,7 +8,7 @@ h1.ucb-person-name span {
 }
 
 .ucb-person-section {
-	margin-bottom: 10px;
+  margin-bottom: 10px;
 }
 
 .ucb-person-main img {
@@ -47,10 +47,34 @@ a.ucb-person-social-link i.fab {
 }
 
 .ucb-person-section-header {
-	display: block;
-	font-weight: bold;
+  display: block;
+  font-weight: bold;
 }
 
-.ucb-person-section.ucb-person-links, .ucb-person-section.ucb-person-address, .ucb-person-section.ucb-person-office-hours, .ucb-person-section.ucb-person-body {
-	margin-top: 20px;
+.ucb-person-section.ucb-person-links,
+.ucb-person-section.ucb-person-address,
+.ucb-person-section.ucb-person-office-hours,
+.ucb-person-section.ucb-person-body {
+  margin-top: 20px;
+}
+
+ul.ucb-person-title li:not(:first-child):before,
+ul.ucb-person-department li:not(:first-child):before {
+  font-family: "Font Awesome 5 Free";
+  font-weight: 900;
+ font-size: 0.25em;
+  content: "\f111";
+  vertical-align: middle;
+  padding: 0 0.25em;
+}
+
+.ucb-person-title li,
+.ucb-person-department li{
+  display: inline-block;
+}
+
+.ucb-person-title,
+.ucb-person-department {
+  padding-left: 0;
+  margin-bottom: 0;
 }

--- a/js/ucb-people-list.js
+++ b/js/ucb-people-list.js
@@ -691,9 +691,9 @@ class PeopleListElement extends HTMLElement {
         allOption.value = JSON.stringify([{id:'', name: '',fieldName:''}])
         // If restricted, set to Default instead of All
 		if(filters.filter_2.restrict){
-			allOption.innerText = 'Default'
-		} else {
 			allOption.innerText = 'All'
+		} else {
+			allOption.innerText = 'Default'
 		}
         // Append
         selectFilter2.appendChild(allOption)    
@@ -761,7 +761,7 @@ class PeopleListElement extends HTMLElement {
             }
       })
 	  // If only 2 options- default and one other option, these mean the same thing. Remove default.
-	  if(selectEl.children.length == 2 && selectEl.children[0].innerText == 'Default'){
+	  if(selectEl.children.length == 2 && selectEl.children[0].innerText == 'All'){
 		  selectEl.removeChild(selectEl.children[0])
 	  }
     }

--- a/js/ucb-people-list.js
+++ b/js/ucb-people-list.js
@@ -216,6 +216,7 @@ class PeopleListElement extends HTMLElement {
   
     // TO DO -- issue here with header adding correctly to grid
     if (DISPLAYFORMAT === 'grid' || DISPLAYFORMAT === 'table') {
+      console.log(el)
       el.appendChild(parentContainer)
     }
   
@@ -454,7 +455,7 @@ class PeopleListElement extends HTMLElement {
         pageBody.appendChild(container)
         
         }else {
-          container = this._contentElement;
+          container = this._contentElement.children[0];
         }
         renderedTable++; 
         break
@@ -804,7 +805,7 @@ class PeopleListElement extends HTMLElement {
     formDiv.appendChild(formButtonContainer)
     form.appendChild(formDiv)
     // Append final container
-    this.parentElement.insertBefore(form, this.parentElement.children[2])
+    // this.parentElement.insertBefore(form, this.parentElement.children[2])
   }
 }
 

--- a/js/ucb-people-list.js
+++ b/js/ucb-people-list.js
@@ -1,605 +1,15 @@
 
-/* naughty global variables!!! */
+// /* naughty global variables!!! */
 let Departments = {} // translate table for department id => department name
 let JobTypes = {} // translate table for type id => type name
 let ourPepole = {} // all of the pepole that match our filter 
 let renderedTable = 0;  // flag to know if we've rendered the table header or not yet
 let firstPassCount = 0; // count for the first pass per group.  
 
-/**
- * Helper function to toggle show hide on an element 
- * @param {string} id // element id to toggle
- * @param {string} display // value to change it to (block | none)
- */
-function toggleMessage(id, display = 'none') {
-  if (id) {
-    var toggle = document.getElementById(id)
-
-    if (toggle) {
-      if (display === 'block') {
-        toggle.style.display = 'block'
-      } else {
-        toggle.style.display = 'none'
-      }
-    }
-  }
-}
-
-/**
- * Helper function to load the data for a taxonomy from the JSON:API endpoint 
- * we need this to get the human-friendly names of the items in this vocabulary
- * @param {string} taxonomyName // Drupal machine name of the taxonomy to retrieve 
- * @returns Promise with resolve or reject 
- */
-function getTaxonomy(taxonomyName) {
-  return new Promise(function (resolve, reject) {
-    if (taxonomyName) {
-      let result = [] 
-      let taxonomyURL = `/jsonapi/taxonomy_term/${taxonomyName}?sort=weight,name`
-
-      fetch(taxonomyURL)
-        .then((response) => response.json())
-        .then((data) => {
-          // console.log("Taxonomy Object : ", data)
-          data.data.map((attributes) => {
-            let id = attributes.attributes.drupal_internal__tid
-            let name = attributes.attributes.name
-            let thisTerm = {}
-
-            thisTerm['id'] = id
-            thisTerm['name'] = name
-            result.push(thisTerm) 
-          })
-
-          resolve(result)
-        })
-    } else {
-      // no taxonomy term to load
-      reject
-    }
-  })
-}
-
-/**
- * Find the taxonomy that matches the id ... makes it easier to retrieve the name
- * @param {*} taxonomy // taxonomy vocab to searh 
- * @param {*} tid // id to find in the array of hashes
- * @returns hash {{ name => "name", id => "id"}}
- */
-function getTaxonomyName(taxonomy, tid) {
-  // console.log(taxonomy)
-  return taxonomy.find( ({ id }) => id === tid );
-}
-
-/**
- * Main function to get People nodes based on the JSON:API URL  
- * @param {string} JSONAPI // JSON:API enpoint URL with required filters and sorts
- * @returns Promise with resolve or reject
- */
-function getStaff(JSONAPI) {
-  return new Promise(function (resolve, reject) {
-    if (JSONAPI) {
-      fetch(JSONAPI)
-        .then((response) => response.json())
-        .then((data) => {
-          if(data.data.length === 0) {
-            console.log("No people matching the filter returned.")
-            toggleMessage('ucb-al-end-of-data', 'block')
-          }
-          resolve(data)
-        })
-    } else {
-      toggleMessage('ucb-al-error', 'block')
-      reject
-    }
-  })
-}
-
-/**
- * Each Format needs a different parent element before people can be inserted
- * this function ensures the correct parent wrapper element is created for data
- * @param {string} Format // display format in use (grid | list | table) 
- * @returns document.elment 
- */
-function getParentContainer(Format) {
-  // console.log("my format is", Format)
-  let container = ''
-  switch (Format) {
-    case 'List':
-      break
-    case 'Grid':
-      container = document.getElementById('ucb-pl-content')
-      container.classList = "row ucb-people-list-content"
-      break
-    case 'Table':
-      // we only need to render the table header the first time
-      // this function will be called multiple times so check to 
-      // see if we've already rendered the table header HTML
-      if(!renderedTable) {
-      let pageBody = document.getElementById('ucb-pl-content')
-      container = document.createElement('table')
-      container.id = 'ucb-pl-table'
-      container.classList = 'table  table-bordered table-striped'
-      tableHead = document.createElement('thead')
-      tableHead.classList = 'ucb-people-list-table-head'
-      tableRow = document.createElement('tr')
-      tableRow.innerHTML = `
-            <th><span class="sr-only">Photo</span></th>
-            <th>Name</th>
-            <th>Contact Information</th>
-      `
-      tableBody = document.createElement('tbody')
-      tableBody.id = 'ucb-people-list-table-tablebody'
-      tableHead.appendChild(tableRow)
-      container.appendChild(tableHead)
-      container.appendChild(tableBody)
-      pageBody.appendChild(container)
-      
-      }else {
-        container = document.getElementById('ucb-pl-table')
-      }
-      renderedTable++; 
-      break
-    default:
-  }
-  return container
-}
-
-/**
- * Function to render the indivdual person card in the correct format  
- * @param {string} Format // display format (grid | list | table)
- * @param {object} Person // person object containing the content to render the card
- * @returns HTML string to be rendered
- */
-function displayPersonCard(Format, Person) {
-  // console.log('Rendering the card for ' + Person.Name)
-  let cardHTML = ''
-  // grab the friendly name from the global variable
-  // note: there may be a race condidtion here as we're also querying
-  //  to get those friendly names from the API endpoint.
-  // console.log('Departments :', Departments)
-  let myDept = ""
-  for(let i = 0; i < Person.Dept.length; i++) {
-    let thisDeptID = Person.Dept[i]
-    let thisDeptName = getTaxonomyName(Departments, thisDeptID).name;
-    myDept += `<li>${thisDeptName}</li>`
-  }
-  let myPhoto = ''
-  if (Person.PhotoURL) {
-    myPhoto = `<img src="${Person.PhotoURL}"  />`
-  }
-
-  switch (Format) {
-    case 'List':
-      cardHTML = `
-                <div class="ucb-person-card-list row">
-                    <div class="col-sm-12 col-md-3 ucb-person-card-img">
-                        <a href="${Person.Link}">${myPhoto}</a>
-                    </div>
-                    <div class="col-sm-12 col-md-9 ucb-person-card-details">
-                        <a href="${Person.Link}">
-                            <span class="ucb-person-card-name">
-                                ${Person.Name ? Person.Name : ''}
-                            </span>
-                        </a>
-                        <span class="ucb-person-card-title">
-                            ${Person.Title ? Person.Title : ''}
-                        </span>
-                    <span class="ucb-person-card-dept">
-                      <ul class="ucb-person-card-dept-ul">
-                        ${myDept} 
-                      </ul>
-                    </span>
-                    <span class="ucb-person-card-body">
-                        ${Person.Body ? Person.Body : ''}
-                    </span>
-                    <div class="ucb-person-card-contact">
-                        <span class="ucb-person-card-email">
-                            ${
-                              Person.Email
-                                ? `<a href="mailto:${Person.Email}"><span class="ucb-people-list-contact">  ${Person.Email}</span></a>`
-                                : ''
-                            }
-                        </span>
-                        <span class="ucb-person-card-phone">
-                            ${
-                              Person.Phone
-                                ? `<a href="tel:${Person.Phone.replace(
-                                    /[^+\d]+/g,
-                                    '',
-                                  )}"><p><span class="ucb-people-list-contact">  ${
-                                    Person.Phone
-                                  }</span></p></a>`
-                                : ''
-                            }
-                        </span>
-                    </div>
-                    </div>
-                </div>
-            `
-      break
-    case 'Grid':
-      cardHTML = `
-                <div class="col-sm mb-3">
-                    <div class="col-sm-12 ucb-person-card-img-grid">
-                        <a href="${Person.Link}">${myPhoto}</a>
-                    </div>
-                <div>
-                <a href="${Person.Link}">
-                            <span class="ucb-person-card-name">
-                                ${Person.Name ? Person.Name : ''}
-                            </span>
-                        </a>
-                <span class="ucb-person-card-title departments-grid">
-                  ${Person.Title ? Person.Title : ''}
-                </span>
-                <span class="ucb-person-card-dept departments-grid">
-                  <ul class="ucb-person-card-dept-ul">
-                   ${myDept}
-                  </ul>
-                 </span>
-                </div>
-                </div>
-        `
-      break
-    case 'Table':
-      cardHTML = `
-
-                  <td class="ucb-people-list-table-photo">
-                    <a href="${Person.Link}">${myPhoto}</a>  
-                  </td>
-                  <td>
-                    <a href="${Person.Link}">
-                      <span class="ucb-person-card-name">
-                        ${Person.Name ? Person.Name : ''}
-                      </span>
-                    </a>
-                    <span class="ucb-person-card-title departments-grid">
-                  ${Person.Title ? Person.Title : ''}
-                </span>
-                <span class="ucb-person-card-dept departments-grid">
-                  <ul class="ucb-person-card-dept-ul">
-                   ${myDept}
-                  </ul>
-                 </span>
-                  </td>
-                  <td>
-                  <span class="ucb-person-card-email">
-                            ${
-                              Person.Email
-                                ? `<a href="mailto:${Person.Email}"><span class="ucb-people-list-contact"> ${Person.Email}</span></p></a>`
-                                : ''
-                            }
-                        </span>
-                        <span class="ucb-person-card-phone">
-                            ${
-                              Person.Phone
-                                ? `<a href="tel:${Person.Phone.replace(
-                                    /[^+\d]+/g,
-                                    '',
-                                  )}"><p>
-                                    <span class="ucb-people-list-contact"> 
-                                  ${Person.Phone}</span></p></a>`
-                                : ''
-                            }
-                        </span>
-                  </td>
-
-        `
-      break
-    default:
-  }
-  return cardHTML
-}
-
-/**
- * Main function to display a collection of people in a given format in the group identified
- * by groupID 
- * @param {string} DISPLAYFORMAT // format to use (grid | list | table)
- * @param {string} GROUPBY // which taxonomy to group people in (department | type | none)
- * @param {string} groupID // which department or type we're currently working on rendering
- * @param {string} ORDERBY // do we sort the current group by last or type+last 
- */
-function displayPeople(DISPLAYFORMAT, GROUPBY, groupID, ORDERBY) {
-  // console.log("display people format", DISPLAYFORMAT)
-  // console.log('groupby', GROUPBY)
-  let renderThisGroup = 0; 
-  let el = document.getElementById('ucb-people-list-page')
-  let thisDeptName = ""
-  let thisTypeName = ""
-  if(GROUPBY === "department") {
-    thisDeptName = getTaxonomyName(Departments, groupID).name
-  } else if(GROUPBY === "type") {
-    thisTypeName = getTaxonomyName(JobTypes, groupID).name
-  }
-  // el.classList = 'container'
-  // let headerHTML = layoutHeader(DISPLAYFORMAT)
-  // let footerHTML = layoutFooter(DISPLAYFORMAT)
-  let parentContainer = getParentContainer(DISPLAYFORMAT)
-
-  // TO DO -- issue here with header adding correctly to grid
-  if (DISPLAYFORMAT === 'grid' || DISPLAYFORMAT === 'table') {
-    el.appendChild(parentContainer)
-  }
-
-  // if this is our second pass on rendering content we don't need a group-by title 
-  // we also don't some of the opening DOM elements before the card info.  
-  if(ORDERBY === "secondpass" && firstPassCount) {
-    renderThisGroup++;
-  }
-
-  // fetch(JSONURL)
-  //   .then((response) => response.json())
-  //   .then((data) => {
-  //     console.log(data) // our data obj
-  if (Object.keys(ourPepole) != 0) {
-    // get all of the include images id => url
-    let urlObj = {} // key from data.data to key from data.includes
-    let idObj = {} // key from data.includes to URL
-    // Remove any blanks from our articles before map
-    if (ourPepole.included) {
-      let filteredData = ourPepole.included.filter((url) => {
-        return url.attributes.uri !== undefined
-      })
-      // creates the urlObj, key: data id, value: url
-      filteredData.map((pair) => {
-        // checks if consumer is working, else default to standard image instead of focal image
-        if(pair.links.focal_image_square != undefined){
-          urlObj[pair.id] = pair.links.focal_image_square.href
-        } else {
-          urlObj[pair.id] = pair.attributes.uri.url
-        }
-      })
-
-      // removes all other included data besides images in our included media
-      let idFilterData = ourPepole.included.filter((item) => {
-        return item.type == 'media--image'
-      })
-      // using the image-only data, creates the idObj =>  key: thumbnail id, value : data id
-      idFilterData.map((pair) => {
-        idObj[pair.id] = pair.relationships.thumbnail.data.id
-      })
-    }
-
-    // maps over data
-    ourPepole.data.map((person) => {
-      // get the person data we need
-      let renderMe = true;
-      let thisPerson = {}
-      let thisPersonCard = '' // placeholder for the HTML to render this card in the required format
-      thisPerson['Name'] = person.attributes.title
-      thisPerson['Title'] = person.attributes.field_ucb_person_title[0]
-      thisPerson['Dept'] = []
-      for(let i = 0; i < person.relationships.field_ucb_person_department.data.length; i++) {
-        thisPerson['Dept'].push(
-          person.relationships.field_ucb_person_department.data[i].meta.drupal_internal__target_id
-        );
-      } 
-      thisPerson['Jobtype'] = []
-      for(let i = 0; i < person.relationships.field_ucb_person_job_type.data.length; i++) {
-        thisPerson['Jobtype'].push(
-          person.relationships.field_ucb_person_job_type.data[i].meta.drupal_internal__target_id
-        );
-      }
-      thisPerson['PhotoID'] =
-        person.relationships.field_ucb_person_photo.data.id
-      thisPerson['PhotoURL'] = ''
-      thisPerson['Email'] = person.attributes.field_ucb_person_email
-      thisPerson['Phone'] = person.attributes.field_ucb_person_phone
-      thisPerson['Link'] = `/node/${person.attributes.drupal_internal__nid}`
-      // needed to verify body exists on the Person page, if so, use that
-      if (person.attributes.body) {
-        myBody = person.attributes.body.processed
-        myBody.replace(/<\/?[^>]+(>|$)/g, '') // strip out HTML characters
-        myBody.replace(/(\r\n|\n|\r)/gm, '') // strip out line breaks
-        thisPerson['Body'] = myBody
-      } else {
-        // if no body, set to empty
-        thisPerson['Body'] = ''
-      }
-      if (thisPerson.PhotoID) {
-        thisPerson['PhotoURL'] = urlObj[idObj[thisPerson.PhotoID]]
-        // console.log('Am I an image URL? : ' + thisPerson.PhotoURL)
-      }
-
-      // if first pass (sort by type first) then only render the people with a Job Type 
-      // else if second pass (sort by type first) then only render the people without a Job Type
-      if(ORDERBY === "firstpass" && !thisPerson['Jobtype'].length) {
-        renderMe = false;
-      } else if(ORDERBY === "secondpass" && thisPerson['Jobtype'].length) {
-        renderMe = false;
-      }
-
-      // check to see if this person needs to be rendered 
-      if(renderMe) {
-
-
-      // check to see if we need to filter based on a group by seeting
-      // and if so that this person matches our groupID
-      if ((!GROUPBY || !groupID) || (thisPerson['Dept'].find(deptid => deptid == groupID) || thisPerson['Jobtype'].find(typeid => typeid == groupID))) {
-        //console.log( "I'm a match! " + groupID + ' = ' + thisPerson['Dept'] + ' or ' + thisPerson['Jobtype'],)
-
-        // increment flags for rendering in this group as necessary
-        renderThisGroup++; 
-        if(ORDERBY === "firstpass") {
-          firstPassCount++;
-        }
-        // console.log("my display format is", DISPLAYFORMAT)
-        thisPersonCard = displayPersonCard(DISPLAYFORMAT, thisPerson)
-
-        let thisCard
-        // Needed to switch types of container for individual person cards => article for grid & list displays, tr for table display
-        if (DISPLAYFORMAT === 'Table') {
-          thisCard = document.createElement('tr')
-        } else {
-          thisCard = document.createElement('article')
-        }
-
-        thisCard.innerHTML = thisPersonCard
-
-        // This section apprends the generated cards for each respective display type
-        if (DISPLAYFORMAT === 'List') {
-          // check to see if this is the first time we're adding in a member of this group
-          // if so, add the name of the group first 
-          if(renderThisGroup === 1 && groupID) {
-            // we may be on a second pass and have already rendered the title in the first pass
-            // if so, skip the title so we don't end up with two 
-            // console.log("First Pass Count is : " + firstPassCount)
-            // console.log("Render pass is : " + ORDERBY)
-            if((ORDERBY === "secondpass" && !firstPassCount) || ORDERBY != "secondpass") {
-              let GroupTitle = document.createElement('div');
-              GroupTitle.innerHTML = ` 
-                <h2>${GROUPBY == 'type' ? thisTypeName : thisDeptName}</h2>`
-              el.appendChild(GroupTitle);
-            }
-          }
-
-          el.appendChild(thisCard)
-        } else if (DISPLAYFORMAT === 'Grid') {
-
-          // check to see if this is the first time we're adding in a member of this group
-          // if so, add the name of the group first 
-          if(renderThisGroup === 1 && groupID) {
-            // we may be on a second pass and have already rendered the title in the first pass
-            // if so, skip the title so we don't end up with two 
-            if((ORDERBY === "secondpass" && !firstPassCount) || ORDERBY != "secondpass") {
-              let GroupTitle = document.createElement('div');
-              GroupTitle.classList = "col-12";
-              GroupTitle.innerHTML = `<h2>${GROUPBY == 'type' ? thisTypeName : thisDeptName}</h2>`
-              parentContainer.appendChild(GroupTitle)
-            }
-          }
-
-          thisCard.classList = 'col-sm-12 col-md-6 col-lg-4'
-          thisCard.innerHTML = thisPersonCard
-
-          parentContainer.appendChild(thisCard)
-        } else {
-          // if table display, append to inner tablebody instead of parent element
-          let tablebody = document.getElementById(
-            'ucb-people-list-table-tablebody',
-          )
-
-          // check to see if this is the first time we're adding in a member of this group
-          // if so, add the name of the group first 
-          if(renderThisGroup === 1 && groupID) { 
-            // we may be on a second pass and have already rendered the title in the first pass
-            // if so, skip the title so we don't end up with two 
-            if((ORDERBY === "secondpass" && !firstPassCount) || ORDERBY != "secondpass") {
-              let GroupTitle = document.createElement('tr');
-              let GroupTitleHTML = `
-                <th colspan="3" class="ucb-people-list-group-title-th">
-                ${GROUPBY == 'type' ? thisTypeName : thisDeptName}
-                </th>
-                `
-              GroupTitle.innerHTML = GroupTitleHTML;
-              // console.log('table body', tablebody)
-              tablebody.appendChild(GroupTitle);
-            }
-          }
-          // console.log('table body', tablebody)
-          
-          tablebody.appendChild(thisCard)
-        }
-      } else {
-        // console.log( 'Not a match! ' + groupID + ' != ' + thisPerson['Dept'] + ' or ' + thisPerson['Jobtype'],);
-      }
-    }
-    })
-  } else {
-    console.log('empty staff object, no people to render ', ourPepole)
-    toggleMessage('ucb-al-end-of-data', 'block')
-  }
-  // done with cards, clean up and close any HTML tags we have opened.
-  // el.append(footerHTML)
-
-  // console.log(el.dataset.json)
-}
-
-// INIT
-(function () {
-  let el = document.getElementById('ucb-people-list-page')
-  let JSONAPI = el.dataset.json ? el.dataset.json : ''
-  let FORMAT = el.dataset.format ? el.dataset.format : ''
-  let GROUPBY = el.dataset.groupby ? el.dataset.groupby : ''
-  let ORDERBY = el.dataset.orderby ? el.dataset.orderby : ''
-  // console.log('Init')
-  // console.log("Order by is : " + ORDERBY)
-
-  getTaxonomy('department').then((response) => {
-    Departments = response
-    // console.log('Our Departments are : ', Departments);
-  })
-
-  getTaxonomy('ucb_person_job_type').then((response) => {
-    // console.log("get tax resp", response)
-    JobTypes = response
-    // console.log('Our Job types are : ', JobTypes);
-  })
-
-  toggleMessage('ucb-al-loading', 'block')
-
-  getStaff(JSONAPI)
-    .then((response) => {
-      // console.log(response)
-      ourPepole = response
-    })
-    .then(() => {
-      toggleMessage('ucb-al-loading', 'none')
-      // console.log(GROUPBY)
-      if (GROUPBY == 'department') {
-        for (const [key] of Object.entries(Departments)) {
-          // let thisDeptID = Departments[key].id
-          // let thisDeptName = getTaxonomyName(Departments, thisDeptID);
-          // console.log("Group by Dept : " + thisDeptID)
-          // console.log("Group by Dept : " + thisDeptName.name)
-
-          if(ORDERBY === "type") {
-            // console.log('i match type')
-            firstPassCount = 0; 
-            displayPeople(FORMAT, GROUPBY, Departments[key].id, "firstpass")
-            displayPeople(FORMAT, GROUPBY, Departments[key].id, "secondpass")
-          }else {
-            displayPeople(FORMAT, GROUPBY, Departments[key].id, "")
-          }
-        }
-      } else if (GROUPBY == 'type') {
-        for (const [key] of Object.entries(JobTypes)) {
-          let thisTypeID = JobTypes[key].id
-          let thisTypeName = getTaxonomyName(JobTypes, thisTypeID) 
-          // console.log("Group by Type : " + thisTypeID)
-          // console.log("Group by Name : " + thisTypeName.name)
-          if(ORDERBY === "type") {
-            firstPassCount = 0; 
-            displayPeople(FORMAT, GROUPBY, JobTypes[key].id, "firstpass")
-            displayPeople(FORMAT, GROUPBY, JobTypes[key].id, "secondpass")
-          }else {
-            displayPeople(FORMAT, GROUPBY, JobTypes[key].id, "")
-          }
-        }
-      } else {
-        if(ORDERBY === "type") {
-          firstPassCount = 0; 
-          displayPeople(FORMAT, "", "", "firstpass")
-          displayPeople(FORMAT, "", "", "secondpass")
-        }else {
-          displayPeople(FORMAT, "", "", "")
-        }
-      }
-    })
-})()
-
-
-
-
-
 class PeopleListElement extends HTMLElement {
 	constructor() {
 		super();
     // Pre build logic
-    var Departments = {} // translate table for department id => department name
-    var JobTypes = {} // translate table for type id => type name
-
     // Fetch all available Departments and Job Types then enter the build stage
     this.getTaxonomy('department').then(departments=>{
       // console.log('I am logging departments',departments)
@@ -619,21 +29,54 @@ class PeopleListElement extends HTMLElement {
     var GROUPBY = this.getAttribute("groupby")
     var ORDERBY = this.getAttribute("orderby")
 
-    var ourPepole = {} // all of the pepole that match our filter 
-    var renderedTable = 0;  // flag to know if we've rendered the table header or not yet
-    var firstPassCount = 0; // count for the first pass per group.  
+    var ourPeople = {} // all of the pepole that match our filter 
+     // count for the first pass per group.  
 
-    console.log("These are my Departments", Departments)
-    console.log('These are my job types', JobTypes)
-    console.log('API point', JSONAPI)
-    console.log('Format?', FORMAT)
-    console.log('group my results by', GROUPBY)
-    console.log('order my results by', ORDERBY)
+    this.toggleMessage('ucb-al-loading','block')
 
     //Get our people
     this.getStaff(JSONAPI).then(response=>{
-      ourPepole = response;
-      console.log(ourPepole)
+      ourPeople = response;
+
+      if (GROUPBY == 'department') {
+        for (const [key] of Object.entries(Departments)) {
+          // let thisDeptID = Departments[key].id
+          // let thisDeptName = getTaxonomyName(Departments, thisDeptID);
+          // console.log("Group by Dept : " + thisDeptID)
+          // console.log("Group by Dept : " + thisDeptName.name)
+
+          if(ORDERBY === "type") {
+            // console.log('i match type')
+            firstPassCount = 0; 
+            this.displayPeople(FORMAT, GROUPBY, Departments[key].id, "firstpass", ourPeople, Departments)
+            this.displayPeople(FORMAT, GROUPBY, Departments[key].id, "secondpass", ourPeople, Departments)
+          }else {
+            this.displayPeople(FORMAT, GROUPBY, Departments[key].id, "", ourPeople, Departments)
+          }
+        }
+      } else if (GROUPBY == 'type') {
+        for (const [key] of Object.entries(JobTypes)) {
+          let thisTypeID = JobTypes[key].id
+          let thisTypeName = this.getTaxonomyName(JobTypes, thisTypeID) 
+          // console.log("Group by Type : " + thisTypeID)
+          // console.log("Group by Name : " + thisTypeName.name)
+          if(ORDERBY === "type") {
+            firstPassCount = 0; 
+            this.displayPeople(FORMAT, GROUPBY, JobTypes[key].id, "firstpass", ourPeople, Departments)
+            this.displayPeople(FORMAT, GROUPBY, JobTypes[key].id, "secondpass", ourPeople, Departments)
+          }else {
+            this.displayPeople(FORMAT, GROUPBY, JobTypes[key].id, "", ourPeople, Departments)
+          }
+        }
+      } else {
+        if(ORDERBY === "type") {
+          firstPassCount = 0; 
+          this.displayPeople(FORMAT, "", "", "firstpass", ourPeople, Departments)
+          this.displayPeople(FORMAT, "", "", "secondpass", ourPeople, Departments)
+        }else {
+          this.displayPeople(FORMAT, "", "", "", ourPeople, Departments)
+        }
+      }
     })
   }
 
@@ -666,7 +109,7 @@ class PeopleListElement extends HTMLElement {
       }
     })
   }
-
+  // Gets person data
   getStaff(JSONAPI) {
     return new Promise(function (resolve, reject) {
       if (JSONAPI) {
@@ -675,15 +118,433 @@ class PeopleListElement extends HTMLElement {
           .then((data) => {
             if(data.data.length === 0) {
               console.log("No people matching the filter returned.")
-              // toggleMessage('ucb-al-end-of-data', 'block')
+              this.toggleMessage('ucb-al-end-of-data', 'block')
             }
             resolve(data)
           })
       } else {
-        // toggleMessage('ucb-al-error', 'block')
+        this.toggleMessage('ucb-al-error', 'block')
         reject
       }
     })
+  }
+
+  displayPeople(DISPLAYFORMAT, GROUPBY, groupID, ORDERBY, ourPeople, Departments) {
+    let renderThisGroup = 0; 
+    let el = this
+    let thisDeptName = ""
+    let thisTypeName = ""
+    if(GROUPBY === "department") {
+      thisDeptName = this.getTaxonomyName(Departments, groupID).name
+    } else if(GROUPBY === "type") {
+      thisTypeName = this.getTaxonomyName(JobTypes, groupID).name
+    }
+    // el.classList = 'container'
+    // let headerHTML = layoutHeader(DISPLAYFORMAT)
+    // let footerHTML = layoutFooter(DISPLAYFORMAT)
+    let parentContainer = this.getParentContainer(DISPLAYFORMAT)
+  
+    // TO DO -- issue here with header adding correctly to grid
+    if (DISPLAYFORMAT === 'grid' || DISPLAYFORMAT === 'table') {
+      el.appendChild(parentContainer)
+    }
+  
+    // if this is our second pass on rendering content we don't need a group-by title 
+    // we also don't some of the opening DOM elements before the card info.  
+    if(ORDERBY === "secondpass" && firstPassCount) {
+      renderThisGroup++;
+    }
+  
+    // fetch(JSONURL)
+    //   .then((response) => response.json())
+    //   .then((data) => {
+    //     console.log(data) // our data obj
+    if (Object.keys(ourPeople) != 0) {
+      // get all of the include images id => url
+      let urlObj = {} // key from data.data to key from data.includes
+      let idObj = {} // key from data.includes to URL
+      // Remove any blanks from our articles before map
+      if (ourPeople.included) {
+        let filteredData = ourPeople.included.filter((url) => {
+          return url.attributes.uri !== undefined
+        })
+        // creates the urlObj, key: data id, value: url
+        filteredData.map((pair) => {
+          // checks if consumer is working, else default to standard image instead of focal image
+          if(pair.links.focal_image_square != undefined){
+            urlObj[pair.id] = pair.links.focal_image_square.href
+          } else {
+            urlObj[pair.id] = pair.attributes.uri.url
+          }
+        })
+  
+        // removes all other included data besides images in our included media
+        let idFilterData = ourPeople.included.filter((item) => {
+          return item.type == 'media--image'
+        })
+        // using the image-only data, creates the idObj =>  key: thumbnail id, value : data id
+        idFilterData.map((pair) => {
+          idObj[pair.id] = pair.relationships.thumbnail.data.id
+        })
+      }
+  
+      // maps over data
+      ourPeople.data.map((person) => {
+        // get the person data we need
+        let renderMe = true;
+        let thisPerson = {}
+        let thisPersonCard = '' // placeholder for the HTML to render this card in the required format
+        thisPerson['Name'] = person.attributes.title
+        thisPerson['Title'] = person.attributes.field_ucb_person_title[0]
+        thisPerson['Dept'] = []
+        for(let i = 0; i < person.relationships.field_ucb_person_department.data.length; i++) {
+          thisPerson['Dept'].push(
+            person.relationships.field_ucb_person_department.data[i].meta.drupal_internal__target_id
+          );
+        } 
+        thisPerson['Jobtype'] = []
+        for(let i = 0; i < person.relationships.field_ucb_person_job_type.data.length; i++) {
+          thisPerson['Jobtype'].push(
+            person.relationships.field_ucb_person_job_type.data[i].meta.drupal_internal__target_id
+          );
+        }
+        thisPerson['PhotoID'] =
+          person.relationships.field_ucb_person_photo.data.id
+        thisPerson['PhotoURL'] = ''
+        thisPerson['Email'] = person.attributes.field_ucb_person_email
+        thisPerson['Phone'] = person.attributes.field_ucb_person_phone
+        thisPerson['Link'] = `/node/${person.attributes.drupal_internal__nid}`
+        // needed to verify body exists on the Person page, if so, use that
+        if (person.attributes.body) {
+          var myBody = person.attributes.body.processed
+          myBody.replace(/<\/?[^>]+(>|$)/g, '') // strip out HTML characters
+          myBody.replace(/(\r\n|\n|\r)/gm, '') // strip out line breaks
+          thisPerson['Body'] = myBody
+        } else {
+          // if no body, set to empty
+          thisPerson['Body'] = ''
+        }
+        if (thisPerson.PhotoID) {
+          thisPerson['PhotoURL'] = urlObj[idObj[thisPerson.PhotoID]]
+          // console.log('Am I an image URL? : ' + thisPerson.PhotoURL)
+        }
+  
+        // if first pass (sort by type first) then only render the people with a Job Type 
+        // else if second pass (sort by type first) then only render the people without a Job Type
+        if(ORDERBY === "firstpass" && !thisPerson['Jobtype'].length) {
+          renderMe = false;
+        } else if(ORDERBY === "secondpass" && thisPerson['Jobtype'].length) {
+          renderMe = false;
+        }
+  
+        // check to see if this person needs to be rendered 
+        if(renderMe) {
+  
+  
+        // check to see if we need to filter based on a group by seeting
+        // and if so that this person matches our groupID
+        if ((!GROUPBY || !groupID) || (thisPerson['Dept'].find(deptid => deptid == groupID) || thisPerson['Jobtype'].find(typeid => typeid == groupID))) {
+          //console.log( "I'm a match! " + groupID + ' = ' + thisPerson['Dept'] + ' or ' + thisPerson['Jobtype'],)
+  
+          // increment flags for rendering in this group as necessary
+          renderThisGroup++; 
+          if(ORDERBY === "firstpass") {
+            firstPassCount++;
+          }
+          // console.log("my display format is", DISPLAYFORMAT)
+          thisPersonCard = this.displayPersonCard(DISPLAYFORMAT, thisPerson, Departments)
+  
+          let thisCard
+          // Needed to switch types of container for individual person cards => article for grid & list displays, tr for table display
+          if (DISPLAYFORMAT === 'Table') {
+            thisCard = document.createElement('tr')
+          } else {
+            thisCard = document.createElement('article')
+          }
+  
+          thisCard.innerHTML = thisPersonCard
+  
+          // This section apprends the generated cards for each respective display type
+          if (DISPLAYFORMAT === 'List') {
+            // check to see if this is the first time we're adding in a member of this group
+            // if so, add the name of the group first 
+            if(renderThisGroup === 1 && groupID) {
+              // we may be on a second pass and have already rendered the title in the first pass
+              // if so, skip the title so we don't end up with two 
+              // console.log("First Pass Count is : " + firstPassCount)
+              // console.log("Render pass is : " + ORDERBY)
+              if((ORDERBY === "secondpass" && !firstPassCount) || ORDERBY != "secondpass") {
+                let GroupTitle = document.createElement('div');
+                GroupTitle.innerHTML = ` 
+                  <h2>${GROUPBY == 'type' ? thisTypeName : thisDeptName}</h2>`
+                el.appendChild(GroupTitle);
+              }
+            }
+            this.toggleMessage('ucb-al-loading')
+
+            el.appendChild(thisCard)
+          } else if (DISPLAYFORMAT === 'Grid') {
+  
+            // check to see if this is the first time we're adding in a member of this group
+            // if so, add the name of the group first 
+            if(renderThisGroup === 1 && groupID) {
+              // we may be on a second pass and have already rendered the title in the first pass
+              // if so, skip the title so we don't end up with two 
+              if((ORDERBY === "secondpass" && !firstPassCount) || ORDERBY != "secondpass") {
+                let GroupTitle = document.createElement('div');
+                GroupTitle.classList = "col-12";
+                GroupTitle.innerHTML = `<h2>${GROUPBY == 'type' ? thisTypeName : thisDeptName}</h2>`
+                parentContainer.appendChild(GroupTitle)
+              }
+            }
+  
+            thisCard.classList = 'col-sm-12 col-md-6 col-lg-4'
+            thisCard.innerHTML = thisPersonCard
+            this.toggleMessage('ucb-al-loading')
+            parentContainer.appendChild(thisCard)
+          } else {
+            // if table display, append to inner tablebody instead of parent element
+            let tablebody = document.getElementById(
+              'ucb-people-list-table-tablebody',
+            )
+  
+            // check to see if this is the first time we're adding in a member of this group
+            // if so, add the name of the group first 
+            if(renderThisGroup === 1 && groupID) { 
+              // we may be on a second pass and have already rendered the title in the first pass
+              // if so, skip the title so we don't end up with two 
+              if((ORDERBY === "secondpass" && !firstPassCount) || ORDERBY != "secondpass") {
+                let GroupTitle = document.createElement('tr');
+                let GroupTitleHTML = `
+                  <th colspan="3" class="ucb-people-list-group-title-th">
+                  ${GROUPBY == 'type' ? thisTypeName : thisDeptName}
+                  </th>
+                  `
+                GroupTitle.innerHTML = GroupTitleHTML;
+                // console.log('table body', tablebody)
+                tablebody.appendChild(GroupTitle);
+              }
+            }
+            // console.log('table body', tablebody)
+            
+            tablebody.appendChild(thisCard)
+          }
+        } else {
+          // console.log( 'Not a match! ' + groupID + ' != ' + thisPerson['Dept'] + ' or ' + thisPerson['Jobtype'],);
+        }
+      }
+      })
+    } else {
+      console.log('empty staff object, no people to render ', ourPepole)
+      this.toggleMessage('ucb-al-end-of-data', 'block')
+    }
+    // done with cards, clean up and close any HTML tags we have opened.
+    // el.append(footerHTML)
+  
+    // console.log(el.dataset.json)
+  }
+  getParentContainer(Format) // flag to know if we've rendered the table header or not yet
+   {
+    // console.log("my format is", Format)
+    let container = ''
+    switch (Format) {
+      case 'List':
+        break
+      case 'Grid':
+        container = this
+        container.classList = "row ucb-people-list-content"
+        break
+      case 'Table':
+        // we only need to render the table header the first time
+        // this function will be called multiple times so check to 
+        // see if we've already rendered the table header HTML
+        if(!renderedTable) {
+        let pageBody = this
+        container = document.createElement('table')
+        container.id = 'ucb-pl-table'
+        container.classList = 'table  table-bordered table-striped'
+        var tableHead = document.createElement('thead')
+        tableHead.classList = 'ucb-people-list-table-head'
+        var tableRow = document.createElement('tr')
+        tableRow.innerHTML = `
+              <th><span class="sr-only">Photo</span></th>
+              <th>Name</th>
+              <th>Contact Information</th>
+        `
+        var tableBody = document.createElement('tbody')
+        tableBody.id = 'ucb-people-list-table-tablebody'
+        this.toggleMessage('ucb-al-loading')
+
+        tableHead.appendChild(tableRow)
+        container.appendChild(tableHead)
+        container.appendChild(tableBody)
+        pageBody.appendChild(container)
+        
+        }else {
+          container = this
+        }
+        renderedTable++; 
+        break
+      default:
+    }
+    return container
+  }
+  displayPersonCard(Format, Person, Departments) {
+    // console.log('Rendering the card for ' + Person.Name)
+    let cardHTML = ''
+    // grab the friendly name from the global variable
+    // note: there may be a race condidtion here as we're also querying
+    //  to get those friendly names from the API endpoint.
+    // console.log('Departments :', Departments)
+    let myDept = ""
+    for(let i = 0; i < Person.Dept.length; i++) {
+      let thisDeptID = Person.Dept[i]
+      let thisDeptName = this.getTaxonomyName(Departments, thisDeptID).name;
+      myDept += `<li>${thisDeptName}</li>`
+    }
+    let myPhoto = ''
+    if (Person.PhotoURL) {
+      myPhoto = `<img src="${Person.PhotoURL}"  />`
+    }
+  
+    switch (Format) {
+      case 'List':
+        cardHTML = `
+                  <div class="ucb-person-card-list row">
+                      <div class="col-sm-12 col-md-3 ucb-person-card-img">
+                          <a href="${Person.Link}">${myPhoto}</a>
+                      </div>
+                      <div class="col-sm-12 col-md-9 ucb-person-card-details">
+                          <a href="${Person.Link}">
+                              <span class="ucb-person-card-name">
+                                  ${Person.Name ? Person.Name : ''}
+                              </span>
+                          </a>
+                          <span class="ucb-person-card-title">
+                              ${Person.Title ? Person.Title : ''}
+                          </span>
+                      <span class="ucb-person-card-dept">
+                        <ul class="ucb-person-card-dept-ul">
+                          ${myDept} 
+                        </ul>
+                      </span>
+                      <span class="ucb-person-card-body">
+                          ${Person.Body ? Person.Body : ''}
+                      </span>
+                      <div class="ucb-person-card-contact">
+                          <span class="ucb-person-card-email">
+                              ${
+                                Person.Email
+                                  ? `<a href="mailto:${Person.Email}"><span class="ucb-people-list-contact">  ${Person.Email}</span></a>`
+                                  : ''
+                              }
+                          </span>
+                          <span class="ucb-person-card-phone">
+                              ${
+                                Person.Phone
+                                  ? `<a href="tel:${Person.Phone.replace(
+                                      /[^+\d]+/g,
+                                      '',
+                                    )}"><p><span class="ucb-people-list-contact">  ${
+                                      Person.Phone
+                                    }</span></p></a>`
+                                  : ''
+                              }
+                          </span>
+                      </div>
+                      </div>
+                  </div>
+              `
+        break
+      case 'Grid':
+        cardHTML = `
+                  <div class="col-sm mb-3">
+                      <div class="col-sm-12 ucb-person-card-img-grid">
+                          <a href="${Person.Link}">${myPhoto}</a>
+                      </div>
+                  <div>
+                  <a href="${Person.Link}">
+                              <span class="ucb-person-card-name">
+                                  ${Person.Name ? Person.Name : ''}
+                              </span>
+                          </a>
+                  <span class="ucb-person-card-title departments-grid">
+                    ${Person.Title ? Person.Title : ''}
+                  </span>
+                  <span class="ucb-person-card-dept departments-grid">
+                    <ul class="ucb-person-card-dept-ul">
+                     ${myDept}
+                    </ul>
+                   </span>
+                  </div>
+                  </div>
+          `
+        break
+      case 'Table':
+        cardHTML = `
+  
+                    <td class="ucb-people-list-table-photo">
+                      <a href="${Person.Link}">${myPhoto}</a>  
+                    </td>
+                    <td>
+                      <a href="${Person.Link}">
+                        <span class="ucb-person-card-name">
+                          ${Person.Name ? Person.Name : ''}
+                        </span>
+                      </a>
+                      <span class="ucb-person-card-title departments-grid">
+                    ${Person.Title ? Person.Title : ''}
+                  </span>
+                  <span class="ucb-person-card-dept departments-grid">
+                    <ul class="ucb-person-card-dept-ul">
+                     ${myDept}
+                    </ul>
+                   </span>
+                    </td>
+                    <td>
+                    <span class="ucb-person-card-email">
+                              ${
+                                Person.Email
+                                  ? `<a href="mailto:${Person.Email}"><span class="ucb-people-list-contact"> ${Person.Email}</span></p></a>`
+                                  : ''
+                              }
+                          </span>
+                          <span class="ucb-person-card-phone">
+                              ${
+                                Person.Phone
+                                  ? `<a href="tel:${Person.Phone.replace(
+                                      /[^+\d]+/g,
+                                      '',
+                                    )}"><p>
+                                      <span class="ucb-people-list-contact"> 
+                                    ${Person.Phone}</span></p></a>`
+                                  : ''
+                              }
+                          </span>
+                    </td>
+  
+          `
+        break
+      default:
+    }
+    return cardHTML
+  }
+  getTaxonomyName(taxonomy, tid) {
+  // console.log(taxonomy)
+    return taxonomy.find( ({ id }) => id === tid );
+  }
+  toggleMessage(id, display = 'none') {
+  if (id) {
+    var toggle = document.getElementById(id)
+
+    if (toggle) {
+      if (display === 'block') {
+        toggle.style.display = 'block'
+      } else {
+        toggle.style.display = 'none'
+      }
+    }
+  }
   }
 }
 

--- a/js/ucb-people-list.js
+++ b/js/ucb-people-list.js
@@ -117,8 +117,12 @@ class PeopleListElement extends HTMLElement {
           .then((response) => response.json())
           .then((data) => {
             if(data.data.length === 0) {
+              // Show Error El and Hide loader
               console.log("No people matching the filter returned.")
-              this.toggleMessage('ucb-al-end-of-data', 'block')
+              var errorEl = document.getElementsByClassName('ucb-list-msg ucb-end-of-results')[0]
+              errorEl.style.display = 'block'
+              var loaderEl = document.getElementsByClassName('ucb-list-msg ucb-loading-data')[0]
+              loaderEl.style.display= 'none'
             }
             resolve(data)
           })
@@ -536,7 +540,7 @@ class PeopleListElement extends HTMLElement {
   toggleMessage(id, display = 'none') {
   if (id) {
     var toggle = document.getElementById(id)
-
+    console.log(toggle)
     if (toggle) {
       if (display === 'block') {
         toggle.style.display = 'block'

--- a/js/ucb-people-list.js
+++ b/js/ucb-people-list.js
@@ -40,7 +40,7 @@ class PeopleListProvider {
 			});
 			if(!filterParams) continue;
 			params += '&filter[' + filterName + '-include][group][conjunction]=OR'
-				+ filterParams;
+				+ filterParams
 				+ '&filter[' + filterName + '-include][group][memberOf]=include-group';
 		}
 		if(params)

--- a/js/ucb-people-list.js
+++ b/js/ucb-people-list.js
@@ -606,11 +606,11 @@ class PeopleListElement extends HTMLElement {
 					selectFilter.appendChild(defaultOption)
 				}else {
 					defaultOption.value = JSON.stringify([{id: "", name: "",fieldName:key}])
-					defaultOption.innerText = 'Default'
+					defaultOption.innerText = 'All'
 					selectFilter.appendChild(defaultOption)
 					if(!filters[key]['restrict']){
 						var allOptions = document.createElement('option')
-						allOptions.innerText = 'All'
+						allOptions.innerText = 'Default'
 						// TO DO - fix
 						allOptions.value = JSON.stringify([{id:"", name: "",fieldName:key}])
 						selectFilter.appendChild(allOptions)

--- a/js/ucb-people-list.js
+++ b/js/ucb-people-list.js
@@ -541,93 +541,59 @@ class PeopleListElement extends HTMLElement {
 	generateForm(){
 		const userAccessibleFilters = this._userAccessibleFilters;
 		// Create Elements
-      	var form = document.createElement('form');
-		form.addEventListener('submit',(event)=> {
-			event.preventDefault();
-			var formData = new FormData(event.target);
-			var dataObj = {};
+      	const form = document.createElement('form'), formDiv = document.createElement('div'), onChange = event => {
+			const form = event.target.form, formItemsData = new FormData(form),
+				userSettings = {};
 			// Create a dataObject with ids for second render
-			for (var p of formData) {
-				dataObj[p[0]] = JSON.parse(p[1]);
+			for (const formItemData of formItemsData) {
+				const filterName = formItemData[0], filterInclude = formItemData[1];
+				if(filterInclude != '-1')
+					userSettings[filterName] = {'includes': [filterInclude]};
 			} 
-			var userSettings = {}
-			for(let key in dataObj){
-				if(dataObj[key]){
-					if(dataObj[key][0]['id'] == "remove" || (dataObj[key][0]['id'] == "" && userAccessibleFilters[key]['restrict'])){
-						delete dataObj[key];
-					} else {
-						let fieldName = dataObj[key][0]['fieldName'];
-						let ids = dataObj[key][0]["id"];
-						
-						let value = {includes: [ids]};
-						userSettings[fieldName] = value;
-					}
-				}
-			
-			}
-			let finalObj = {filters: userSettings};
-			this.setAttribute('user-config', JSON.stringify(finalObj));
-		})
-		form.classList = 'people-list-filter';
-		var formDiv = document.createElement('div');
-		formDiv.classList = 'd-flex align-items-center';
+			this.setAttribute('user-config', JSON.stringify({'filters': userSettings}));
+		};
+		form.className = 'people-list-filter';
+		formDiv.className = 'd-flex align-items-center';
 	
 		// If User-Filterable...Create Dropdowns
-		for(let key in userAccessibleFilters){
+		for(const key in userAccessibleFilters){
 			const filter = userAccessibleFilters[key];
 			// Create container
-			var container = document.createElement('div');
+			const container = document.createElement('div');
 			container.className = `form-item-${key} form-item`;
 			// Create label el
-			var itemLabel = document.createElement('label');
+			const itemLabel = document.createElement('label');
 			itemLabel.htmlFor = `Edit ${filter['label']}`;
 			itemLabel.innerText = filter['label'];
 			// Create select el
-			var selectFilter = document.createElement('select');
+			const selectFilter = document.createElement('select');
 			selectFilter.name = key;
 			selectFilter.className = 'taxonomy-select-' + key + ' taxonomy-select';
+			selectFilter.onchange = onChange;
 
-			// All option as first entry
-			var defaultOption = document.createElement('option');
-			defaultOption.value = JSON.stringify([{id:"", name: "",fieldName:''}]);
-
-			if(filter['includes'].length == 0){
-				defaultOption.value = JSON.stringify([{id:"", name: "",fieldName:key}]);
+			if(filter['includes'].length != 1) {
+				// All option as first entry
+				const defaultOption = document.createElement('option');
+				defaultOption.value = '-1';
 				defaultOption.innerText = 'All';
 				defaultOption.className = 'taxonomy-option-all';
-				selectFilter.appendChild(defaultOption);
-			} else if(filter['restrict'] && filter['includes'].length > 1){
-				defaultOption.value = JSON.stringify([{id:"", name: "",fieldName:key}]);
-				defaultOption.innerText = 'All';
-				defaultOption.className = 'taxonomy-option-all';
-				selectFilter.appendChild(defaultOption);
-			} else {
 				if(!filter['restrict'] && filter['includes'].length > 1){
-					var allOptions = document.createElement('option');
-					allOptions.innerText = 'Default';
-					allOptions.value = JSON.stringify([{id:"remove", name: "",fieldName:key}]);
-					allOptions.className = 'taxonomy-option-default';
+					defaultOption.innerText = 'Default';
+					defaultOption.className = 'taxonomy-option-default';
+					const allOptions = document.createElement('option');
+					allOptions.innerText = 'All';
+					allOptions.value = '';
+					allOptions.className = 'taxonomy-option-all';
 					selectFilter.appendChild(allOptions);
 				}
-				defaultOption.value = JSON.stringify([{id: "", name: "",fieldName:key}]);
-				defaultOption.innerText = 'All';
-				defaultOption.className = 'taxonomy-option-all';
+				defaultOption.selected = true;
+				// Append
 				selectFilter.appendChild(defaultOption);
 			}
-			// Append
 			container.appendChild(itemLabel);
 			container.appendChild(selectFilter);
 			formDiv.appendChild(container);
 		}
-		// Create Filter button after filters are rendered
-		var formButtonContainer = document.createElement('div');
-		formButtonContainer.classList = 'form-item-button form-item';
-	
-		var formButton = document.createElement('input');
-		formButton.classList = 'form-submit-btn';
-		formButton.type = 'submit';
-		formButtonContainer.appendChild(formButton);
-		formDiv.appendChild(formButtonContainer);
 		form.appendChild(formDiv);
 		// Append final container
 		this._userFormElement.appendChild(form);   
@@ -643,7 +609,7 @@ class PeopleListElement extends HTMLElement {
 		taxonomy.forEach(taxonomyTerm => {
 			if(restrict && taxonomiesIncluded.indexOf(taxonomyTerm.id) === -1) return; // Rejects a restricted option
 			const option = document.createElement('option');
-			option.value = JSON.stringify([{id: taxonomyTerm.id, name: taxonomyTerm.name, fieldName: taxonomyFieldName}]);
+			option.value = taxonomyTerm.id;
 			option.innerText = taxonomyTerm.name;
 			option.selected = taxonomiesIncluded.length === 1 && taxonomiesIncluded[0] == taxonomyTerm.id;
 			selectElement.appendChild(option);

--- a/js/ucb-people-list.js
+++ b/js/ucb-people-list.js
@@ -364,7 +364,7 @@ class PeopleListElement extends HTMLElement {
 				thisPerson = {
 					link: (personAttributeData['path'] || {})['alias'] || `/node/${personAttributeData['drupal_internal__nid']}`,
 					name: personAttributeData['title'],
-					title: personAttributeData['field_ucb_person_title'][0],
+					titles: personAttributeData['field_ucb_person_title'],
 					departments: departments,
 					jobTypes: jobTypes,
 					photoId: photoId,
@@ -390,20 +390,24 @@ class PeopleListElement extends HTMLElement {
 	}
 
 	appendPerson(format, person, containerElement) {
-		let cardElement, cardHTML = '', myDept = '';
+		let cardElement, cardHTML = '', personTitleList = '', personDepartmentList = '';
 		const
 			personLink = person.link,
 			personName = PeopleListElement.escapeHTML(person.name),
-			personTitle = PeopleListElement.escapeHTML(person.title),
-			personPhoto = person.photoURI ? `<img src="${person.photoURI}">` : '',
+			personPhoto = person.photoURI ? '<img src="' + person.photoURI + '">' : '',
 			personBody = PeopleListElement.escapeHTML(person.body),
 			personEmail = PeopleListElement.escapeHTML(person.email),
 			personPhone = PeopleListElement.escapeHTML(person.phone),
 			departmentTaxonomy = this.getTaxonomy('department');
+		person.titles.forEach(title => {
+			personTitleList += (personTitleList ? ' &bull; ' : '') + PeopleListElement.escapeHTML(title);
+		});
 		person.departments.forEach(termId => {
-			const thisDeptName = departmentTaxonomy ? PeopleListElement.escapeHTML(PeopleListElement.getTaxonomyName(departmentTaxonomy, termId)) : '';
-			myDept += '<li class="taxonomy-department" data-term-id="' + termId + '">' + thisDeptName + '</li>';
-		});	
+			const department = departmentTaxonomy ? PeopleListElement.escapeHTML(PeopleListElement.getTaxonomyName(departmentTaxonomy, termId)) : '';
+			personDepartmentList +=  (personDepartmentList ? ' &bull; ' : '') + '<span class="taxonomy-department" data-term-id="' + termId + '">' + department + '</span>';
+		});
+		if(personDepartmentList)
+			personDepartmentList = '<span' + (departmentTaxonomy ? '' : ' hidden') + ' class="taxonomy-visible-department">' + personDepartmentList + '</span>';
 		switch (format) {
 			case 'list': default:
 				cardElement = document.createElement('div');
@@ -419,12 +423,10 @@ class PeopleListElement extends HTMLElement {
 								</span>
 							</a>
 							<span class="ucb-person-card-title">
-								${personTitle}
+								${personTitleList}
 							</span>
 							<span class="ucb-person-card-dept">
-								<ul${departmentTaxonomy ? '' : ' hidden'} class="ucb-person-card-dept-ul taxonomy-visible-department">
-									${myDept} 
-								</ul>
+								${personDepartmentList} 
 							</span>
 							<span class="ucb-person-card-body">
 								${personBody}
@@ -467,12 +469,10 @@ class PeopleListElement extends HTMLElement {
 								</span>
 							</a>
 							<span class="ucb-person-card-title departments-grid">
-								${personTitle}
+								${personTitleList}
 							</span>
 							<span class="ucb-person-card-dept departments-grid">
-								<ul${departmentTaxonomy ? '' : ' hidden'} class="ucb-person-card-dept-ul taxonomy-visible-department">
-									${myDept}
-								</ul>
+								${personDepartmentList}
 							</span>
 						</div>
 					</div>`;
@@ -490,12 +490,10 @@ class PeopleListElement extends HTMLElement {
 							</span>
 						</a>
 						<span class="ucb-person-card-title departments-grid">
-							${personTitle}
+							${personTitleList}
 						</span>
 						<span class="ucb-person-card-dept departments-grid">
-							<ul${departmentTaxonomy ? '' : ' hidden'} class="ucb-person-card-dept-ul taxonomy-visible-department">
-								${myDept}
-							</ul>
+							${personDepartmentList}
 						</span>
 					</td>
 					<td>

--- a/js/ucb-people-list.js
+++ b/js/ucb-people-list.js
@@ -127,7 +127,12 @@ class PeopleListElement extends HTMLElement {
             resolve(data)
           })
       } else {
-        this.toggleMessage('ucb-al-error', 'block')
+        // this.toggleMessage('ucb-al-error', 'block')
+        console.log("Error retrieving people from the API endpoint.  Please try again later. ")
+        var errorEl = document.getElementsByClassName('ucb-error')[0]
+        errorEl.style.display = 'block'
+        var loaderEl = document.getElementsByClassName('ucb-list-msg ucb-loading-data')[0]
+        loaderEl.style.display= 'none'
         reject
       }
     })
@@ -540,7 +545,6 @@ class PeopleListElement extends HTMLElement {
   toggleMessage(id, display = 'none') {
   if (id) {
     var toggle = document.getElementById(id)
-    console.log(toggle)
     if (toggle) {
       if (display === 'block') {
         toggle.style.display = 'block'

--- a/js/ucb-people-list.js
+++ b/js/ucb-people-list.js
@@ -154,7 +154,6 @@ class PeopleListElement extends HTMLElement {
 			format = this._format = userConfig['format'] || config['format'] || 'list',
 			groupBy = userConfig['groupby'] || config['groupby'] || 'none',
 			orderBy = this._orderBy = userConfig['orderby'] || config['orderby'] || 'last';
-    
 		this.toggleMessageDisplay(this._messageElement, 'none', null, null);
 		this.toggleMessageDisplay(this._loadingElement, 'block', null, null);
 
@@ -530,13 +529,7 @@ class PeopleListElement extends HTMLElement {
 			element.setAttribute('hidden', '');
 		else element.removeAttribute('hidden');
 	}
-/**
- * 
- * TO DO -
- * 
- * - Add functionality to re-filter list after user input
- *
- */
+
   async generateForm(config){
     if(this._userFormElement.children.length == 0){
       // Create Elements
@@ -550,11 +543,41 @@ class PeopleListElement extends HTMLElement {
         for (var p of formData) {
           dataObj[p[0]] = JSON.parse(p[1])
         } 
-        console.log("results", dataObj)
-
-         // TO DO -- fix build
-        // this.build(deptObj, typeObj)
-
+        var userSettings = {
+          filters: {
+            department: {
+              includes: [dataObj.department[0].id],
+              userAccessible: config.filters.department.userAccessible,
+              label: config.filters.department.label,
+              restrict: config.filters.department.restrict
+            },
+            filter_1:{
+                includes: [dataObj.filter_1[0].id],
+                userAccessible: config.filters.filter_1.userAccessible,
+                label: config.filters.filter_1.label,
+                restrict: config.filters.filter_1.restrict
+            },
+            filter_2:{
+                includes: [dataObj.filter_2[0].id],
+                userAccessible: config.filters.filter_2.userAccessible,
+                label: config.filters.filter_2.label,
+                restrict: config.filters.filter_2.restrict
+            },
+            filter_3:{
+                includes: [dataObj.filter_3[0].id],
+                userAccessible: config.filters.filter_3.userAccessible,
+                label: config.filters.filter_3.label,
+                restrict: config.filters.filter_3.restrict
+            },
+            job_type:{
+                includes: [dataObj.job_type[0].id],
+                userAccessible: config.filters.job_type.userAccessible,
+                label: config.filters.job_type.label,
+                restrict: config.filters.job_type.restrict
+            },            
+        }
+      }
+      this.setAttribute('user-config', JSON.stringify(userSettings))
       })
       form.classList = 'people-list-filter'
       var formDiv = document.createElement('div')
@@ -571,7 +594,7 @@ class PeopleListElement extends HTMLElement {
         formItemDeptLabel.innerText = 'Departments'
     
         var selectDept = document.createElement('select')
-        selectDept.name = 'editDepartment'
+        selectDept.name = 'department'
         selectDept.id = 'edit-department'
         selectDept.className = "taxonomy-select"
         // All option as first entry
@@ -595,7 +618,7 @@ class PeopleListElement extends HTMLElement {
         formItemJobTypeLabel.innerText = 'Job Types'
     
         var selectJobType = document.createElement('select')
-        selectJobType.name = 'editJobType'
+        selectJobType.name = 'job_type'
         selectJobType.id = 'edit-job-types'
         selectJobType.className = "taxonomy-select"
   
@@ -620,7 +643,7 @@ class PeopleListElement extends HTMLElement {
         formItemFilter1Label.innerText = config.filters.filter_1.label
     
         var selectFilter1 = document.createElement('select')
-        selectFilter1.name = 'editFilterOne'
+        selectFilter1.name = 'filter_1'
         selectFilter1.id = 'edit-filter-one'
         selectFilter1.className = "taxonomy-select"
   
@@ -644,7 +667,7 @@ class PeopleListElement extends HTMLElement {
         formItemFilter2Label.innerText = config.filters.filter_2.label
     
         var selectFilter2 = document.createElement('select')
-        selectFilter2.name = 'editFilterTwo'
+        selectFilter2.name = 'filter_2'
         selectFilter2.id = 'edit-filter-two'
         selectFilter2.className = "taxonomy-select"
         // All option as first entry
@@ -667,7 +690,7 @@ class PeopleListElement extends HTMLElement {
         formItemFilter3Label.innerText = config.filters.filter_3.label
     
         var selectFilter3 = document.createElement('select')
-        selectFilter3.name = 'editFilterThree'
+        selectFilter3.name = 'filter_3'
         selectFilter3.id = 'edit-filter-three'
         selectFilter3.className = "taxonomy-select"
         // All option as first entry

--- a/js/ucb-people-list.js
+++ b/js/ucb-people-list.js
@@ -752,7 +752,7 @@ class PeopleListElement extends HTMLElement {
             let taxonomiesIncluded = taxonomyConfig.includes[0] == "" ? taxonomyConfig.includes : taxonomyConfig.includes.map(Number)
 
             // Render selection if no taxonomies were selected to filter, if restricted is on and the taxonomy is included, or if restricted = false
-            if((taxonomyConfig.includes[0] == "") || (taxonomyConfig.restrict && taxonomiesIncluded.includes(taxonomy.id)) || taxonomyConfig.restrict == false){
+            if((taxonomyConfig.includes[0] == "") || (taxonomyConfig.restrict && taxonomiesIncluded.includes(taxonomy.id)) || (taxonomyConfig.restrict && taxonomiesIncluded.length == 0) || taxonomyConfig.restrict == false){
               let option = document.createElement('option')
               option.value = JSON.stringify([{id:taxonomy.id, name: taxonomy.name, fieldName: taxonomy.fieldName}])
               option.innerText = taxonomy.name

--- a/js/ucb-people-list.js
+++ b/js/ucb-people-list.js
@@ -551,7 +551,6 @@ class PeopleListElement extends HTMLElement {
 			for (var p of formData) {
 				dataObj[p[0]] = JSON.parse(p[1])
 			} 
-			console.log(dataObj)
 			var userSettings = {}
 			for(let key in dataObj){
 				if(dataObj[key][0]['id']){
@@ -606,10 +605,8 @@ class PeopleListElement extends HTMLElement {
 					defaultOption.innerText = 'All'
 					selectFilter.appendChild(defaultOption)
 				}else {
-					console.log(key,filters[key]['includes'])
 					defaultOption.value = JSON.stringify([{id: filters[key]['includes'], name: "",fieldName:key}])
 					defaultOption.innerText = 'Default'
-					console.log(JSON.parse(defaultOption.value))
 					selectFilter.appendChild(defaultOption)
 					if(!filters[key]['restrict']){
 						var allOptions = document.createElement('option')

--- a/js/ucb-people-list.js
+++ b/js/ucb-people-list.js
@@ -558,37 +558,28 @@ class PeopleListElement extends HTMLElement {
         var userSettings = {
           filters: {
             department: {
-              includes: dataObj.department ? [dataObj.department[0].id] : [""],
-            //   userAccessible: config.filters.department.userAccessible,
-            //   label: config.filters.department.label,
-            //   restrict: config.filters.department.restrict
+              includes: dataObj.department ? [dataObj.department[0].id] : [],
             },
             filter_1:{
-                includes: dataObj.filter_1 ? [dataObj.filter_1[0].id] : [""],
-                // userAccessible: config.filters.filter_1.userAccessible,
-                // label: config.filters.filter_1.label,
-                // restrict: config.filters.filter_1.restrict
+                includes: dataObj.filter_1 ? [dataObj.filter_1[0].id] : [],
             },
             filter_2:{
-                includes: dataObj.filter_2 ? [dataObj.filter_2[0].id] : [""],
-                // userAccessible: config.filters.filter_2.userAccessible,
-                // label: config.filters.filter_2.label,
-                // restrict: config.filters.filter_2.restrict
+                includes: dataObj.filter_2 ? [dataObj.filter_2[0].id] : [],
             },
             filter_3:{
-                includes: dataObj.filter_3 ? [dataObj.filter_3[0].id] : [""],
-                // userAccessible: config.filters.filter_3.userAccessible,
-                // label: config.filters.filter_3.label,
-                // restrict: config.filters.filter_3.restrict
+                includes: dataObj.filter_3 ? [dataObj.filter_3[0].id] : [],
             },
             job_type:{
-                includes: dataObj.job_type ? [dataObj.job_type[0].id] : [""],
-                // userAccessible: config.filters.job_type.userAccessible,
-                // label: config.filters.job_type.label,
-                // restrict: config.filters.job_type.restrict
+                includes: dataObj.job_type ? [dataObj.job_type[0].id] : [],
             },            
         }
-      }
+	}
+		// If restricted, remove user config filters from the user filter, default to config obj
+		for(let key in userSettings['filters']){
+			if(userSettings['filters'][key]['includes'][0] == "" && config['filters'][key]['restrict']){
+				delete userSettings['filters'][key]
+			}
+		}
       this.setAttribute('user-config', JSON.stringify(userSettings))
       })
       form.classList = 'people-list-filter'

--- a/js/ucb-people-list.js
+++ b/js/ucb-people-list.js
@@ -558,34 +558,34 @@ class PeopleListElement extends HTMLElement {
         var userSettings = {
           filters: {
             department: {
-              includes: [dataObj.department[0].id],
-              userAccessible: config.filters.department.userAccessible,
-              label: config.filters.department.label,
-              restrict: config.filters.department.restrict
+              includes: dataObj.department ? [dataObj.department[0].id] : [""],
+            //   userAccessible: config.filters.department.userAccessible,
+            //   label: config.filters.department.label,
+            //   restrict: config.filters.department.restrict
             },
             filter_1:{
                 includes: dataObj.filter_1 ? [dataObj.filter_1[0].id] : [""],
-                userAccessible: config.filters.filter_1.userAccessible,
-                label: config.filters.filter_1.label,
-                restrict: config.filters.filter_1.restrict
+                // userAccessible: config.filters.filter_1.userAccessible,
+                // label: config.filters.filter_1.label,
+                // restrict: config.filters.filter_1.restrict
             },
             filter_2:{
                 includes: dataObj.filter_2 ? [dataObj.filter_2[0].id] : [""],
-                userAccessible: config.filters.filter_2.userAccessible,
-                label: config.filters.filter_2.label,
-                restrict: config.filters.filter_2.restrict
+                // userAccessible: config.filters.filter_2.userAccessible,
+                // label: config.filters.filter_2.label,
+                // restrict: config.filters.filter_2.restrict
             },
             filter_3:{
                 includes: dataObj.filter_3 ? [dataObj.filter_3[0].id] : [""],
-                userAccessible: config.filters.filter_3.userAccessible,
-                label: config.filters.filter_3.label,
-                restrict: config.filters.filter_3.restrict
+                // userAccessible: config.filters.filter_3.userAccessible,
+                // label: config.filters.filter_3.label,
+                // restrict: config.filters.filter_3.restrict
             },
             job_type:{
-                includes: [dataObj.job_type[0].id],
-                userAccessible: config.filters.job_type.userAccessible,
-                label: config.filters.job_type.label,
-                restrict: config.filters.job_type.restrict
+                includes: dataObj.job_type ? [dataObj.job_type[0].id] : [""],
+                // userAccessible: config.filters.job_type.userAccessible,
+                // label: config.filters.job_type.label,
+                // restrict: config.filters.job_type.restrict
             },            
         }
       }
@@ -612,7 +612,12 @@ class PeopleListElement extends HTMLElement {
         // All option as first entry
         var allOption = document.createElement('option')
         allOption.value = JSON.stringify([{id:"", name: "",fieldName:''}])
-        allOption.innerText = 'All'
+		// If restricted, set to Default instead of All
+		if(config.filters.department.restrict){
+			allOption.innerText = 'Default'
+		} else {
+			allOption.innerText = 'All'
+		}
         selectDept.appendChild(allOption)
         // Append
         formItemDeptContainer.appendChild(formItemDeptLabel)
@@ -637,7 +642,12 @@ class PeopleListElement extends HTMLElement {
         // All option as first entry
         var allOption = document.createElement('option')
         allOption.value = JSON.stringify([{id:'', name: "",fieldName:''}])
-        allOption.innerText = 'All'
+        	// If restricted, set to Default instead of All
+		if(config.filters.job_type.restrict){
+			allOption.innerText = 'Default'
+		} else {
+			allOption.innerText = 'All'
+		}
         // Append
         selectJobType.appendChild(allOption)    
         formItemJobTypeContainer.appendChild(formItemJobTypeLabel)
@@ -662,7 +672,12 @@ class PeopleListElement extends HTMLElement {
         // All option as first entry
         var allOption = document.createElement('option')
         allOption.value = JSON.stringify([{id:'', name: '',fieldName:''}])
-        allOption.innerText = 'All'
+        // If restricted, set to Default instead of All
+		if(config.filters.filter_1.restrict){
+			allOption.innerText = 'Default'
+		} else {
+			allOption.innerText = 'All'
+		}
         // Append
         selectFilter1.appendChild(allOption)
         formItemFilter1Container.appendChild(formItemFilter1Label)
@@ -685,7 +700,12 @@ class PeopleListElement extends HTMLElement {
         // All option as first entry
         var allOption = document.createElement('option')
         allOption.value = JSON.stringify([{id:'', name: '',fieldName:''}])
-        allOption.innerText = 'All'
+        // If restricted, set to Default instead of All
+		if(config.filters.filter_2.restrict){
+			allOption.innerText = 'Default'
+		} else {
+			allOption.innerText = 'All'
+		}
         // Append
         selectFilter2.appendChild(allOption)    
         formItemFilter2Container.appendChild(formItemFilter2Label)
@@ -708,7 +728,12 @@ class PeopleListElement extends HTMLElement {
         // All option as first entry
         var allOption = document.createElement('option')
         allOption.value = JSON.stringify([{id:'', name: '', fieldName:''}])
-        allOption.innerText = 'All'
+        // If restricted, set to Default instead of All
+		if(config.filters.filter_3.restrict){
+			allOption.innerText = 'Default'
+		} else {
+			allOption.innerText = 'All'
+		}
         // Append
         selectFilter3.appendChild(allOption)    
         formItemFilter3Container.appendChild(formItemFilter3Label)

--- a/js/ucb-people-list.js
+++ b/js/ucb-people-list.js
@@ -541,193 +541,89 @@ class PeopleListElement extends HTMLElement {
 
 	generateForm(){
 		const filters = this._filters, userAccessibleFilters = this._userAccessibleFilters;
-	// for(filter in config.)
-      // Create Elements
-      var form = document.createElement('form')
-      form.addEventListener('submit',(event)=> {
-        event.preventDefault()
-        var formData = new FormData(event.target);
-        var dataObj = {}
-        // Create a dataObject with ids for second render
-        for (var p of formData) {
-          dataObj[p[0]] = JSON.parse(p[1])
-        } 
-        var userSettings = {
-          filters: {
-            department: {
-              includes: dataObj.department ? [dataObj.department[0].id] : [],
-            },
-            filter_1:{
-                includes: dataObj.filter_1 ? [dataObj.filter_1[0].id] : [],
-            },
-            filter_2:{
-                includes: dataObj.filter_2 ? [dataObj.filter_2[0].id] : [],
-            },
-            filter_3:{
-                includes: dataObj.filter_3 ? [dataObj.filter_3[0].id] : [],
-            },
-            job_type:{
-                includes: dataObj.job_type ? [dataObj.job_type[0].id] : [],
-            },            
-        }
-	}
-		// If restricted, remove user config filters from the user filter, default to config obj
-		for(let key in userSettings['filters']){
-			if(userSettings['filters'][key]['includes'][0] == "" && filters[key]['restrict']){
-				delete userSettings['filters'][key]
+		// Create Elements
+      	var form = document.createElement('form')
+		form.addEventListener('submit',(event)=> {
+			event.preventDefault()
+			var formData = new FormData(event.target);
+			var dataObj = {}
+			// Create a dataObject with ids for second render
+			for (var p of formData) {
+				dataObj[p[0]] = JSON.parse(p[1])
+			} 
+			console.log(dataObj)
+			var userSettings = {}
+			for(let key in dataObj){
+				if(dataObj[key][0]['id']){
+					if(dataObj[key][0]['id'] == "" && filters[key]['restrict']){
+						delete dataObj[key]
+					} else {
+						let fieldName = dataObj[key][0]['fieldName']
+						let ids = dataObj[key][0]["id"]
+						
+						let value = {includes: [ids]}
+						userSettings[fieldName] = value
+					}
+				}
+			
+			}
+			let finalObj = {filters: userSettings}
+			// If restricted, remove user config filters from the user filter, default to config obj
+		this.setAttribute('user-config', JSON.stringify(finalObj))
+		})
+		form.classList = 'people-list-filter'
+		var formDiv = document.createElement('div')
+		formDiv.classList = 'd-flex align-items-center'
+	
+		// If User-Filterable...
+		// Departments, create filterable dropdown of Departments
+		// Create Dropdowns
+		for(let key in filters){
+			if(filters[key].userAccessible){
+				// Create container
+				var container = document.createElement('div')
+				container.classList = `form-item-${key} form-item taxonomy-select-${key}`
+				// Create label el
+				var itemLabel = document.createElement('label')
+				itemLabel.htmlFor = `Edit ${filters[key]['label']}`
+				itemLabel.innerText = filters[key]['label']
+				// Create select el
+				var selectFilter = document.createElement('select')
+				selectFilter.name = key
+				selectFilter.id = `edit-${key}`
+				selectFilter.className = "taxonomy-select"
+
+				// All option as first entry
+				var defaultOption = document.createElement('option')
+				defaultOption.value = JSON.stringify([{id:"", name: "",fieldName:''}])
+
+				if(filters[key]['includes'].length == 0){
+					defaultOption.value = JSON.stringify([{id:"", name: "",fieldName:key}])
+					defaultOption.innerText = 'All'
+					selectFilter.appendChild(defaultOption)
+				} else if(filters[key]['restrict'] && filters[key]['includes'].length >=2 ){
+					defaultOption.value = JSON.stringify([{id:"", name: "",fieldName:key}])
+					defaultOption.innerText = 'All'
+					selectFilter.appendChild(defaultOption)
+				}else {
+					console.log(key,filters[key]['includes'])
+					defaultOption.value = JSON.stringify([{id: filters[key]['includes'], name: "",fieldName:key}])
+					defaultOption.innerText = 'Default'
+					console.log(JSON.parse(defaultOption.value))
+					selectFilter.appendChild(defaultOption)
+					if(!filters[key]['restrict']){
+						var allOptions = document.createElement('option')
+						allOptions.innerText = 'All'
+						allOptions.value = JSON.stringify([{id:"", name: "",fieldName:key}])
+						selectFilter.appendChild(allOptions)
+					}
+				}
+				// Append
+				container.appendChild(itemLabel)
+				container.appendChild(selectFilter)
+				formDiv.appendChild(container)
 			}
 		}
-      this.setAttribute('user-config', JSON.stringify(userSettings))
-      })
-      form.classList = 'people-list-filter'
-      var formDiv = document.createElement('div')
-      formDiv.classList = 'd-flex align-items-center'
-  
-      // If User-Filterable...
-      // Departments, create filterable dropdown of Departments
-      if(filters.department.userAccessible){
-        var formItemDeptContainer = document.createElement('div')
-        formItemDeptContainer.classList = 'form-item-department form-item taxonomy-select-department'
-    
-        var formItemDeptLabel = document.createElement('label')
-        formItemDeptLabel.htmlFor = "Edit Departments"
-        formItemDeptLabel.innerText = 'Departments'
-    
-        var selectDept = document.createElement('select')
-        selectDept.name = 'department'
-        selectDept.id = 'edit-department'
-        selectDept.className = "taxonomy-select"
-        // All option as first entry
-        var allOption = document.createElement('option')
-        allOption.value = JSON.stringify([{id:"", name: "",fieldName:''}])
-		// If restricted, and has filters set to Default instead of All
-		if(filters.department.restrict && filters.department.includes.length > 0){
-			allOption.innerText = 'Default'
-		} else {
-			allOption.innerText = 'All'
-		}
-        selectDept.appendChild(allOption)
-        // Append
-        formItemDeptContainer.appendChild(formItemDeptLabel)
-        formItemDeptContainer.appendChild(selectDept)
-        formDiv.appendChild(formItemDeptContainer)
-      }
-  
-      // Create filterable dropdown of Job Types
-      if(filters.job_type.userAccessible){
-        var formItemJobTypeContainer = document.createElement('div')
-        formItemJobTypeContainer.classList = 'form-item-job-type form-item taxonomy-select-job_type'
-    
-        var formItemJobTypeLabel = document.createElement('label')
-        formItemJobTypeLabel.htmlFor = "Edit Job Types"
-        formItemJobTypeLabel.innerText = 'Job Types'
-    
-        var selectJobType = document.createElement('select')
-        selectJobType.name = 'job_type'
-        selectJobType.id = 'edit-job-types'
-        selectJobType.className = "taxonomy-select"
-  
-        // All option as first entry
-        var allOption = document.createElement('option')
-        allOption.value = JSON.stringify([{id:'', name: "",fieldName:''}])
-        	// If restricted, set to Default instead of All
-		if(filters.job_type.restrict && filters.job_type.includes.length >0){
-			allOption.innerText = 'Default'
-		} else {
-			allOption.innerText = 'All'
-		}
-        // Append
-        selectJobType.appendChild(allOption)    
-        formItemJobTypeContainer.appendChild(formItemJobTypeLabel)
-        formItemJobTypeContainer.appendChild(selectJobType)
-    
-        formDiv.appendChild(formItemJobTypeContainer)
-      }
-      // Create Filter 1
-      if(filters.filter_1.userAccessible){
-        var formItemFilter1Container = document.createElement('div')
-        formItemFilter1Container.classList = 'form-item-filter-one form-item taxonomy-select-filter_1'
-    
-        var formItemFilter1Label = document.createElement('label')
-        formItemFilter1Label.htmlFor = "Edit Filer 1"
-        formItemFilter1Label.innerText = filters.filter_1.label
-    
-        var selectFilter1 = document.createElement('select')
-        selectFilter1.name = 'filter_1'
-        selectFilter1.id = 'edit-filter-one'
-        selectFilter1.className = "taxonomy-select"
-  
-        // All option as first entry
-        var allOption = document.createElement('option')
-        allOption.value = JSON.stringify([{id:'', name: '',fieldName:''}])
-        // If restricted, set to Default instead of All
-		if(filters.filter_1.restrict && filters.filter_1.includes.length > 0){
-			allOption.innerText = 'Default'
-		} else {
-			allOption.innerText = 'All'
-		}
-        // Append
-        selectFilter1.appendChild(allOption)
-        formItemFilter1Container.appendChild(formItemFilter1Label)
-        formItemFilter1Container.appendChild(selectFilter1)
-        formDiv.appendChild(formItemFilter1Container)
-      }
-      // Create Filter 2
-      if(filters.filter_2.userAccessible){
-        var formItemFilter2Container = document.createElement('div')
-        formItemFilter2Container.classList = 'form-item-filter-two form-item taxonomy-select-filter_2'
-    
-        var formItemFilter2Label = document.createElement('label')
-        formItemFilter2Label.htmlFor = "Edit Filter 2"
-        formItemFilter2Label.innerText = filters.filter_2.label
-    
-        var selectFilter2 = document.createElement('select')
-        selectFilter2.name = 'filter_2'
-        selectFilter2.id = 'edit-filter-two'
-        selectFilter2.className = "taxonomy-select"
-        // All option as first entry
-        var allOption = document.createElement('option')
-        allOption.value = JSON.stringify([{id:'', name: '',fieldName:''}])
-        // If restricted, set to Default instead of All
-		if(filters.filter_2.restrict && filters.filter_2.includes.length > 0){
-			allOption.innerText = 'Default'
-		} else {
-			allOption.innerText = 'All'
-		}
-        // Append
-        selectFilter2.appendChild(allOption)    
-        formItemFilter2Container.appendChild(formItemFilter2Label)
-        formItemFilter2Container.appendChild(selectFilter2)
-        formDiv.appendChild(formItemFilter2Container)
-      }
-      // Create Filter 3
-      if(filters.filter_3.userAccessible){
-        var formItemFilter3Container = document.createElement('div')
-        formItemFilter3Container.classList = 'form-item-filter-three form-item taxonomy-select-filter_3'
-    
-        var formItemFilter3Label = document.createElement('label')
-        formItemFilter3Label.htmlFor = "Edit Filter 3"
-        formItemFilter3Label.innerText = filters.filter_3.label
-    
-        var selectFilter3 = document.createElement('select')
-        selectFilter3.name = 'filter_3'
-        selectFilter3.id = 'edit-filter-three'
-        selectFilter3.className = "taxonomy-select"
-        // All option as first entry
-        var allOption = document.createElement('option')
-        allOption.value = JSON.stringify([{id:'', name: '', fieldName:''}])
-        // If restricted, set to Default instead of All
-		if(filters.filter_3.restrict && filters.filter_3.includes.length > 0){
-			allOption.innerText = 'Default'
-		} else {
-			allOption.innerText = 'All'
-		}
-        // Append
-        selectFilter3.appendChild(allOption)    
-        formItemFilter3Container.appendChild(formItemFilter3Label)
-        formItemFilter3Container.appendChild(selectFilter3)
-        formDiv.appendChild(formItemFilter3Container)
-      }
       // Create Filter button after filters are rendered
       var formButtonContainer = document.createElement('div')
       formButtonContainer.classList = 'form-item-button form-item'

--- a/js/ucb-people-list.js
+++ b/js/ucb-people-list.js
@@ -71,6 +71,11 @@ class PeopleListProvider {
 }
 
 class PeopleListElement extends HTMLElement {
+	/**
+	 * 
+	 * @param {string|null|undefined} raw A raw string
+	 * @returns {string} An HTML-safe string (or an empty string if `raw` is `null` or `undefined`)
+	 */
 	static escapeHTML(raw) { return raw ? raw.replace(/\&/g, '&amp;').replace(/"/g, '&quot;').replace(/</g, '&lt;').replace(/>/g, '&gt;') : ''; }
 	static get observedAttributes() { return ['user-config']; }
 
@@ -257,7 +262,7 @@ class PeopleListElement extends HTMLElement {
         })
         // using the image-only data, creates the idObj =>  key: thumbnail id, value : data id
         idFilterData.map((pair) => {
-          idObj[pair.id] = pair['relationships']['thumbnail']['data']['id']
+          idObj[pair['id']] = pair['relationships']['thumbnail']['data']['id']
         })
       }
   
@@ -464,154 +469,144 @@ class PeopleListElement extends HTMLElement {
     }
     return container
   }
-  displayPersonCard(Format, Person, Departments) {
-	// console.log('Rendering the card for ' + Person.Name)
-	let cardHTML = '';
-	// grab the friendly name from the global variable
-	// note: there may be a race condidtion here as we're also querying
-	//  to get those friendly names from the API endpoint.
-	// console.log('Departments :', Departments)
-	let myDept = "";
-	for(let i = 0; i < Person.departments.length; i++) {
-	let thisDeptID = Person.departments[i]
-	let thisDeptName = this.getTaxonomyName(Departments, thisDeptID)['name'];
-	myDept += `<li>${PeopleListElement.escapeHTML(thisDeptName)}</li>`;
-	}
-	let myPhoto = '';
-	if (Person.photoURI) {
-		myPhoto = `<img src="${PeopleListElement.escapeHTML(Person.photoURI)}">`;
-	}
-
-	const
-		personLink = Person.link,
-		personName = PeopleListElement.escapeHTML(Person.name),
-		personTitle = PeopleListElement.escapeHTML(Person.title),
-		personBody = PeopleListElement.escapeHTML(Person.body),
-		personEmail = PeopleListElement.escapeHTML(Person.email),
-		personPhone = PeopleListElement.escapeHTML(Person.phone);
-  
-	switch (Format) {
-	case 'list':
-		cardHTML = `
-				<div class="ucb-person-card-list row">
-					<div class="col-sm-12 col-md-3 ucb-person-card-img">
-						<a href="${personLink}">${myPhoto}</a>
-					</div>
-					<div class="col-sm-12 col-md-9 ucb-person-card-details">
-						<a href="${personLink}">
-							<span class="ucb-person-card-name">
-								${personName ? personName : ''}
+	displayPersonCard(format, person, departments) {
+		// console.log('Rendering the card for ' + Person.Name)
+		let cardHTML = '';
+		// grab the friendly name from the global variable
+		// note: there may be a race condidtion here as we're also querying
+		//  to get those friendly names from the API endpoint.
+		// console.log('Departments :', Departments)
+		let myDept = "";
+		for(let i = 0; i < person.departments.length; i++) {
+			const 
+				thisDeptID = person.departments[i], 
+				thisDeptName = this.getTaxonomyName(departments, thisDeptID)['name'];
+			myDept += `<li>${PeopleListElement.escapeHTML(thisDeptName)}</li>`;
+		}
+		const
+			personLink = person.link,
+			personName = PeopleListElement.escapeHTML(person.name),
+			personPhoto = person.photoURI ? `<img src="${PeopleListElement.escapeHTML(person.photoURI)}">` : '',
+			personTitle = PeopleListElement.escapeHTML(person.title),
+			personBody = PeopleListElement.escapeHTML(person.body),
+			personEmail = PeopleListElement.escapeHTML(person.email),
+			personPhone = PeopleListElement.escapeHTML(person.phone);
+	
+		switch (format) {
+			case 'list':
+				cardHTML = `
+					<div class="ucb-person-card-list row">
+						<div class="col-sm-12 col-md-3 ucb-person-card-img">
+							<a href="${personLink}">${personPhoto}</a>
+						</div>
+						<div class="col-sm-12 col-md-9 ucb-person-card-details">
+							<a href="${personLink}">
+								<span class="ucb-person-card-name">
+									${personName}
+								</span>
+							</a>
+							<span class="ucb-person-card-title">
+								${personTitle}
 							</span>
-						</a>
-						<span class="ucb-person-card-title">
-							${personTitle ? personTitle : ''}
-						</span>
-					<span class="ucb-person-card-dept">
-						<ul class="ucb-person-card-dept-ul">
-						${myDept} 
-						</ul>
-					</span>
-					<span class="ucb-person-card-body">
-						${personBody ? personBody : ''}
-					</span>
-					<div class="ucb-person-card-contact">
-						<span class="ucb-person-card-email">
-							${
-								personEmail
-								? `<a href="mailto:${personEmail}"><span class="ucb-people-list-contact">  ${personEmail}</span></a>`
-								: ''
-							}
-						</span>
-						<span class="ucb-person-card-phone">
-							${
-								personPhone
-								? `<a href="tel:${personPhone.replace(
-									/[^+\d]+/g,
-									'',
-									)}"><p><span class="ucb-people-list-contact">  ${
-										personPhone
-									}</span></p></a>`
-								: ''
-							}
-						</span>
-					</div>
-					</div>
-				</div>
-			`
-		break
-	case 'grid':
-		cardHTML = `
-				<div class="col-sm mb-3">
-					<div class="col-sm-12 ucb-person-card-img-grid">
-						<a href="${personLink}">${myPhoto}</a>
-					</div>
-				<div>
-				<a href="${personLink}">
-							<span class="ucb-person-card-name">
-								${personBody ? personBody : ''}
+							<span class="ucb-person-card-dept">
+								<ul class="ucb-person-card-dept-ul">
+									${myDept} 
+								</ul>
 							</span>
-						</a>
-				<span class="ucb-person-card-title departments-grid">
-					${personTitle ? personTitle : ''}
-				</span>
-				<span class="ucb-person-card-dept departments-grid">
-					<ul class="ucb-person-card-dept-ul">
-					${myDept}
-					</ul>
-				</span>
-				</div>
-				</div>
-		`
-		break
-	case 'table':
-		cardHTML = `
-
+							<span class="ucb-person-card-body">
+								${personBody}
+							</span>
+							<div class="ucb-person-card-contact">
+								<span class="ucb-person-card-email">
+									${
+										personEmail ?
+											`<a href="mailto:${personEmail}">
+												<span class="ucb-people-list-contact">  ${personEmail}</span>
+											</a>`
+										: ''
+									}
+								</span>
+								<span class="ucb-person-card-phone">
+									${
+										personPhone ?
+											`<a href="tel:${personPhone.replace(/[^+\d]+/g, '',)}">
+												<p><span class="ucb-people-list-contact">  ${personPhone}</span></p>
+											</a>`
+										: ''
+									}
+								</span>
+							</div>
+						</div>
+					</div>`;
+			break;
+			case 'grid':
+				cardHTML = `
+					<div class="col-sm mb-3">
+						<div class="col-sm-12 ucb-person-card-img-grid">
+							<a href="${personLink}">${personPhoto}</a>
+						</div>
+						<div>
+							<a href="${personLink}">
+								<span class="ucb-person-card-name">
+									${personBody ? personBody : ''}
+								</span>
+							</a>
+							<span class="ucb-person-card-title departments-grid">
+								${personTitle}
+							</span>
+							<span class="ucb-person-card-dept departments-grid">
+								<ul class="ucb-person-card-dept-ul">
+									${myDept}
+								</ul>
+							</span>
+						</div>
+					</div>`;
+			break;
+			case 'table':
+				cardHTML = `
 					<td class="ucb-people-list-table-photo">
-					<a href="${personLink}">${myPhoto}</a>  
+						<a href="${personLink}">${personPhoto}</a>  
 					</td>
 					<td>
-					<a href="${personLink}">
-						<span class="ucb-person-card-name">
-						${personName ? personName : ''}
+						<a href="${personLink}">
+							<span class="ucb-person-card-name">
+								${personName}
+							</span>
+						</a>
+						<span class="ucb-person-card-title departments-grid">
+							${personTitle}
 						</span>
-					</a>
-					<span class="ucb-person-card-title departments-grid">
-					${personTitle ? personTitle : ''}
-				</span>
-				<span class="ucb-person-card-dept departments-grid">
-					<ul class="ucb-person-card-dept-ul">
-					${myDept}
-					</ul>
-				</span>
+						<span class="ucb-person-card-dept departments-grid">
+							<ul class="ucb-person-card-dept-ul">
+								${myDept}
+							</ul>
+						</span>
 					</td>
 					<td>
 					<span class="ucb-person-card-email">
-							${
-								personEmail
-								? `<a href="mailto:${personEmail}"><span class="ucb-people-list-contact"> ${personEmail}</span></p></a>`
-								: ''
-							}
+						${
+							personEmail ?
+								`<a href="mailto:${personEmail}">
+									<span class="ucb-people-list-contact"> ${personEmail}</span>
+								</a>`
+							: ''
+						}
 						</span>
 						<span class="ucb-person-card-phone">
 							${
-								personPhone
-								? `<a href="tel:${personPhone.replace(
-									/[^+\d]+/g,
-									'',
-									)}"><p>
-									<span class="ucb-people-list-contact"> 
-									${personPhone}</span></p></a>`
+								personPhone ?
+									`<a href="tel:${personPhone.replace(/[^+\d]+/g, '',)}">
+										<p><span class="ucb-people-list-contact">${personPhone}</span></p>
+									</a>`
 								: ''
 							}
 						</span>
-					</td>
-
-		`
-		break
-	default:
+					</td>`;
+			break;
+			default:
+		}
+		return cardHTML;
 	}
-	return cardHTML;
-}
 	getTaxonomyName(taxonomy, tid) {
 		return taxonomy.find( ({ id }) => id === tid );
 	}

--- a/js/ucb-people-list.js
+++ b/js/ucb-people-list.js
@@ -298,16 +298,22 @@ class PeopleListElement extends HTMLElement {
         thisPerson.link = `/node/${person['attributes']['drupal_internal__nid']}`
         // needed to verify body exists on the Person page, if so, use that
         if (person['attributes']['body']) {
-          const myBody = person['attributes']['body']['processed'];
-          myBody.replace(/(\r\n|\n|\r)/gm, ''); // strip out line breaks
-          thisPerson.body = myBody;
+          // use summary if available
+          if(person['attributes']['body']['summary']){
+            const myBody = person['attributes']['body']['summary'];
+            myBody.replace(/(\r\n|\n|\r)/gm, ''); // strip out line breaks
+            thisPerson.body = myBody;
+          } else {
+            // no summary but body, leave blank?
+            thisPerson.body = '';
+          }
         } else {
           // if no body, set to empty
           thisPerson.body = '';
         }
-        if (thisPerson.PhotoID) {
-          thisPerson.photoURI = urlObj[idObj[thisPerson.PhotoID]]
-          // console.log('Am I an image URL? : ' + thisPerson.PhotoURL)
+        if (thisPerson.photoId) {
+          thisPerson.photoURI = urlObj[idObj[thisPerson.photoId]]
+          // console.log('Am I an image URL? : ' + thisPerson.photoId)
         }
   
         // if first pass (sort by type first) then only render the people with a Job Type 
@@ -483,7 +489,8 @@ class PeopleListElement extends HTMLElement {
 				thisDeptName = this.getTaxonomyName(departments, thisDeptID)['name'];
 			myDept += `<li>${PeopleListElement.escapeHTML(thisDeptName)}</li>`;
 		}
-		const
+
+    const
 			personLink = person.link,
 			personName = PeopleListElement.escapeHTML(person.name),
 			personPhoto = person.photoURI ? `<img src="${PeopleListElement.escapeHTML(person.photoURI)}">` : '',
@@ -548,7 +555,7 @@ class PeopleListElement extends HTMLElement {
 						<div>
 							<a href="${personLink}">
 								<span class="ucb-person-card-name">
-									${personBody ? personBody : ''}
+									${personName ? personName : ''}
 								</span>
 							</a>
 							<span class="ucb-person-card-title departments-grid">

--- a/js/ucb-people-list.js
+++ b/js/ucb-people-list.js
@@ -138,13 +138,14 @@ class PeopleListElement extends HTMLElement {
 		this.toggleMessageDisplay(this._loadingElement, 'block', null, null);
 		// Get our people
 		peopleListProvider.fetchPeople().then(response => {
+      this.generateDropdown()
 			this._contentElement.innerText = '';
 			const ourPeople = response;
 			if(ourPeople['data'].length == 0){
 				this.toggleMessageDisplay(this._messageElement, 'block', 'ucb-list-msg ucb-end-of-results', PeopleListProvider.noResultsMessage);
 			} else {
 				if (GROUPBY == 'department') {
-					for (const [key] of Object.entries(Departments)) {
+					for (const [key] of Object.entries(Departments)) {  
 						// let thisDeptID = Departments[key].id
 						// let thisDeptName = getTaxonomyName(Departments, thisDeptID);
 						// console.log("Group by Dept : " + thisDeptID)
@@ -427,7 +428,6 @@ class PeopleListElement extends HTMLElement {
     }
     // done with cards, clean up and close any HTML tags we have opened.
     // el.append(footerHTML)
-  this.generateDropdown()
     // console.log(el.dataset.json)
   }
   getParentContainer(Format) // flag to know if we've rendered the table header or not yet
@@ -636,7 +636,8 @@ class PeopleListElement extends HTMLElement {
  * - Programatically assign options - (value and innerText)
  *
  */
-  generateDropdown(){
+  async generateDropdown(){
+    var config = JSON.parse(this.getAttribute('config'))
     // Create Elements
     var form = document.createElement('form')
     form.classList = 'people-list-filter'
@@ -645,7 +646,7 @@ class PeopleListElement extends HTMLElement {
 
     // If User-Filterable...
     // Departments, create filterable dropdown of Departments
-    if(this.getAttribute('allowUserDeptFilters')==='True'){
+    if(config.filters.department.userAccessible){
       var formItemDeptContainer = document.createElement('div')
       formItemDeptContainer.classList = 'form-item-department form-item'
   
@@ -655,22 +656,20 @@ class PeopleListElement extends HTMLElement {
   
       var selectDept = document.createElement('select')
       selectDept.id = 'edit-department'
-      // Create options programmatically - TO DO
-      var option4 = document.createElement('option')
-      var option5 = document.createElement('option')
-      var option6 = document.createElement('option')
-      
-      option4.value = '0'
-      option4.innerText = 'Example 4'
-      option5.value = '1'
-      option5.innerText = 'Example 5'
-      option6.value = '3'
-      option6.innerText = 'Example 6'
-  
-      selectDept.appendChild(option4)
-      selectDept.appendChild(option5)
-      selectDept.appendChild(option6)
-  
+      // Get departments and IDs and iterate over creating options
+      const departments = await this.getTaxonomy('department')
+      // All option as first entry
+      var allOption = document.createElement('option')
+      allOption.value = ''
+      allOption.innerText = 'All'
+      selectDept.appendChild(allOption)
+      departments.forEach(department=>{
+        let option = document.createElement('option')
+        option.value = department.id
+        option.innerText = department.name
+        selectDept.appendChild(option)
+      })
+      // Append
       formItemDeptContainer.appendChild(formItemDeptLabel)
       formItemDeptContainer.appendChild(selectDept)
   
@@ -678,7 +677,7 @@ class PeopleListElement extends HTMLElement {
     }
 
     // Create filterable dropdown of Job Types
-    if(this.getAttribute('allowUserJobTypeFilters')==='True'){
+    if(config.filters.job_type.userAccessible){
       var formItemJobTypeContainer = document.createElement('div')
       formItemJobTypeContainer.classList = 'form-item-job-type form-item'
   
@@ -688,21 +687,20 @@ class PeopleListElement extends HTMLElement {
   
       var selectJobType = document.createElement('select')
       selectJobType.id = 'edit-job-types'
-      // Create options programmatically - TO DO
-      var option1 = document.createElement('option')
-      var option2 = document.createElement('option')
-      var option3 = document.createElement('option')
-      
-      option1.value = '0'
-      option1.innerText = 'Example'
-      option2.value = '1'
-      option2.innerText = 'Example 2'
-      option3.value = '3'
-      option3.innerText = 'Example 3'
-  
-      selectJobType.appendChild(option1)
-      selectJobType.appendChild(option2)
-      selectJobType.appendChild(option3)
+
+      const jobTypes = await this.getTaxonomy('ucb_person_job_type')
+      // All option as first entry
+      var allOption = document.createElement('option')
+      allOption.value = ''
+      allOption.innerText = 'All'
+      // Get ID's of departments
+      selectJobType.appendChild(allOption)
+      jobTypes.forEach(type=>{
+        let option = document.createElement('option')
+        option.value = type.id
+        option.innerText = type.name
+        selectJobType.appendChild(option)
+      })
   
       formItemJobTypeContainer.appendChild(formItemJobTypeLabel)
       formItemJobTypeContainer.appendChild(selectJobType)
@@ -710,7 +708,7 @@ class PeopleListElement extends HTMLElement {
       formDiv.appendChild(formItemJobTypeContainer)
     }
     // Create Filter 1
-    if(this.getAttribute('allowUserFilter1')==='True'){
+    if(config.filters.filter_1.userAccessible){
       var formItemFilter1Container = document.createElement('div')
       formItemFilter1Container.classList = 'form-item-filter-one form-item'
   
@@ -720,21 +718,37 @@ class PeopleListElement extends HTMLElement {
   
       var selectFilter1 = document.createElement('select')
       selectFilter1.id = 'edit-filter-one'
+
+
+      const filter1s = await this.getTaxonomy('filter_1')
+      // All option as first entry
+      var allOption = document.createElement('option')
+      allOption.value = ''
+      allOption.innerText = 'All'
+      // Get ID's of filter 1
+      selectFilter1.appendChild(allOption)
+      filter1s.forEach(type=>{
+        let option = document.createElement('option')
+        option.value = type.id
+        option.innerText = type.name
+        selectFilter1.appendChild(option)
+      })
       // Create options programmatically - TO DO
-      var option7 = document.createElement('option')
-      var option8 = document.createElement('option')
-      var option9 = document.createElement('option')
+      // var option7 = document.createElement('option')
+      // var option8 = document.createElement('option')
+      // var option9 = document.createElement('option')
       
-      option7.value = '0'
-      option7.innerText = 'Example'
-      option8.value = '1'
-      option8.innerText = 'Example 2'
-      option9.value = '3'
-      option9.innerText = 'Example 3'
+      // option7.value = '0'
+      // option7.innerText = 'Example'
+      // option8.value = '1'
+      // option8.innerText = 'Example 2'
+      // option9.value = '3'
+      // option9.innerText = 'Example 3'
   
-      selectFilter1.appendChild(option7)
-      selectFilter1.appendChild(option8)
-      selectFilter1.appendChild(option9)
+      // selectFilter1.appendChild(option7)
+      // selectFilter1.appendChild(option8)
+      // selectFilter1.appendChild(option9)
+      
   
       formItemFilter1Container.appendChild(formItemFilter1Label)
       formItemFilter1Container.appendChild(selectFilter1)
@@ -742,7 +756,7 @@ class PeopleListElement extends HTMLElement {
       formDiv.appendChild(formItemFilter1Container)
     }
     // Create Filter 2
-    if(this.getAttribute('allowUserFilter2')==='True'){
+    if(config.filters.filter_2.userAccessible){
       var formItemFilter2Container = document.createElement('div')
       formItemFilter2Container.classList = 'form-item-filter-two form-item'
   
@@ -753,20 +767,34 @@ class PeopleListElement extends HTMLElement {
       var selectFilter2 = document.createElement('select')
       selectFilter2.id = 'edit-filter-two'
       // Create options programmatically - TO DO
-      var option10 = document.createElement('option')
-      var option11 = document.createElement('option')
-      var option12 = document.createElement('option')
+      // var option10 = document.createElement('option')
+      // var option11 = document.createElement('option')
+      // var option12 = document.createElement('option')
       
-      option10.value = '0'
-      option10.innerText = 'Example'
-      option11.value = '1'
-      option11.innerText = 'Example 2'
-      option12.value = '3'
-      option12.innerText = 'Example 3'
+      // option10.value = '0'
+      // option10.innerText = 'Example'
+      // option11.value = '1'
+      // option11.innerText = 'Example 2'
+      // option12.value = '3'
+      // option12.innerText = 'Example 3'
   
-      selectFilter2.appendChild(option10)
-      selectFilter2.appendChild(option11)
-      selectFilter2.appendChild(option12)
+      // selectFilter2.appendChild(option10)
+      // selectFilter2.appendChild(option11)
+      // selectFilter2.appendChild(option12)
+
+      const filter2s = await this.getTaxonomy('filter_2')
+      // All option as first entry
+      var allOption = document.createElement('option')
+      allOption.value = ''
+      allOption.innerText = 'All'
+      // Get ID's of filter 1
+      selectFilter2.appendChild(allOption)
+      filter2s.forEach(type=>{
+        let option = document.createElement('option')
+        option.value = type.id
+        option.innerText = type.name
+        selectFilter2.appendChild(option)
+      })
   
       formItemFilter2Container.appendChild(formItemFilter2Label)
       formItemFilter2Container.appendChild(selectFilter2)
@@ -774,7 +802,7 @@ class PeopleListElement extends HTMLElement {
       formDiv.appendChild(formItemFilter2Container)
     }
     // Create Filter 3
-    if(this.getAttribute('allowUserFilter3')==='True'){
+    if(config.filters.filter_3.userAccessible){
       var formItemFilter3Container = document.createElement('div')
       formItemFilter3Container.classList = 'form-item-filter-three form-item'
   
@@ -785,20 +813,34 @@ class PeopleListElement extends HTMLElement {
       var selectFilter3 = document.createElement('select')
       selectFilter3.id = 'edit-filter-three'
       // Create options programmatically - TO DO
-      var option13 = document.createElement('option')
-      var option14 = document.createElement('option')
-      var option15 = document.createElement('option')
+      // var option13 = document.createElement('option')
+      // var option14 = document.createElement('option')
+      // var option15 = document.createElement('option')
       
-      option13.value = '0'
-      option13.innerText = 'Example'
-      option14.value = '1'
-      option14.innerText = 'Example 2'
-      option15.value = '3'
-      option15.innerText = 'Example 3'
+      // option13.value = '0'
+      // option13.innerText = 'Example'
+      // option14.value = '1'
+      // option14.innerText = 'Example 2'
+      // option15.value = '3'
+      // option15.innerText = 'Example 3'
   
-      selectFilter3.appendChild(option13)
-      selectFilter3.appendChild(option14)
-      selectFilter3.appendChild(option15)
+      // selectFilter3.appendChild(option13)
+      // selectFilter3.appendChild(option14)
+      // selectFilter3.appendChild(option15)
+
+      const filter3s = await this.getTaxonomy('filter_3')
+      // All option as first entry
+      var allOption = document.createElement('option')
+      allOption.value = ''
+      allOption.innerText = 'All'
+      // Get ID's of filter 3
+      selectFilter3.appendChild(allOption)
+      filter3s.forEach(type=>{
+        let option = document.createElement('option')
+        option.value = type.id
+        option.innerText = type.name
+        selectFilter3.appendChild(option)
+      })
   
       formItemFilter3Container.appendChild(formItemFilter3Label)
       formItemFilter3Container.appendChild(selectFilter3)

--- a/js/ucb-people-list.js
+++ b/js/ucb-people-list.js
@@ -605,12 +605,13 @@ class PeopleListElement extends HTMLElement {
 					defaultOption.innerText = 'All'
 					selectFilter.appendChild(defaultOption)
 				}else {
-					defaultOption.value = JSON.stringify([{id: filters[key]['includes'], name: "",fieldName:key}])
+					defaultOption.value = JSON.stringify([{id: "", name: "",fieldName:key}])
 					defaultOption.innerText = 'Default'
 					selectFilter.appendChild(defaultOption)
 					if(!filters[key]['restrict']){
 						var allOptions = document.createElement('option')
 						allOptions.innerText = 'All'
+						// TO DO - fix
 						allOptions.value = JSON.stringify([{id:"", name: "",fieldName:key}])
 						selectFilter.appendChild(allOptions)
 					}

--- a/js/ucb-people-list.js
+++ b/js/ucb-people-list.js
@@ -105,7 +105,7 @@ class PeopleListElement extends HTMLElement {
 			if(filters[filterName]['userAccessible'] && !syncTaxonomies.has(filterName))
 				asyncTaxonomies.add(filterName);
 		}
-    this.generateForm();
+    this.generateForm(config);
 		this._loadedTaxonomies = {};
 		this._syncTaxonomiesLoaded = 0;
 		this.loadSyncTaxonomies();
@@ -535,13 +535,10 @@ class PeopleListElement extends HTMLElement {
  * TO DO -
  * 
  * - Add functionality to re-filter list after user input
- * - Assign Filter 1,2,3 names
- * - Programatically assign options - (value and innerText)
  *
  */
-  async generateForm(){
+  async generateForm(config){
     if(this._userFormElement.children.length == 0){
-      var config = JSON.parse(this.getAttribute('config'))
       // Create Elements
       var form = document.createElement('form')
       form.id = 'user-filter'
@@ -551,20 +548,9 @@ class PeopleListElement extends HTMLElement {
         var dataObj = {}
         // Create a dataObject with ids for second render
         for (var p of formData) {
-          dataObj[p[0]] = p[1]
-        }
-        var deptObj = JSON.parse(dataObj.editDepartment)
-        var typeObj = JSON.parse(dataObj.editJobType)
-        var filter1Obj = JSON.parse(dataObj.editFilterOne)
-        var filter2Obj = JSON.parse(dataObj.editFilterTwo)
-        var filter3Obj = JSON.parse(dataObj.editFilterThree)
-        
-        console.log('=====================')
-        console.log('dropdown dept', deptObj)
-        console.log('dropdown type', typeObj)
-        console.log('filter 1 obj', filter1Obj)
-        console.log('filter 2 obj', filter2Obj)
-        console.log('filter 3 obj', filter3Obj)
+          dataObj[p[0]] = JSON.parse(p[1])
+        } 
+        console.log("results", dataObj)
 
          // TO DO -- fix build
         // this.build(deptObj, typeObj)
@@ -578,7 +564,7 @@ class PeopleListElement extends HTMLElement {
       // Departments, create filterable dropdown of Departments
       if(config.filters.department.userAccessible){
         var formItemDeptContainer = document.createElement('div')
-        formItemDeptContainer.classList = 'form-item-department form-item'
+        formItemDeptContainer.classList = 'form-item-department form-item taxonomy-select-department'
     
         var formItemDeptLabel = document.createElement('label')
         formItemDeptLabel.htmlFor = "Edit Departments"
@@ -587,7 +573,7 @@ class PeopleListElement extends HTMLElement {
         var selectDept = document.createElement('select')
         selectDept.name = 'editDepartment'
         selectDept.id = 'edit-department'
-        selectDept.className = "taxonomy-select-department"
+        selectDept.className = "taxonomy-select"
         // All option as first entry
         var allOption = document.createElement('option')
         allOption.value = JSON.stringify([{id:"", name: "",fieldName:''}])
@@ -602,7 +588,7 @@ class PeopleListElement extends HTMLElement {
       // Create filterable dropdown of Job Types
       if(config.filters.job_type.userAccessible){
         var formItemJobTypeContainer = document.createElement('div')
-        formItemJobTypeContainer.classList = 'form-item-job-type form-item'
+        formItemJobTypeContainer.classList = 'form-item-job-type form-item taxonomy-select-job_type'
     
         var formItemJobTypeLabel = document.createElement('label')
         formItemJobTypeLabel.htmlFor = "Edit Job Types"
@@ -611,7 +597,7 @@ class PeopleListElement extends HTMLElement {
         var selectJobType = document.createElement('select')
         selectJobType.name = 'editJobType'
         selectJobType.id = 'edit-job-types'
-        selectJobType.className = "taxonomy-select-job_type"
+        selectJobType.className = "taxonomy-select"
   
         // All option as first entry
         var allOption = document.createElement('option')
@@ -627,7 +613,7 @@ class PeopleListElement extends HTMLElement {
       // Create Filter 1
       if(config.filters.filter_1.userAccessible){
         var formItemFilter1Container = document.createElement('div')
-        formItemFilter1Container.classList = 'form-item-filter-one form-item'
+        formItemFilter1Container.classList = 'form-item-filter-one form-item taxonomy-select-filter_1'
     
         var formItemFilter1Label = document.createElement('label')
         formItemFilter1Label.htmlFor = "Edit Filer 1"
@@ -636,7 +622,7 @@ class PeopleListElement extends HTMLElement {
         var selectFilter1 = document.createElement('select')
         selectFilter1.name = 'editFilterOne'
         selectFilter1.id = 'edit-filter-one'
-        selectFilter1.className = "taxonomy-select-filter_1"
+        selectFilter1.className = "taxonomy-select"
   
         // All option as first entry
         var allOption = document.createElement('option')
@@ -651,7 +637,7 @@ class PeopleListElement extends HTMLElement {
       // Create Filter 2
       if(config.filters.filter_2.userAccessible){
         var formItemFilter2Container = document.createElement('div')
-        formItemFilter2Container.classList = 'form-item-filter-two form-item'
+        formItemFilter2Container.classList = 'form-item-filter-two form-item taxonomy-select-filter_2'
     
         var formItemFilter2Label = document.createElement('label')
         formItemFilter2Label.htmlFor = "Edit Filter 2"
@@ -660,7 +646,7 @@ class PeopleListElement extends HTMLElement {
         var selectFilter2 = document.createElement('select')
         selectFilter2.name = 'editFilterTwo'
         selectFilter2.id = 'edit-filter-two'
-        selectFilter2.className = "taxonomy-select-filter_2"
+        selectFilter2.className = "taxonomy-select"
         // All option as first entry
         var allOption = document.createElement('option')
         allOption.value = JSON.stringify([{id:'', name: '',fieldName:''}])
@@ -674,7 +660,7 @@ class PeopleListElement extends HTMLElement {
       // Create Filter 3
       if(config.filters.filter_3.userAccessible){
         var formItemFilter3Container = document.createElement('div')
-        formItemFilter3Container.classList = 'form-item-filter-three form-item'
+        formItemFilter3Container.classList = 'form-item-filter-three form-item taxonomy-select-filter_3'
     
         var formItemFilter3Label = document.createElement('label')
         formItemFilter3Label.htmlFor = "Edit Filter 3"
@@ -683,7 +669,7 @@ class PeopleListElement extends HTMLElement {
         var selectFilter3 = document.createElement('select')
         selectFilter3.name = 'editFilterThree'
         selectFilter3.id = 'edit-filter-three'
-        selectFilter3.className = "taxonomy-select-filter_3"
+        selectFilter3.className = "taxonomy-select"
         // All option as first entry
         var allOption = document.createElement('option')
         allOption.value = JSON.stringify([{id:'', name: '', fieldName:''}])
@@ -711,13 +697,15 @@ class PeopleListElement extends HTMLElement {
   }
 
   generateDropdown(taxonomy, selectContainerElements){
-    taxonomy.forEach(taxonomy=>{
-          let option = document.createElement('option')
-          option.value = JSON.stringify([{id:taxonomy.id, name: taxonomy.name, fieldName: taxonomy.fieldName}])
-          option.innerText = taxonomy.name
-          selectContainerElements.appendChild(option)
-    })
-
+    if(selectContainerElements.getElementsByClassName('taxonomy-select')[0]){
+      let selectEl = selectContainerElements.getElementsByClassName('taxonomy-select')[0]
+      taxonomy.forEach(taxonomy=>{
+            let option = document.createElement('option')
+            option.value = JSON.stringify([{id:taxonomy.id, name: taxonomy.name, fieldName: taxonomy.fieldName}])
+            option.innerText = taxonomy.name
+            selectEl.appendChild(option)
+      })
+    }
   }
 }
 

--- a/js/ucb-people-list.js
+++ b/js/ucb-people-list.js
@@ -552,19 +552,19 @@ class PeopleListElement extends HTMLElement {
               restrict: config.filters.department.restrict
             },
             filter_1:{
-                includes: [dataObj.filter_1[0].id],
+                includes: dataObj.filter_1 ? [dataObj.filter_1[0].id] : [""],
                 userAccessible: config.filters.filter_1.userAccessible,
                 label: config.filters.filter_1.label,
                 restrict: config.filters.filter_1.restrict
             },
             filter_2:{
-                includes: [dataObj.filter_2[0].id],
+                includes: dataObj.filter_2 ? [dataObj.filter_2[0].id] : [""],
                 userAccessible: config.filters.filter_2.userAccessible,
                 label: config.filters.filter_2.label,
                 restrict: config.filters.filter_2.restrict
             },
             filter_3:{
-                includes: [dataObj.filter_3[0].id],
+                includes: dataObj.filter_3 ? [dataObj.filter_3[0].id] : [""],
                 userAccessible: config.filters.filter_3.userAccessible,
                 label: config.filters.filter_3.label,
                 restrict: config.filters.filter_3.restrict

--- a/js/ucb-people-list.js
+++ b/js/ucb-people-list.js
@@ -114,10 +114,10 @@ class PeopleListElement extends HTMLElement {
 						// console.log("Group by Dept : " + thisDeptName.name)
 						if(ORDERBY == "type") {
 							firstPassCount = 0; 
-							this.displayPeople(FORMAT, GROUPBY, Departments[key].id, "firstpass", ourPeople, Departments);
-							this.displayPeople(FORMAT, GROUPBY, Departments[key].id, "secondpass", ourPeople, Departments);
+							this.displayPeople(FORMAT, GROUPBY, Departments[key].id, "firstpass", ourPeople, Departments, JobTypes);
+							this.displayPeople(FORMAT, GROUPBY, Departments[key].id, "secondpass", ourPeople, Departments, JobTypes);
 						} else {
-							this.displayPeople(FORMAT, GROUPBY, Departments[key].id, "", ourPeople, Departments);
+							this.displayPeople(FORMAT, GROUPBY, Departments[key].id, "", ourPeople, Departments, JobTypes);
 						}
 					}
 				} else if (GROUPBY == 'type') {
@@ -128,24 +128,24 @@ class PeopleListElement extends HTMLElement {
 						// console.log("Group by Name : " + thisTypeName.name)
 						if(ORDERBY == "type") {
 							firstPassCount = 0; 
-							this.displayPeople(FORMAT, GROUPBY, JobTypes[key].id, "firstpass", ourPeople, Departments);
-							this.displayPeople(FORMAT, GROUPBY, JobTypes[key].id, "secondpass", ourPeople, Departments);
+							this.displayPeople(FORMAT, GROUPBY, JobTypes[key].id, "firstpass", ourPeople, Departments, JobTypes);
+							this.displayPeople(FORMAT, GROUPBY, JobTypes[key].id, "secondpass", ourPeople, Departments, JobTypes);
 						} else {
-							this.displayPeople(FORMAT, GROUPBY, JobTypes[key].id, "", ourPeople, Departments);
+							this.displayPeople(FORMAT, GROUPBY, JobTypes[key].id, "", ourPeople, Departments, JobTypes);
 						}
 					}
 				} else {
 					if(ORDERBY == "type") {
 						firstPassCount = 0; 
-						this.displayPeople(FORMAT, "", "", "firstpass", ourPeople, Departments);
-						this.displayPeople(FORMAT, "", "", "secondpass", ourPeople, Departments);
+						this.displayPeople(FORMAT, "", "", "firstpass", ourPeople, Departments, JobTypes);
+						this.displayPeople(FORMAT, "", "", "secondpass", ourPeople, Departments, JobTypes);
 					} else {
-						this.displayPeople(FORMAT, "", "", "", ourPeople, Departments);
+						this.displayPeople(FORMAT, "", "", "", ourPeople, Departments, JobTypes);
 					}
 				}
 			}
 			this.toggleMessage('ucb-loading-data');
-		})/*.catch(reason => this.fatalError(reason)*/;
+		}).catch(reason => this.fatalError(reason));
 	}
 
 	// Getter function for Departments and Job Types
@@ -167,9 +167,10 @@ class PeopleListElement extends HTMLElement {
 	fatalError(reason) {
 		this.toggleMessage('ucb-error', 'block');
 		this.toggleMessage('ucb-loading-data');
+		throw reason;
 	}
 
-  displayPeople(DISPLAYFORMAT, GROUPBY, groupID, ORDERBY, ourPeople, Departments) {
+  displayPeople(DISPLAYFORMAT, GROUPBY, groupID, ORDERBY, ourPeople, Departments, JobTypes) {
     let renderThisGroup = 0; 
     let el = this
     let thisDeptName = ""
@@ -300,7 +301,7 @@ class PeopleListElement extends HTMLElement {
   
           let thisCard
           // Needed to switch types of container for individual person cards => article for grid & list displays, tr for table display
-          if (DISPLAYFORMAT === 'Table') {
+          if (DISPLAYFORMAT === 'table') {
             thisCard = document.createElement('tr')
           } else {
             thisCard = document.createElement('article')

--- a/js/ucb-people-list.js
+++ b/js/ucb-people-list.js
@@ -616,6 +616,19 @@ class PeopleListElement extends HTMLElement {
     var config = JSON.parse(this.getAttribute('config'))
     // Create Elements
     var form = document.createElement('form')
+    form.id = 'user-filter'
+    form.addEventListener('submit',(event)=> {
+      event.preventDefault()
+      var formData = new FormData(document.forms['user-filter']);
+      var dataObj = {}
+      // Create a dataObject with ids for second render
+      for (var p of formData) {
+        dataObj[p[0]] = p[1]
+      }
+      // TO DO --
+      // Call a function here, passing ids for each thing. 
+      // Re render page
+    })
     form.classList = 'people-list-filter'
     var formDiv = document.createElement('div')
     formDiv.classList = 'd-flex align-items-center'
@@ -631,6 +644,7 @@ class PeopleListElement extends HTMLElement {
       formItemDeptLabel.innerText = 'Departments'
   
       var selectDept = document.createElement('select')
+      selectDept.name = 'editDepartment'
       selectDept.id = 'edit-department'
       // Get departments and IDs and iterate over creating options
       const departments = await this.getTaxonomy('department')
@@ -662,6 +676,7 @@ class PeopleListElement extends HTMLElement {
       formItemJobTypeLabel.innerText = 'Job Types'
   
       var selectJobType = document.createElement('select')
+      selectJobType.name = 'editJobType'
       selectJobType.id = 'edit-job-types'
 
       const jobTypes = await this.getTaxonomy('ucb_person_job_type')
@@ -693,6 +708,7 @@ class PeopleListElement extends HTMLElement {
       formItemFilter1Label.innerText = 'Filter 1'
   
       var selectFilter1 = document.createElement('select')
+      selectFilter1.name = 'editFilterOne'
       selectFilter1.id = 'edit-filter-one'
 
 
@@ -741,6 +757,7 @@ class PeopleListElement extends HTMLElement {
       formItemFilter2Label.innerText = 'Filter 2'
   
       var selectFilter2 = document.createElement('select')
+      selectFilter2.name = 'editFilterTwo'
       selectFilter2.id = 'edit-filter-two'
       // Create options programmatically - TO DO
       // var option10 = document.createElement('option')
@@ -787,6 +804,7 @@ class PeopleListElement extends HTMLElement {
       formItemFilter3Label.innerText = 'Filter 3'
   
       var selectFilter3 = document.createElement('select')
+      selectFilter3.name = 'editFilterThree'
       selectFilter3.id = 'edit-filter-three'
       // Create options programmatically - TO DO
       // var option13 = document.createElement('option')

--- a/js/ucb-people-list.js
+++ b/js/ucb-people-list.js
@@ -29,7 +29,7 @@ class PeopleListProvider {
 			if(!filterIncludes || !filterIncludes.length) return;
 			let filterParams = '';
 			filterIncludes.forEach(filterItem => {
-				if(filterItem == '') return;
+				if(!filterItem) return;
 				filterParams += '&filter[filter-' + filterName + '-' + filterItem + '][condition][path]=field_ucb_person_' + filterName + '.meta.drupal_internal__target_id'
 					+ '&filter[filter-' + filterName + '-' + filterItem + '][condition][value]=' + filterItem
 					+ '&filter[filter-' + filterName + '-' + filterItem + '][condition][memberOf]=' + filterName + '-include';
@@ -106,6 +106,7 @@ class PeopleListElement extends HTMLElement {
 		let formRenderBool = false; // running check
 		for(const filterName in filters) { // If user filter dropdowns are necessary, they can be generated async
 			const filter = filters[filterName];
+			filter['includes'] = filter['includes'].filter(include => !!include);
 			if(filter['userAccessible']) {
 				userAccessibleFilters[filterName] = filter;
 				if(!syncTaxonomies.has(filterName))

--- a/js/ucb-people-list.js
+++ b/js/ucb-people-list.js
@@ -600,8 +600,8 @@ class PeopleListElement extends HTMLElement {
         // All option as first entry
         var allOption = document.createElement('option')
         allOption.value = JSON.stringify([{id:"", name: "",fieldName:''}])
-		// If restricted, set to Default instead of All
-		if(filters.department.restrict){
+		// If restricted, and has filters set to Default instead of All
+		if(filters.department.restrict && filters.department.includes.length > 0){
 			allOption.innerText = 'Default'
 		} else {
 			allOption.innerText = 'All'
@@ -631,7 +631,7 @@ class PeopleListElement extends HTMLElement {
         var allOption = document.createElement('option')
         allOption.value = JSON.stringify([{id:'', name: "",fieldName:''}])
         	// If restricted, set to Default instead of All
-		if(filters.job_type.restrict){
+		if(filters.job_type.restrict && filters.job_type.includes.length >0){
 			allOption.innerText = 'Default'
 		} else {
 			allOption.innerText = 'All'
@@ -661,7 +661,7 @@ class PeopleListElement extends HTMLElement {
         var allOption = document.createElement('option')
         allOption.value = JSON.stringify([{id:'', name: '',fieldName:''}])
         // If restricted, set to Default instead of All
-		if(filters.filter_1.restrict){
+		if(filters.filter_1.restrict && filters.filter_1.includes.length > 0){
 			allOption.innerText = 'Default'
 		} else {
 			allOption.innerText = 'All'
@@ -689,7 +689,7 @@ class PeopleListElement extends HTMLElement {
         var allOption = document.createElement('option')
         allOption.value = JSON.stringify([{id:'', name: '',fieldName:''}])
         // If restricted, set to Default instead of All
-		if(filters.filter_2.restrict){
+		if(filters.filter_2.restrict && filters.filter_2.includes.length > 0){
 			allOption.innerText = 'All'
 		} else {
 			allOption.innerText = 'Default'
@@ -717,7 +717,7 @@ class PeopleListElement extends HTMLElement {
         var allOption = document.createElement('option')
         allOption.value = JSON.stringify([{id:'', name: '', fieldName:''}])
         // If restricted, set to Default instead of All
-		if(filters.filter_3.restrict){
+		if(filters.filter_3.restrict && filters.department.includes.length > 0){
 			allOption.innerText = 'Default'
 		} else {
 			allOption.innerText = 'All'
@@ -760,7 +760,7 @@ class PeopleListElement extends HTMLElement {
             }
       })
 	  // If only 2 options- default and one other option, these mean the same thing. Remove default.
-	  if(selectEl.children.length == 2 && selectEl.children[0].innerText == 'All'){
+	  if(selectEl.children.length == 2 && selectEl.children[0].innerText == 'Default'){
 		  selectEl.removeChild(selectEl.children[0])
 	  }
     }

--- a/js/ucb-people-list.js
+++ b/js/ucb-people-list.js
@@ -553,8 +553,8 @@ class PeopleListElement extends HTMLElement {
 			} 
 			var userSettings = {}
 			for(let key in dataObj){
-				if(dataObj[key][0]['id']){
-					if(dataObj[key][0]['id'] == "" && filters[key]['restrict']){
+				if(dataObj[key]){
+					if(dataObj[key][0]['id'] == "remove" || (dataObj[key][0]['id'] == "" && filters[key].restrict)){
 						delete dataObj[key]
 					} else {
 						let fieldName = dataObj[key][0]['fieldName']
@@ -567,16 +567,13 @@ class PeopleListElement extends HTMLElement {
 			
 			}
 			let finalObj = {filters: userSettings}
-			// If restricted, remove user config filters from the user filter, default to config obj
-		this.setAttribute('user-config', JSON.stringify(finalObj))
+			this.setAttribute('user-config', JSON.stringify(finalObj))
 		})
 		form.classList = 'people-list-filter'
 		var formDiv = document.createElement('div')
 		formDiv.classList = 'd-flex align-items-center'
 	
-		// If User-Filterable...
-		// Departments, create filterable dropdown of Departments
-		// Create Dropdowns
+		// If User-Filterable...Create Dropdowns
 		for(let key in filters){
 			if(filters[key].userAccessible){
 				// Create container
@@ -605,16 +602,15 @@ class PeopleListElement extends HTMLElement {
 					defaultOption.innerText = 'All'
 					selectFilter.appendChild(defaultOption)
 				}else {
-					defaultOption.value = JSON.stringify([{id: "", name: "",fieldName:key}])
-					defaultOption.innerText = 'All'
-					selectFilter.appendChild(defaultOption)
 					if(!filters[key]['restrict']){
 						var allOptions = document.createElement('option')
 						allOptions.innerText = 'Default'
-						// TO DO - fix
-						allOptions.value = JSON.stringify([{id:"", name: "",fieldName:key}])
+						allOptions.value = JSON.stringify([{id:"remove", name: "",fieldName:key}])
 						selectFilter.appendChild(allOptions)
 					}
+					defaultOption.value = JSON.stringify([{id: "", name: "",fieldName:key}])
+					defaultOption.innerText = 'All'
+					selectFilter.appendChild(defaultOption)
 				}
 				// Append
 				container.appendChild(itemLabel)

--- a/js/ucb-people-list.js
+++ b/js/ucb-people-list.js
@@ -166,6 +166,7 @@ class PeopleListElement extends HTMLElement {
 			this.loadSyncTaxonomies();
 			return;
 		}
+		this._groupBy = groupBy;
 
 		// Get our people
 		peopleListProvider.fetchPeople().then(response => {
@@ -531,14 +532,14 @@ class PeopleListElement extends HTMLElement {
 	}
 
 	generateForm(){
-		const config = this._config, filters = config['filters'], userFilters = {};
+		const config = this._config, filters = config['filters'], userAccessibleFilters = {};
 		// If no filters are visitor accessible, skip the form entirely
 		let formRenderBool = false; // running check
 		for(const filterName in filters){
 			const filter = filters[filterName];
 			if(filter['userAccessible']/* && filter['includes'].filter(include => include != '').length > 0 */) {
 				formRenderBool = true;
-				userFilters[filterName] = filter;
+				userAccessibleFilters[filterName] = filter;
 			}
 		}
 		// run generateForm method if there's atleast one vistor accessible field

--- a/js/ucb-people-list.js
+++ b/js/ucb-people-list.js
@@ -690,9 +690,9 @@ class PeopleListElement extends HTMLElement {
         allOption.value = JSON.stringify([{id:'', name: '',fieldName:''}])
         // If restricted, set to Default instead of All
 		if(filters.filter_2.restrict && filters.filter_2.includes.length > 0){
-			allOption.innerText = 'All'
-		} else {
 			allOption.innerText = 'Default'
+		} else {
+			allOption.innerText = 'All'
 		}
         // Append
         selectFilter2.appendChild(allOption)    
@@ -717,7 +717,7 @@ class PeopleListElement extends HTMLElement {
         var allOption = document.createElement('option')
         allOption.value = JSON.stringify([{id:'', name: '', fieldName:''}])
         // If restricted, set to Default instead of All
-		if(filters.filter_3.restrict && filters.department.includes.length > 0){
+		if(filters.filter_3.restrict && filters.filter_3.includes.length > 0){
 			allOption.innerText = 'Default'
 		} else {
 			allOption.innerText = 'All'
@@ -745,24 +745,32 @@ class PeopleListElement extends HTMLElement {
 	generateDropdown(taxonomy, selectContainerElements){
 		const filters = this._filters;
 		let selectEl = selectContainerElements.getElementsByClassName('taxonomy-select')[0]
-    if(selectContainerElements.getElementsByClassName('taxonomy-select')[0]){
-      taxonomy.forEach(taxonomy=>{
-            let fieldName = taxonomy.fieldName
-            let taxonomyConfig = filters[fieldName]
-            let taxonomiesIncluded = taxonomyConfig.includes[0] == "" ? taxonomyConfig.includes : taxonomyConfig.includes.map(Number)
+		if(selectContainerElements.getElementsByClassName('taxonomy-select')[0]){
+		taxonomy.forEach(taxonomy=>{
+				let fieldName = taxonomy.fieldName
+				let taxonomyConfig = filters[fieldName]
+				let taxonomiesIncluded = taxonomyConfig.includes[0] == "" ? taxonomyConfig.includes : taxonomyConfig.includes.map(Number)
 
-            // Render selection if no taxonomies were selected to filter, if restricted is on and the taxonomy is included, or if restricted = false
-            if((taxonomyConfig.includes[0] == "") || (taxonomyConfig.restrict && taxonomiesIncluded.includes(taxonomy.id)) || (taxonomyConfig.restrict && taxonomiesIncluded.length == 0) || taxonomyConfig.restrict == false){
-              let option = document.createElement('option')
-              option.value = JSON.stringify([{id:taxonomy.id, name: taxonomy.name, fieldName: taxonomy.fieldName}])
-              option.innerText = taxonomy.name
-              selectEl.appendChild(option)
-            }
-      })
-	  // If only 2 options- default and one other option, these mean the same thing. Remove default.
-	  if(selectEl.children.length == 2 && selectEl.children[0].innerText == 'Default'){
-		  selectEl.removeChild(selectEl.children[0])
-	  }
+				// Render selection if no taxonomies were selected to filter, if restricted is on and the taxonomy is included, or if restricted = false
+				if((taxonomyConfig.includes[0] == "") || (taxonomyConfig.restrict && taxonomiesIncluded.includes(taxonomy.id)) || (taxonomyConfig.restrict && taxonomiesIncluded.length == 0) || taxonomyConfig.restrict == false){
+				let option = document.createElement('option')
+				option.id = `option-${taxonomy.name}`
+				option.value = JSON.stringify([{id:taxonomy.id, name: taxonomy.name, fieldName: taxonomy.fieldName}])
+				option.innerText = taxonomy.name
+
+				if(taxonomiesIncluded.includes(taxonomy.id) && taxonomyConfig.restrict==false && taxonomiesIncluded.length == 1){
+					option.selected = true
+					selectEl.appendChild(option)
+				} else {
+					selectEl.appendChild(option)
+				}
+				}
+		})
+
+		// If only 2 options- default and one other option, these mean the same thing. Remove default.
+		if(selectEl.children.length == 2){
+			selectEl.removeChild(selectEl.children[0])
+		}
     }
   }
 }

--- a/js/ucb-people-list.js
+++ b/js/ucb-people-list.js
@@ -602,7 +602,7 @@ class PeopleListElement extends HTMLElement {
 					defaultOption.innerText = 'All'
 					selectFilter.appendChild(defaultOption)
 				}else {
-					if(!filters[key]['restrict']){
+					if(!filters[key]['restrict']&& !filters[key]['includes'].length == 1){
 						var allOptions = document.createElement('option')
 						allOptions.innerText = 'Default'
 						allOptions.value = JSON.stringify([{id:"remove", name: "",fieldName:key}])

--- a/js/ucb-people-list.js
+++ b/js/ucb-people-list.js
@@ -217,8 +217,12 @@ class PeopleListElement extends HTMLElement {
             person.relationships.field_ucb_person_job_type.data[i].meta.drupal_internal__target_id
           );
         }
-        thisPerson['PhotoID'] =
-          person.relationships.field_ucb_person_photo.data.id
+        if(!person.relationships.field_ucb_person_photo.data){
+          thisPerson['PhotoID']= ""
+        } else {
+          thisPerson['PhotoID'] =
+            person.relationships.field_ucb_person_photo.data.id
+        }
         thisPerson['PhotoURL'] = ''
         thisPerson['Email'] = person.attributes.field_ucb_person_email
         thisPerson['Phone'] = person.attributes.field_ucb_person_phone

--- a/js/ucb-people-list.js
+++ b/js/ucb-people-list.js
@@ -112,6 +112,7 @@ class PeopleListElement extends HTMLElement {
 			this._jobTypes = jobs;
 			this._taxonomiesLoaded++;
 			if(this._taxonomiesLoaded == 2) // Enter build method
+      console.log(this._departments, this._jobTypes)
 				this.build(this._departments, this._jobTypes);
 		}).catch(reason => this.fatalError(reason));
 	}
@@ -613,246 +614,264 @@ class PeopleListElement extends HTMLElement {
  *
  */
   async generateDropdown(){
-    var config = JSON.parse(this.getAttribute('config'))
-    // Create Elements
-    var form = document.createElement('form')
-    form.id = 'user-filter'
-    form.addEventListener('submit',(event)=> {
-      event.preventDefault()
-      var formData = new FormData(document.forms['user-filter']);
-      var dataObj = {}
-      // Create a dataObject with ids for second render
-      for (var p of formData) {
-        dataObj[p[0]] = p[1]
+    if(this._userFormElement.children.length == 0){
+      var config = JSON.parse(this.getAttribute('config'))
+      // Create Elements
+      var form = document.createElement('form')
+      form.id = 'user-filter'
+      form.addEventListener('submit',(event)=> {
+        event.preventDefault()
+        var formData = new FormData(document.forms['user-filter']);
+        var dataObj = {}
+        // Create a dataObject with ids for second render
+        for (var p of formData) {
+          dataObj[p[0]] = p[1]
+        }
+        var deptObj = JSON.parse(dataObj.editDepartment)
+        var typeObj = JSON.parse(dataObj.editJobType)
+        var filter1Obj = JSON.parse(dataObj.editFilterOne)
+        var filter2Obj = JSON.parse(dataObj.editFilterTwo)
+        var filter3Obj = JSON.parse(dataObj.editFilterThree)
+        
+        console.log('=====================')
+        console.log('dropdown dept', deptObj)
+        console.log('dropdown type', typeObj)
+        console.log('filter 1 obj', filter1Obj)
+        console.log('filter 2 obj', filter2Obj)
+        console.log('filter 3 obj', filter3Obj)
+  
+        renderedTable = 0;  // flag to know if we've rendered the table header or not yet
+        firstPassCount = 0;
+         // TO DO -- fix build
+        // this.build(deptObj, typeObj)
+
+      })
+      form.classList = 'people-list-filter'
+      var formDiv = document.createElement('div')
+      formDiv.classList = 'd-flex align-items-center'
+  
+      // If User-Filterable...
+      // Departments, create filterable dropdown of Departments
+      if(config.filters.department.userAccessible){
+        var formItemDeptContainer = document.createElement('div')
+        formItemDeptContainer.classList = 'form-item-department form-item'
+    
+        var formItemDeptLabel = document.createElement('label')
+        formItemDeptLabel.htmlFor = "Edit Departments"
+        formItemDeptLabel.innerText = 'Departments'
+    
+        var selectDept = document.createElement('select')
+        selectDept.name = 'editDepartment'
+        selectDept.id = 'edit-department'
+        // Get departments and IDs and iterate over creating options
+        const departments = await this.getTaxonomy('department')
+        // All option as first entry
+        var allOption = document.createElement('option')
+        allOption.value = JSON.stringify([{id:"", name: "" }])
+        allOption.innerText = 'All'
+        selectDept.appendChild(allOption)
+        departments.forEach(department=>{
+          let option = document.createElement('option')
+          option.value = JSON.stringify([{id:department.id, name: department.name}])
+          option.innerText = department.name
+          selectDept.appendChild(option)
+        })
+        // Append
+        formItemDeptContainer.appendChild(formItemDeptLabel)
+        formItemDeptContainer.appendChild(selectDept)
+    
+        formDiv.appendChild(formItemDeptContainer)
       }
-      // TO DO --
-      // Call a function here, passing ids for each thing. 
-      // Re render page
-    })
-    form.classList = 'people-list-filter'
-    var formDiv = document.createElement('div')
-    formDiv.classList = 'd-flex align-items-center'
-
-    // If User-Filterable...
-    // Departments, create filterable dropdown of Departments
-    if(config.filters.department.userAccessible){
-      var formItemDeptContainer = document.createElement('div')
-      formItemDeptContainer.classList = 'form-item-department form-item'
   
-      var formItemDeptLabel = document.createElement('label')
-      formItemDeptLabel.htmlFor = "Edit Departments"
-      formItemDeptLabel.innerText = 'Departments'
+      // Create filterable dropdown of Job Types
+      if(config.filters.job_type.userAccessible){
+        var formItemJobTypeContainer = document.createElement('div')
+        formItemJobTypeContainer.classList = 'form-item-job-type form-item'
+    
+        var formItemJobTypeLabel = document.createElement('label')
+        formItemJobTypeLabel.htmlFor = "Edit Job Types"
+        formItemJobTypeLabel.innerText = 'Job Types'
+    
+        var selectJobType = document.createElement('select')
+        selectJobType.name = 'editJobType'
+        selectJobType.id = 'edit-job-types'
   
-      var selectDept = document.createElement('select')
-      selectDept.name = 'editDepartment'
-      selectDept.id = 'edit-department'
-      // Get departments and IDs and iterate over creating options
-      const departments = await this.getTaxonomy('department')
-      // All option as first entry
-      var allOption = document.createElement('option')
-      allOption.value = ''
-      allOption.innerText = 'All'
-      selectDept.appendChild(allOption)
-      departments.forEach(department=>{
-        let option = document.createElement('option')
-        option.value = department.id
-        option.innerText = department.name
-        selectDept.appendChild(option)
-      })
-      // Append
-      formItemDeptContainer.appendChild(formItemDeptLabel)
-      formItemDeptContainer.appendChild(selectDept)
+        const jobTypes = await this.getTaxonomy('ucb_person_job_type')
+        // All option as first entry
+        var allOption = document.createElement('option')
+        allOption.value = JSON.stringify([{id:'', name: ""}])
+        allOption.innerText = 'All'
+        // Get ID's of departments
+        selectJobType.appendChild(allOption)
+        jobTypes.forEach(type=>{
+          let option = document.createElement('option')
+          option.value = JSON.stringify([{id:type.id, name: type.name}])
+          option.innerText = type.name
+          selectJobType.appendChild(option)
+        })
+    
+        formItemJobTypeContainer.appendChild(formItemJobTypeLabel)
+        formItemJobTypeContainer.appendChild(selectJobType)
+    
+        formDiv.appendChild(formItemJobTypeContainer)
+      }
+      // Create Filter 1
+      if(config.filters.filter_1.userAccessible){
+        var formItemFilter1Container = document.createElement('div')
+        formItemFilter1Container.classList = 'form-item-filter-one form-item'
+    
+        var formItemFilter1Label = document.createElement('label')
+        formItemFilter1Label.htmlFor = "Edit Filer 1"
+        formItemFilter1Label.innerText = 'Filter 1'
+    
+        var selectFilter1 = document.createElement('select')
+        selectFilter1.name = 'editFilterOne'
+        selectFilter1.id = 'edit-filter-one'
   
-      formDiv.appendChild(formItemDeptContainer)
+  
+        const filter1s = await this.getTaxonomy('filter_1')
+        // All option as first entry
+        var allOption = document.createElement('option')
+        allOption.value = JSON.stringify([{id:'', name: ''}])
+        allOption.innerText = 'All'
+        // Get ID's of filter 1
+        selectFilter1.appendChild(allOption)
+        filter1s.forEach(type=>{
+          let option = document.createElement('option')
+          option.value = JSON.stringify([{id:type.id, name: type.name}])
+          option.innerText = type.name
+          selectFilter1.appendChild(option)
+        })
+        // Create options programmatically - TO DO
+        // var option7 = document.createElement('option')
+        // var option8 = document.createElement('option')
+        // var option9 = document.createElement('option')
+        
+        // option7.value = '0'
+        // option7.innerText = 'Example'
+        // option8.value = '1'
+        // option8.innerText = 'Example 2'
+        // option9.value = '3'
+        // option9.innerText = 'Example 3'
+    
+        // selectFilter1.appendChild(option7)
+        // selectFilter1.appendChild(option8)
+        // selectFilter1.appendChild(option9)
+        
+    
+        formItemFilter1Container.appendChild(formItemFilter1Label)
+        formItemFilter1Container.appendChild(selectFilter1)
+    
+        formDiv.appendChild(formItemFilter1Container)
+      }
+      // Create Filter 2
+      if(config.filters.filter_2.userAccessible){
+        var formItemFilter2Container = document.createElement('div')
+        formItemFilter2Container.classList = 'form-item-filter-two form-item'
+    
+        var formItemFilter2Label = document.createElement('label')
+        formItemFilter2Label.htmlFor = "Edit Filter 2"
+        formItemFilter2Label.innerText = 'Filter 2'
+    
+        var selectFilter2 = document.createElement('select')
+        selectFilter2.name = 'editFilterTwo'
+        selectFilter2.id = 'edit-filter-two'
+        // Create options programmatically - TO DO
+        // var option10 = document.createElement('option')
+        // var option11 = document.createElement('option')
+        // var option12 = document.createElement('option')
+        
+        // option10.value = '0'
+        // option10.innerText = 'Example'
+        // option11.value = '1'
+        // option11.innerText = 'Example 2'
+        // option12.value = '3'
+        // option12.innerText = 'Example 3'
+    
+        // selectFilter2.appendChild(option10)
+        // selectFilter2.appendChild(option11)
+        // selectFilter2.appendChild(option12)
+  
+        const filter2s = await this.getTaxonomy('filter_2')
+        // All option as first entry
+        var allOption = document.createElement('option')
+        allOption.value = JSON.stringify([{id:'', name: ''}])
+        allOption.innerText = 'All'
+        // Get ID's of filter 1
+        selectFilter2.appendChild(allOption)
+        filter2s.forEach(type=>{
+          let option = document.createElement('option')
+          option.value = JSON.stringify([{id:type.id, name: type.name}])
+          option.innerText = type.name
+          selectFilter2.appendChild(option)
+        })
+    
+        formItemFilter2Container.appendChild(formItemFilter2Label)
+        formItemFilter2Container.appendChild(selectFilter2)
+    
+        formDiv.appendChild(formItemFilter2Container)
+      }
+      // Create Filter 3
+      if(config.filters.filter_3.userAccessible){
+        var formItemFilter3Container = document.createElement('div')
+        formItemFilter3Container.classList = 'form-item-filter-three form-item'
+    
+        var formItemFilter3Label = document.createElement('label')
+        formItemFilter3Label.htmlFor = "Edit Filter 3"
+        formItemFilter3Label.innerText = 'Filter 3'
+    
+        var selectFilter3 = document.createElement('select')
+        selectFilter3.name = 'editFilterThree'
+        selectFilter3.id = 'edit-filter-three'
+        // Create options programmatically - TO DO
+        // var option13 = document.createElement('option')
+        // var option14 = document.createElement('option')
+        // var option15 = document.createElement('option')
+        
+        // option13.value = '0'
+        // option13.innerText = 'Example'
+        // option14.value = '1'
+        // option14.innerText = 'Example 2'
+        // option15.value = '3'
+        // option15.innerText = 'Example 3'
+    
+        // selectFilter3.appendChild(option13)
+        // selectFilter3.appendChild(option14)
+        // selectFilter3.appendChild(option15)
+  
+        const filter3s = await this.getTaxonomy('filter_3')
+        // All option as first entry
+        var allOption = document.createElement('option')
+        allOption.value = JSON.stringify([{id:'', name: ''}])
+        allOption.innerText = 'All'
+        // Get ID's of filter 3
+        selectFilter3.appendChild(allOption)
+        filter3s.forEach(type=>{
+          let option = document.createElement('option')
+          option.value = JSON.stringify([{id:type.id, name: type.name}])
+          option.innerText = type.name
+          selectFilter3.appendChild(option)
+        })
+    
+        formItemFilter3Container.appendChild(formItemFilter3Label)
+        formItemFilter3Container.appendChild(selectFilter3)
+    
+        formDiv.appendChild(formItemFilter3Container)
+      }
+      // Create Filter button after filters are rendered
+      var formButtonContainer = document.createElement('div')
+      formButtonContainer.classList = 'form-item-button form-item'
+  
+      var formButton = document.createElement('input')
+      formButton.classList = 'form-submit-btn'
+      formButton.type = 'submit'
+      formButtonContainer.appendChild(formButton)
+      formDiv.appendChild(formButtonContainer)
+      form.appendChild(formDiv)
+      // Append final container
+      this._userFormElement.appendChild(form);
     }
-
-    // Create filterable dropdown of Job Types
-    if(config.filters.job_type.userAccessible){
-      var formItemJobTypeContainer = document.createElement('div')
-      formItemJobTypeContainer.classList = 'form-item-job-type form-item'
-  
-      var formItemJobTypeLabel = document.createElement('label')
-      formItemJobTypeLabel.htmlFor = "Edit Job Types"
-      formItemJobTypeLabel.innerText = 'Job Types'
-  
-      var selectJobType = document.createElement('select')
-      selectJobType.name = 'editJobType'
-      selectJobType.id = 'edit-job-types'
-
-      const jobTypes = await this.getTaxonomy('ucb_person_job_type')
-      // All option as first entry
-      var allOption = document.createElement('option')
-      allOption.value = ''
-      allOption.innerText = 'All'
-      // Get ID's of departments
-      selectJobType.appendChild(allOption)
-      jobTypes.forEach(type=>{
-        let option = document.createElement('option')
-        option.value = type.id
-        option.innerText = type.name
-        selectJobType.appendChild(option)
-      })
-  
-      formItemJobTypeContainer.appendChild(formItemJobTypeLabel)
-      formItemJobTypeContainer.appendChild(selectJobType)
-  
-      formDiv.appendChild(formItemJobTypeContainer)
-    }
-    // Create Filter 1
-    if(config.filters.filter_1.userAccessible){
-      var formItemFilter1Container = document.createElement('div')
-      formItemFilter1Container.classList = 'form-item-filter-one form-item'
-  
-      var formItemFilter1Label = document.createElement('label')
-      formItemFilter1Label.htmlFor = "Edit Filer 1"
-      formItemFilter1Label.innerText = 'Filter 1'
-  
-      var selectFilter1 = document.createElement('select')
-      selectFilter1.name = 'editFilterOne'
-      selectFilter1.id = 'edit-filter-one'
-
-
-      const filter1s = await this.getTaxonomy('filter_1')
-      // All option as first entry
-      var allOption = document.createElement('option')
-      allOption.value = ''
-      allOption.innerText = 'All'
-      // Get ID's of filter 1
-      selectFilter1.appendChild(allOption)
-      filter1s.forEach(type=>{
-        let option = document.createElement('option')
-        option.value = type.id
-        option.innerText = type.name
-        selectFilter1.appendChild(option)
-      })
-      // Create options programmatically - TO DO
-      // var option7 = document.createElement('option')
-      // var option8 = document.createElement('option')
-      // var option9 = document.createElement('option')
-      
-      // option7.value = '0'
-      // option7.innerText = 'Example'
-      // option8.value = '1'
-      // option8.innerText = 'Example 2'
-      // option9.value = '3'
-      // option9.innerText = 'Example 3'
-  
-      // selectFilter1.appendChild(option7)
-      // selectFilter1.appendChild(option8)
-      // selectFilter1.appendChild(option9)
-      
-  
-      formItemFilter1Container.appendChild(formItemFilter1Label)
-      formItemFilter1Container.appendChild(selectFilter1)
-  
-      formDiv.appendChild(formItemFilter1Container)
-    }
-    // Create Filter 2
-    if(config.filters.filter_2.userAccessible){
-      var formItemFilter2Container = document.createElement('div')
-      formItemFilter2Container.classList = 'form-item-filter-two form-item'
-  
-      var formItemFilter2Label = document.createElement('label')
-      formItemFilter2Label.htmlFor = "Edit Filter 2"
-      formItemFilter2Label.innerText = 'Filter 2'
-  
-      var selectFilter2 = document.createElement('select')
-      selectFilter2.name = 'editFilterTwo'
-      selectFilter2.id = 'edit-filter-two'
-      // Create options programmatically - TO DO
-      // var option10 = document.createElement('option')
-      // var option11 = document.createElement('option')
-      // var option12 = document.createElement('option')
-      
-      // option10.value = '0'
-      // option10.innerText = 'Example'
-      // option11.value = '1'
-      // option11.innerText = 'Example 2'
-      // option12.value = '3'
-      // option12.innerText = 'Example 3'
-  
-      // selectFilter2.appendChild(option10)
-      // selectFilter2.appendChild(option11)
-      // selectFilter2.appendChild(option12)
-
-      const filter2s = await this.getTaxonomy('filter_2')
-      // All option as first entry
-      var allOption = document.createElement('option')
-      allOption.value = ''
-      allOption.innerText = 'All'
-      // Get ID's of filter 1
-      selectFilter2.appendChild(allOption)
-      filter2s.forEach(type=>{
-        let option = document.createElement('option')
-        option.value = type.id
-        option.innerText = type.name
-        selectFilter2.appendChild(option)
-      })
-  
-      formItemFilter2Container.appendChild(formItemFilter2Label)
-      formItemFilter2Container.appendChild(selectFilter2)
-  
-      formDiv.appendChild(formItemFilter2Container)
-    }
-    // Create Filter 3
-    if(config.filters.filter_3.userAccessible){
-      var formItemFilter3Container = document.createElement('div')
-      formItemFilter3Container.classList = 'form-item-filter-three form-item'
-  
-      var formItemFilter3Label = document.createElement('label')
-      formItemFilter3Label.htmlFor = "Edit Filter 3"
-      formItemFilter3Label.innerText = 'Filter 3'
-  
-      var selectFilter3 = document.createElement('select')
-      selectFilter3.name = 'editFilterThree'
-      selectFilter3.id = 'edit-filter-three'
-      // Create options programmatically - TO DO
-      // var option13 = document.createElement('option')
-      // var option14 = document.createElement('option')
-      // var option15 = document.createElement('option')
-      
-      // option13.value = '0'
-      // option13.innerText = 'Example'
-      // option14.value = '1'
-      // option14.innerText = 'Example 2'
-      // option15.value = '3'
-      // option15.innerText = 'Example 3'
-  
-      // selectFilter3.appendChild(option13)
-      // selectFilter3.appendChild(option14)
-      // selectFilter3.appendChild(option15)
-
-      const filter3s = await this.getTaxonomy('filter_3')
-      // All option as first entry
-      var allOption = document.createElement('option')
-      allOption.value = ''
-      allOption.innerText = 'All'
-      // Get ID's of filter 3
-      selectFilter3.appendChild(allOption)
-      filter3s.forEach(type=>{
-        let option = document.createElement('option')
-        option.value = type.id
-        option.innerText = type.name
-        selectFilter3.appendChild(option)
-      })
-  
-      formItemFilter3Container.appendChild(formItemFilter3Label)
-      formItemFilter3Container.appendChild(selectFilter3)
-  
-      formDiv.appendChild(formItemFilter3Container)
-    }
-    // Create Filter button after filters are rendered
-    var formButtonContainer = document.createElement('div')
-    formButtonContainer.classList = 'form-item-button form-item'
-
-    var formButton = document.createElement('input')
-    formButton.classList = 'form-submit-btn'
-    formButton.type = 'submit'
-    formButtonContainer.appendChild(formButton)
-    formDiv.appendChild(formButtonContainer)
-    form.appendChild(formDiv)
-    // Append final container
-    this._userFormElement.appendChild(form);
+   
   }
 }
 

--- a/js/ucb-people-list.js
+++ b/js/ucb-people-list.js
@@ -92,7 +92,6 @@ class PeopleListElement extends HTMLElement {
 		chromeElement.appendChild(loadingElement);
 		this.appendChild(chromeElement);
 		this.appendChild(contentElement);
-		// this.generateDropdown();
 		const taxonomyIds = this._taxonomyIds = config['taxonomies'], 
 			filters = this._filters = config['filters'] || {},
 			groupBy = this._groupBy = config['groupby'] || 'none',
@@ -106,6 +105,7 @@ class PeopleListElement extends HTMLElement {
 			if(filters[filterName]['userAccessible'] && !syncTaxonomies.has(filterName))
 				asyncTaxonomies.add(filterName);
 		}
+    this.generateForm();
 		this._loadedTaxonomies = {};
 		this._syncTaxonomiesLoaded = 0;
 		this.loadSyncTaxonomies();
@@ -235,7 +235,8 @@ class PeopleListElement extends HTMLElement {
 			showContainerElements[index].removeAttribute('hidden');
 		for(let index = 0; index < hideContainerElements.length; index++)
 			showContainerElements[index].setAttribute('hidden', '');
-		// for(let index = 0; index < selectContainerElements.length; index++)
+		for(let index = 0; index < selectContainerElements.length; index++)
+      this.generateDropdown(taxonomy, selectContainerElements[0])
 			// TODO: Construct dropdowns in form
 		for(let index = 0; index < taxonomyElements.length; index++) {
 			const taxonomyElement = taxonomyElements[index];
@@ -538,7 +539,7 @@ class PeopleListElement extends HTMLElement {
  * - Programatically assign options - (value and innerText)
  *
  */
-  async generateDropdown(){
+  async generateForm(){
     if(this._userFormElement.children.length == 0){
       var config = JSON.parse(this.getAttribute('config'))
       // Create Elements
@@ -564,9 +565,7 @@ class PeopleListElement extends HTMLElement {
         console.log('filter 1 obj', filter1Obj)
         console.log('filter 2 obj', filter2Obj)
         console.log('filter 3 obj', filter3Obj)
-  
-        renderedTable = 0;  // flag to know if we've rendered the table header or not yet
-        firstPassCount = 0;
+
          // TO DO -- fix build
         // this.build(deptObj, typeObj)
 
@@ -588,23 +587,15 @@ class PeopleListElement extends HTMLElement {
         var selectDept = document.createElement('select')
         selectDept.name = 'editDepartment'
         selectDept.id = 'edit-department'
-        // Get departments and IDs and iterate over creating options
-        const departments = await this.getTaxonomy('department')
+        selectDept.className = "taxonomy-select-department"
         // All option as first entry
         var allOption = document.createElement('option')
-        allOption.value = JSON.stringify([{id:"", name: "" }])
+        allOption.value = JSON.stringify([{id:"", name: "",fieldName:''}])
         allOption.innerText = 'All'
         selectDept.appendChild(allOption)
-        departments.forEach(department=>{
-          let option = document.createElement('option')
-          option.value = JSON.stringify([{id:department.id, name: department.name}])
-          option.innerText = department.name
-          selectDept.appendChild(option)
-        })
         // Append
         formItemDeptContainer.appendChild(formItemDeptLabel)
         formItemDeptContainer.appendChild(selectDept)
-    
         formDiv.appendChild(formItemDeptContainer)
       }
   
@@ -620,21 +611,14 @@ class PeopleListElement extends HTMLElement {
         var selectJobType = document.createElement('select')
         selectJobType.name = 'editJobType'
         selectJobType.id = 'edit-job-types'
+        selectJobType.className = "taxonomy-select-job_type"
   
-        const jobTypes = await this.getTaxonomy('ucb_person_job_type')
         // All option as first entry
         var allOption = document.createElement('option')
-        allOption.value = JSON.stringify([{id:'', name: ""}])
+        allOption.value = JSON.stringify([{id:'', name: "",fieldName:''}])
         allOption.innerText = 'All'
-        // Get ID's of departments
-        selectJobType.appendChild(allOption)
-        jobTypes.forEach(type=>{
-          let option = document.createElement('option')
-          option.value = JSON.stringify([{id:type.id, name: type.name}])
-          option.innerText = type.name
-          selectJobType.appendChild(option)
-        })
-    
+        // Append
+        selectJobType.appendChild(allOption)    
         formItemJobTypeContainer.appendChild(formItemJobTypeLabel)
         formItemJobTypeContainer.appendChild(selectJobType)
     
@@ -652,41 +636,16 @@ class PeopleListElement extends HTMLElement {
         var selectFilter1 = document.createElement('select')
         selectFilter1.name = 'editFilterOne'
         selectFilter1.id = 'edit-filter-one'
+        selectFilter1.className = "taxonomy-select-filter_1"
   
-  
-        const filter1s = await this.getTaxonomy('filter_1')
         // All option as first entry
         var allOption = document.createElement('option')
-        allOption.value = JSON.stringify([{id:'', name: ''}])
+        allOption.value = JSON.stringify([{id:'', name: '',fieldName:''}])
         allOption.innerText = 'All'
-        // Get ID's of filter 1
+        // Append
         selectFilter1.appendChild(allOption)
-        filter1s.forEach(type=>{
-          let option = document.createElement('option')
-          option.value = JSON.stringify([{id:type.id, name: type.name}])
-          option.innerText = type.name
-          selectFilter1.appendChild(option)
-        })
-        // Create options programmatically - TO DO
-        // var option7 = document.createElement('option')
-        // var option8 = document.createElement('option')
-        // var option9 = document.createElement('option')
-        
-        // option7.value = '0'
-        // option7.innerText = 'Example'
-        // option8.value = '1'
-        // option8.innerText = 'Example 2'
-        // option9.value = '3'
-        // option9.innerText = 'Example 3'
-    
-        // selectFilter1.appendChild(option7)
-        // selectFilter1.appendChild(option8)
-        // selectFilter1.appendChild(option9)
-        
-    
         formItemFilter1Container.appendChild(formItemFilter1Label)
         formItemFilter1Container.appendChild(selectFilter1)
-    
         formDiv.appendChild(formItemFilter1Container)
       }
       // Create Filter 2
@@ -701,39 +660,15 @@ class PeopleListElement extends HTMLElement {
         var selectFilter2 = document.createElement('select')
         selectFilter2.name = 'editFilterTwo'
         selectFilter2.id = 'edit-filter-two'
-        // Create options programmatically - TO DO
-        // var option10 = document.createElement('option')
-        // var option11 = document.createElement('option')
-        // var option12 = document.createElement('option')
-        
-        // option10.value = '0'
-        // option10.innerText = 'Example'
-        // option11.value = '1'
-        // option11.innerText = 'Example 2'
-        // option12.value = '3'
-        // option12.innerText = 'Example 3'
-    
-        // selectFilter2.appendChild(option10)
-        // selectFilter2.appendChild(option11)
-        // selectFilter2.appendChild(option12)
-  
-        const filter2s = await this.getTaxonomy('filter_2')
+        selectFilter2.className = "taxonomy-select-filter_2"
         // All option as first entry
         var allOption = document.createElement('option')
-        allOption.value = JSON.stringify([{id:'', name: ''}])
+        allOption.value = JSON.stringify([{id:'', name: '',fieldName:''}])
         allOption.innerText = 'All'
-        // Get ID's of filter 1
-        selectFilter2.appendChild(allOption)
-        filter2s.forEach(type=>{
-          let option = document.createElement('option')
-          option.value = JSON.stringify([{id:type.id, name: type.name}])
-          option.innerText = type.name
-          selectFilter2.appendChild(option)
-        })
-    
+        // Append
+        selectFilter2.appendChild(allOption)    
         formItemFilter2Container.appendChild(formItemFilter2Label)
         formItemFilter2Container.appendChild(selectFilter2)
-    
         formDiv.appendChild(formItemFilter2Container)
       }
       // Create Filter 3
@@ -748,39 +683,15 @@ class PeopleListElement extends HTMLElement {
         var selectFilter3 = document.createElement('select')
         selectFilter3.name = 'editFilterThree'
         selectFilter3.id = 'edit-filter-three'
-        // Create options programmatically - TO DO
-        // var option13 = document.createElement('option')
-        // var option14 = document.createElement('option')
-        // var option15 = document.createElement('option')
-        
-        // option13.value = '0'
-        // option13.innerText = 'Example'
-        // option14.value = '1'
-        // option14.innerText = 'Example 2'
-        // option15.value = '3'
-        // option15.innerText = 'Example 3'
-    
-        // selectFilter3.appendChild(option13)
-        // selectFilter3.appendChild(option14)
-        // selectFilter3.appendChild(option15)
-  
-        const filter3s = await this.getTaxonomy('filter_3')
+        selectFilter3.className = "taxonomy-select-filter_3"
         // All option as first entry
         var allOption = document.createElement('option')
-        allOption.value = JSON.stringify([{id:'', name: ''}])
+        allOption.value = JSON.stringify([{id:'', name: '', fieldName:''}])
         allOption.innerText = 'All'
-        // Get ID's of filter 3
-        selectFilter3.appendChild(allOption)
-        filter3s.forEach(type=>{
-          let option = document.createElement('option')
-          option.value = JSON.stringify([{id:type.id, name: type.name}])
-          option.innerText = type.name
-          selectFilter3.appendChild(option)
-        })
-    
+        // Append
+        selectFilter3.appendChild(allOption)    
         formItemFilter3Container.appendChild(formItemFilter3Label)
         formItemFilter3Container.appendChild(selectFilter3)
-    
         formDiv.appendChild(formItemFilter3Container)
       }
       // Create Filter button after filters are rendered
@@ -797,6 +708,16 @@ class PeopleListElement extends HTMLElement {
       this._userFormElement.appendChild(form);
     }
    
+  }
+
+  generateDropdown(taxonomy, selectContainerElements){
+    taxonomy.forEach(taxonomy=>{
+          let option = document.createElement('option')
+          option.value = JSON.stringify([{id:taxonomy.id, name: taxonomy.name, fieldName: taxonomy.fieldName}])
+          option.innerText = taxonomy.name
+          selectContainerElements.appendChild(option)
+    })
+
   }
 }
 

--- a/js/ucb-people-list.js
+++ b/js/ucb-people-list.js
@@ -262,7 +262,7 @@ class PeopleListElement extends HTMLElement {
 		for(let index = 0; index < hideContainerElements.length; index++)
 			showContainerElements[index].setAttribute('hidden', '');
 		for(let index = 0; index < selectContainerElements.length; index++)
-			this.generateDropdown(taxonomy, selectContainerElements[index], this._config);
+			this.generateDropdown(taxonomy, taxonomyFieldName, selectContainerElements[index]);
 		for(let index = 0; index < taxonomyElements.length; index++) {
 			const taxonomyElement = taxonomyElements[index];
 			taxonomyElement.innerText = PeopleListElement.getTaxonomyName(taxonomy, parseInt(taxonomyElement.dataset['termId'])) || '';
@@ -318,7 +318,6 @@ class PeopleListElement extends HTMLElement {
 		// see if we've already rendered the table header HTML
 		if(!table) {
 			table = document.createElement('table');
-			table.id = 'ucb-pl-table';
 			table.classList = 'table table-bordered table-striped';
 			const tableHead = document.createElement('thead');
 			tableHead.classList = 'ucb-people-list-table-head';
@@ -540,129 +539,122 @@ class PeopleListElement extends HTMLElement {
 	}
 
 	generateForm(){
-		const filters = this._filters, userAccessibleFilters = this._userAccessibleFilters;
+		const userAccessibleFilters = this._userAccessibleFilters;
 		// Create Elements
-      	var form = document.createElement('form')
+      	var form = document.createElement('form');
 		form.addEventListener('submit',(event)=> {
-			event.preventDefault()
+			event.preventDefault();
 			var formData = new FormData(event.target);
-			var dataObj = {}
+			var dataObj = {};
 			// Create a dataObject with ids for second render
 			for (var p of formData) {
-				dataObj[p[0]] = JSON.parse(p[1])
+				dataObj[p[0]] = JSON.parse(p[1]);
 			} 
 			var userSettings = {}
 			for(let key in dataObj){
 				if(dataObj[key]){
-					if(dataObj[key][0]['id'] == "remove" || (dataObj[key][0]['id'] == "" && filters[key].restrict)){
-						delete dataObj[key]
+					if(dataObj[key][0]['id'] == "remove" || (dataObj[key][0]['id'] == "" && userAccessibleFilters[key]['restrict'])){
+						delete dataObj[key];
 					} else {
-						let fieldName = dataObj[key][0]['fieldName']
-						let ids = dataObj[key][0]["id"]
+						let fieldName = dataObj[key][0]['fieldName'];
+						let ids = dataObj[key][0]["id"];
 						
-						let value = {includes: [ids]}
-						userSettings[fieldName] = value
+						let value = {includes: [ids]};
+						userSettings[fieldName] = value;
 					}
 				}
 			
 			}
-			let finalObj = {filters: userSettings}
-			this.setAttribute('user-config', JSON.stringify(finalObj))
+			let finalObj = {filters: userSettings};
+			this.setAttribute('user-config', JSON.stringify(finalObj));
 		})
-		form.classList = 'people-list-filter'
-		var formDiv = document.createElement('div')
-		formDiv.classList = 'd-flex align-items-center'
+		form.classList = 'people-list-filter';
+		var formDiv = document.createElement('div');
+		formDiv.classList = 'd-flex align-items-center';
 	
 		// If User-Filterable...Create Dropdowns
-		for(let key in filters){
-			if(filters[key].userAccessible){
-				// Create container
-				var container = document.createElement('div')
-				container.classList = `form-item-${key} form-item taxonomy-select-${key}`
-				// Create label el
-				var itemLabel = document.createElement('label')
-				itemLabel.htmlFor = `Edit ${filters[key]['label']}`
-				itemLabel.innerText = filters[key]['label']
-				// Create select el
-				var selectFilter = document.createElement('select')
-				selectFilter.name = key
-				selectFilter.id = `edit-${key}`
-				selectFilter.className = "taxonomy-select"
+		for(let key in userAccessibleFilters){
+			const filter = userAccessibleFilters[key];
+			// Create container
+			var container = document.createElement('div');
+			container.className = `form-item-${key} form-item`;
+			// Create label el
+			var itemLabel = document.createElement('label');
+			itemLabel.htmlFor = `Edit ${filter['label']}`;
+			itemLabel.innerText = filter['label'];
+			// Create select el
+			var selectFilter = document.createElement('select');
+			selectFilter.name = key;
+			selectFilter.className = 'taxonomy-select-' + key + ' taxonomy-select';
 
-				// All option as first entry
-				var defaultOption = document.createElement('option')
-				defaultOption.value = JSON.stringify([{id:"", name: "",fieldName:''}])
+			// All option as first entry
+			var defaultOption = document.createElement('option');
+			defaultOption.value = JSON.stringify([{id:"", name: "",fieldName:''}]);
 
-				if(filters[key]['includes'].length == 0){
-					defaultOption.value = JSON.stringify([{id:"", name: "",fieldName:key}])
-					defaultOption.innerText = 'All'
-					selectFilter.appendChild(defaultOption)
-				} else if(filters[key]['restrict'] && filters[key]['includes'].length >=2 ){
-					defaultOption.value = JSON.stringify([{id:"", name: "",fieldName:key}])
-					defaultOption.innerText = 'All'
-					selectFilter.appendChild(defaultOption)
-				}else {
-					if(!filters[key]['restrict']&& !filters[key]['includes'].length == 1){
-						var allOptions = document.createElement('option')
-						allOptions.innerText = 'Default'
-						allOptions.value = JSON.stringify([{id:"remove", name: "",fieldName:key}])
-						selectFilter.appendChild(allOptions)
-					}
-					defaultOption.value = JSON.stringify([{id: "", name: "",fieldName:key}])
-					defaultOption.innerText = 'All'
-					selectFilter.appendChild(defaultOption)
+			if(filter['includes'].length == 0){
+				defaultOption.value = JSON.stringify([{id:"", name: "",fieldName:key}]);
+				defaultOption.innerText = 'All';
+				defaultOption.className = 'taxonomy-option-all';
+				selectFilter.appendChild(defaultOption);
+			} else if(filter['restrict'] && filter['includes'].length > 1){
+				defaultOption.value = JSON.stringify([{id:"", name: "",fieldName:key}]);
+				defaultOption.innerText = 'All';
+				defaultOption.className = 'taxonomy-option-all';
+				selectFilter.appendChild(defaultOption);
+			} else {
+				if(!filter['restrict'] && filter['includes'].length > 1){
+					var allOptions = document.createElement('option');
+					allOptions.innerText = 'Default';
+					allOptions.value = JSON.stringify([{id:"remove", name: "",fieldName:key}]);
+					allOptions.className = 'taxonomy-option-default';
+					selectFilter.appendChild(allOptions);
 				}
-				// Append
-				container.appendChild(itemLabel)
-				container.appendChild(selectFilter)
-				formDiv.appendChild(container)
+				defaultOption.value = JSON.stringify([{id: "", name: "",fieldName:key}]);
+				defaultOption.innerText = 'All';
+				defaultOption.className = 'taxonomy-option-all';
+				selectFilter.appendChild(defaultOption);
 			}
+			// Append
+			container.appendChild(itemLabel);
+			container.appendChild(selectFilter);
+			formDiv.appendChild(container);
 		}
-      // Create Filter button after filters are rendered
-      var formButtonContainer = document.createElement('div')
-      formButtonContainer.classList = 'form-item-button form-item'
-  
-      var formButton = document.createElement('input')
-      formButton.classList = 'form-submit-btn'
-      formButton.type = 'submit'
-      formButtonContainer.appendChild(formButton)
-      formDiv.appendChild(formButtonContainer)
-      form.appendChild(formDiv)
+		// Create Filter button after filters are rendered
+		var formButtonContainer = document.createElement('div');
+		formButtonContainer.classList = 'form-item-button form-item';
+	
+		var formButton = document.createElement('input');
+		formButton.classList = 'form-submit-btn';
+		formButton.type = 'submit';
+		formButtonContainer.appendChild(formButton);
+		formDiv.appendChild(formButtonContainer);
+		form.appendChild(formDiv);
 		// Append final container
 		this._userFormElement.appendChild(form);   
 	}
 
-	generateDropdown(taxonomy, selectContainerElements){
-		const filters = this._filters;
-		let selectEl = selectContainerElements.getElementsByClassName('taxonomy-select')[0]
-		if(selectContainerElements.getElementsByClassName('taxonomy-select')[0]){
-		taxonomy.forEach(taxonomy=>{
-				let fieldName = taxonomy.fieldName
-				let taxonomyConfig = filters[fieldName]
-				let taxonomiesIncluded = taxonomyConfig.includes[0] == "" ? taxonomyConfig.includes : taxonomyConfig.includes.map(Number)
-
-				// Render selection if no taxonomies were selected to filter, if restricted is on and the taxonomy is included, or if restricted = false
-				if((taxonomyConfig.includes[0] == "") || (taxonomyConfig.restrict && taxonomiesIncluded.includes(taxonomy.id)) || (taxonomyConfig.restrict && taxonomiesIncluded.length == 0) || taxonomyConfig.restrict == false){
-				let option = document.createElement('option')
-				option.id = `option-${taxonomy.name}`
-				option.value = JSON.stringify([{id:taxonomy.id, name: taxonomy.name, fieldName: taxonomy.fieldName}])
-				option.innerText = taxonomy.name
-
-				if(taxonomiesIncluded.includes(taxonomy.id) && taxonomyConfig.restrict==false && taxonomiesIncluded.length == 1){
-					option.selected = true
-					selectEl.appendChild(option)
-				} else {
-					selectEl.appendChild(option)
-				}
-				}
-		})
-
-		// If only 2 options- default and one other option, these mean the same thing. Remove default.
-		if(selectEl.children.length == 2){
-			selectEl.removeChild(selectEl.children[0])
+	generateDropdown(taxonomy, taxonomyFieldName, selectElement){
+		if(taxonomy.length === 0) return;
+		const
+			filters = this._filters,
+			taxonomyConfig = filters[taxonomyFieldName],
+			taxonomiesIncluded = taxonomyConfig['includes'].map(Number), // The data type for taxonomyTerm.id is Number, the includes may be strings
+			restrict = taxonomyConfig['restrict'] && taxonomiesIncluded.length > 0;
+		taxonomy.forEach(taxonomyTerm => {
+			if(restrict && taxonomiesIncluded.indexOf(taxonomyTerm.id) === -1) return; // Rejects a restricted option
+			const option = document.createElement('option');
+			option.value = JSON.stringify([{id: taxonomyTerm.id, name: taxonomyTerm.name, fieldName: taxonomyFieldName}]);
+			option.innerText = taxonomyTerm.name;
+			option.selected = taxonomiesIncluded.length === 1 && taxonomiesIncluded[0] == taxonomyTerm.id;
+			selectElement.appendChild(option);
+		});
+		if(!restrict && taxonomy.length > 1 && taxonomy.length === taxonomiesIncluded.length) { // Removes the "Default" option if all the taxonomy terms are included
+			const defaultOption = selectElement.querySelector('.taxonomy-option-default');
+			if(selectElement.options[selectElement.selectedIndex] == defaultOption)
+				selectElement.querySelector('.taxonomy-option-all').selected = true;
+			selectElement.removeChild(defaultOption);
 		}
-    }
-  }
+	}
 }
 
 customElements.define('ucb-people-list', PeopleListElement);

--- a/js/ucb-people-list.js
+++ b/js/ucb-people-list.js
@@ -105,7 +105,17 @@ class PeopleListElement extends HTMLElement {
 			if(filters[filterName]['userAccessible'] && !syncTaxonomies.has(filterName))
 				asyncTaxonomies.add(filterName);
 		}
-    this.generateForm(config);
+		// If no filters are visitor accessible, skip the form entirely
+		var formRenderBool = false // running check
+		for(var key in config.filters){
+			if(config.filters[key]['userAccessible'] == true){
+				formRenderBool = true
+			}
+		}
+		// call generateForm method if there's atleast one vistor accessible field
+		if (formRenderBool){
+			this.generateForm(config)
+		}
 		this._loadedTaxonomies = {};
 		this._syncTaxonomiesLoaded = 0;
 		this.loadSyncTaxonomies(config);
@@ -161,7 +171,6 @@ class PeopleListElement extends HTMLElement {
 			groupBy = 'none';
 		// User-specified grouping is working as a feature to add in the future
 		if(groupBy != this._groupBy && !this.taxonomyHasLoaded(groupBy)) {
-			this._groupBy = groupBy;
 			this._syncTaxonomies.add(groupBy);
 			this.loadSyncTaxonomies();
 			return;
@@ -531,6 +540,7 @@ class PeopleListElement extends HTMLElement {
 	}
 
   async generateForm(config){
+	// for(filter in config.)
     if(this._userFormElement.children.length == 0){
       // Create Elements
       var form = document.createElement('form')

--- a/js/ucb-people-list.js
+++ b/js/ucb-people-list.js
@@ -747,8 +747,8 @@ class PeopleListElement extends HTMLElement {
 
 	generateDropdown(taxonomy, selectContainerElements){
 		const config = this._config;
+		let selectEl = selectContainerElements.getElementsByClassName('taxonomy-select')[0]
     if(selectContainerElements.getElementsByClassName('taxonomy-select')[0]){
-      let selectEl = selectContainerElements.getElementsByClassName('taxonomy-select')[0]
       taxonomy.forEach(taxonomy=>{
             let fieldName = taxonomy.fieldName
             let taxonomyConfig = config.filters[fieldName]
@@ -762,6 +762,10 @@ class PeopleListElement extends HTMLElement {
               selectEl.appendChild(option)
             }
       })
+	  // If only 2 options- default and one other option, these mean the same thing. Remove default.
+	  if(selectEl.children.length == 2 && selectEl.children[0].innerText == 'Default'){
+		  selectEl.removeChild(selectEl.children[0])
+	  }
     }
   }
 }

--- a/js/ucb-people-list.js
+++ b/js/ucb-people-list.js
@@ -145,7 +145,7 @@ class PeopleListElement extends HTMLElement {
 				}
 			}
 			this.toggleMessage('ucb-loading-data');
-		}).catch(reason => this.fatalError(reason));
+		})/*.catch(reason => this.fatalError(reason)*/;
 	}
 
 	// Getter function for Departments and Job Types
@@ -326,7 +326,7 @@ class PeopleListElement extends HTMLElement {
             }
 
             el.appendChild(thisCard)
-          } else if (DISPLAYFORMAT === 'Grid') {
+          } else if (DISPLAYFORMAT === 'grid') {
   
             // check to see if this is the first time we're adding in a member of this group
             // if so, add the name of the group first 
@@ -390,13 +390,13 @@ class PeopleListElement extends HTMLElement {
   getParentContainer(Format) // flag to know if we've rendered the table header or not yet
    {
     // console.log("my format is", Format)
-    let container = ''
+    let container = null;
     switch (Format) {
       case 'list':
         break
       case 'grid':
-        container = this
-        container.classList = "row ucb-people-list-content"
+        container = document.createElement('div');
+        container.classList = "row ucb-people-list-content";
         break
       case 'table':
         // we only need to render the table header the first time

--- a/js/ucb-people-list.js
+++ b/js/ucb-people-list.js
@@ -1,4 +1,3 @@
-
 // /* naughty global variables!!! */
 let Departments = {} // translate table for department id => department name
 let JobTypes = {} // translate table for type id => type name
@@ -32,51 +31,57 @@ class PeopleListElement extends HTMLElement {
     var ourPeople = {} // all of the pepole that match our filter 
      // count for the first pass per group.  
 
-    this.toggleMessage('ucb-al-loading','block')
+    this.toggleMessage('ucb-loading-data','block')
 
     //Get our people
     this.getStaff(JSONAPI).then(response=>{
       ourPeople = response;
 
-      if (GROUPBY == 'department') {
-        for (const [key] of Object.entries(Departments)) {
-          // let thisDeptID = Departments[key].id
-          // let thisDeptName = getTaxonomyName(Departments, thisDeptID);
-          // console.log("Group by Dept : " + thisDeptID)
-          // console.log("Group by Dept : " + thisDeptName.name)
-
-          if(ORDERBY === "type") {
-            // console.log('i match type')
-            firstPassCount = 0; 
-            this.displayPeople(FORMAT, GROUPBY, Departments[key].id, "firstpass", ourPeople, Departments)
-            this.displayPeople(FORMAT, GROUPBY, Departments[key].id, "secondpass", ourPeople, Departments)
-          }else {
-            this.displayPeople(FORMAT, GROUPBY, Departments[key].id, "", ourPeople, Departments)
-          }
-        }
-      } else if (GROUPBY == 'type') {
-        for (const [key] of Object.entries(JobTypes)) {
-          let thisTypeID = JobTypes[key].id
-          let thisTypeName = this.getTaxonomyName(JobTypes, thisTypeID) 
-          // console.log("Group by Type : " + thisTypeID)
-          // console.log("Group by Name : " + thisTypeName.name)
-          if(ORDERBY === "type") {
-            firstPassCount = 0; 
-            this.displayPeople(FORMAT, GROUPBY, JobTypes[key].id, "firstpass", ourPeople, Departments)
-            this.displayPeople(FORMAT, GROUPBY, JobTypes[key].id, "secondpass", ourPeople, Departments)
-          }else {
-            this.displayPeople(FORMAT, GROUPBY, JobTypes[key].id, "", ourPeople, Departments)
-          }
-        }
+      if(ourPeople.data.length==0){
+        this.toggleMessage('ucb-end-of-results','block')
+        this.toggleMessage('ucb-loading-data')
       } else {
-        if(ORDERBY === "type") {
-          firstPassCount = 0; 
-          this.displayPeople(FORMAT, "", "", "firstpass", ourPeople, Departments)
-          this.displayPeople(FORMAT, "", "", "secondpass", ourPeople, Departments)
-        }else {
-          this.displayPeople(FORMAT, "", "", "", ourPeople, Departments)
+        if (GROUPBY == 'department') {
+          for (const [key] of Object.entries(Departments)) {
+            // let thisDeptID = Departments[key].id
+            // let thisDeptName = getTaxonomyName(Departments, thisDeptID);
+            // console.log("Group by Dept : " + thisDeptID)
+            // console.log("Group by Dept : " + thisDeptName.name)
+  
+            if(ORDERBY === "type") {
+              // console.log('i match type')
+              firstPassCount = 0; 
+              this.displayPeople(FORMAT, GROUPBY, Departments[key].id, "firstpass", ourPeople, Departments)
+              this.displayPeople(FORMAT, GROUPBY, Departments[key].id, "secondpass", ourPeople, Departments)
+            }else {
+              this.displayPeople(FORMAT, GROUPBY, Departments[key].id, "", ourPeople, Departments)
+            }
+          }
+        } else if (GROUPBY == 'type') {
+          for (const [key] of Object.entries(JobTypes)) {
+            let thisTypeID = JobTypes[key].id
+            let thisTypeName = this.getTaxonomyName(JobTypes, thisTypeID) 
+            // console.log("Group by Type : " + thisTypeID)
+            // console.log("Group by Name : " + thisTypeName.name)
+            if(ORDERBY === "type") {
+              firstPassCount = 0; 
+              this.displayPeople(FORMAT, GROUPBY, JobTypes[key].id, "firstpass", ourPeople, Departments)
+              this.displayPeople(FORMAT, GROUPBY, JobTypes[key].id, "secondpass", ourPeople, Departments)
+            }else {
+              this.displayPeople(FORMAT, GROUPBY, JobTypes[key].id, "", ourPeople, Departments)
+            }
+          }
+        } else {
+          if(ORDERBY === "type") {
+            firstPassCount = 0; 
+            this.displayPeople(FORMAT, "", "", "firstpass", ourPeople, Departments)
+            this.displayPeople(FORMAT, "", "", "secondpass", ourPeople, Departments)
+          }else {
+            this.displayPeople(FORMAT, "", "", "", ourPeople, Departments)
+          }
         }
       }
+
     })
   }
 
@@ -119,20 +124,12 @@ class PeopleListElement extends HTMLElement {
             if(data.data.length === 0) {
               // Show Error El and Hide loader
               console.log("No people matching the filter returned.")
-              var errorEl = document.getElementsByClassName('ucb-list-msg ucb-end-of-results')[0]
-              errorEl.style.display = 'block'
-              var loaderEl = document.getElementsByClassName('ucb-list-msg ucb-loading-data')[0]
-              loaderEl.style.display= 'none'
             }
             resolve(data)
           })
       } else {
-        // this.toggleMessage('ucb-al-error', 'block')
+        this.toggleMessage('ucb-error', 'block')
         console.log("Error retrieving people from the API endpoint.  Please try again later. ")
-        var errorEl = document.getElementsByClassName('ucb-error')[0]
-        errorEl.style.display = 'block'
-        var loaderEl = document.getElementsByClassName('ucb-list-msg ucb-loading-data')[0]
-        loaderEl.style.display= 'none'
         reject
       }
     })
@@ -293,7 +290,7 @@ class PeopleListElement extends HTMLElement {
                 el.appendChild(GroupTitle);
               }
             }
-            this.toggleMessage('ucb-al-loading')
+            this.toggleMessage('ucb-loading-data')
 
             el.appendChild(thisCard)
           } else if (DISPLAYFORMAT === 'Grid') {
@@ -313,13 +310,15 @@ class PeopleListElement extends HTMLElement {
   
             thisCard.classList = 'col-sm-12 col-md-6 col-lg-4'
             thisCard.innerHTML = thisPersonCard
-            this.toggleMessage('ucb-al-loading')
+            this.toggleMessage('ucb-loading-data')
             parentContainer.appendChild(thisCard)
           } else {
             // if table display, append to inner tablebody instead of parent element
-            let tablebody = document.getElementById(
+            let tablebody = this.getElementsByClassName(
               'ucb-people-list-table-tablebody',
-            )
+            )[0]
+
+            // let tablebody = this.getElementById('ucb-people-list-table-tablebody')
   
             // check to see if this is the first time we're adding in a member of this group
             // if so, add the name of the group first 
@@ -349,7 +348,7 @@ class PeopleListElement extends HTMLElement {
       })
     } else {
       console.log('empty staff object, no people to render ', ourPepole)
-      this.toggleMessage('ucb-al-end-of-data', 'block')
+      this.toggleMessage('ucb-end-of-results', 'block')
     }
     // done with cards, clean up and close any HTML tags we have opened.
     // el.append(footerHTML)
@@ -385,8 +384,8 @@ class PeopleListElement extends HTMLElement {
               <th>Contact Information</th>
         `
         var tableBody = document.createElement('tbody')
-        tableBody.id = 'ucb-people-list-table-tablebody'
-        this.toggleMessage('ucb-al-loading')
+        tableBody.classList = 'ucb-people-list-table-tablebody'
+        this.toggleMessage('ucb-loading-data')
 
         tableHead.appendChild(tableRow)
         container.appendChild(tableHead)
@@ -548,7 +547,7 @@ class PeopleListElement extends HTMLElement {
   }
   toggleMessage(id, display = 'none') {
   if (id) {
-    var toggle = document.getElementById(id)
+    var toggle = this.parentElement.children[1].getElementsByClassName(id)[0]
     if (toggle) {
       if (display === 'block') {
         toggle.style.display = 'block'

--- a/templates/block/block--ucb-campus-news.html.twig
+++ b/templates/block/block--ucb-campus-news.html.twig
@@ -1,0 +1,45 @@
+{#
+/**
+ * @file
+ * Theme override to display a block.
+ *
+ * Available variables:
+ * - plugin_id: The ID of the block implementation.
+ * - label: The configured label of the block if visible.
+ * - configuration: A list of the block's configuration values.
+ *   - label: The configured label for the block.
+ *   - label_display: The display settings for the label.
+ *   - provider: The module or other provider that provided this block plugin.
+ *   - Block plugin specific settings will also be stored here.
+ * - content: The content of this block.
+ * - attributes: array of HTML attributes populated by modules, intended to
+ *   be added to the main container tag of this template.
+ *   - id: A valid HTML ID and guaranteed unique.
+ * - title_attributes: Same as attributes, except applied to the main title
+ *   tag that appears in the template.
+ * - title_prefix: Additional output populated by modules, intended to be
+ *   displayed in front of the main title tag that appears in the template.
+ * - title_suffix: Additional output populated by modules, intended to be
+ *   displayed after the main title tag that appears in the template.
+ *
+ * @see template_preprocess_block()
+ */
+#}
+{%
+  set classes = [
+    'container',
+    'block',
+    'block-' ~ configuration.provider|clean_class,
+    'block-' ~ plugin_id|clean_class,
+  ]
+%}
+<div{{ attributes.addClass(classes) }}>
+  {{ title_prefix }}
+  {% if label %}
+    <h2{{ title_attributes }}>{{ label }}</h2>
+  {% endif %}
+  {{ title_suffix }}
+  {% block content %}
+    {{ content }}
+  {% endblock %}
+</div>

--- a/templates/content/node--ucb-people-list-page.html.twig
+++ b/templates/content/node--ucb-people-list-page.html.twig
@@ -186,3 +186,11 @@
     </div>
 	</div>
 </article>
+
+<ucb-people-list
+  JSON={{peopleJSON}}{{ IncludeFilter }}{{ sortFilter}}
+  format={{ displayFormat|trim }}
+  groupby={{ GroupBy }}
+  orderby={{ OrderBy }}
+>
+</ucb-people-list>

--- a/templates/content/node--ucb-people-list-page.html.twig
+++ b/templates/content/node--ucb-people-list-page.html.twig
@@ -104,7 +104,8 @@
 
   <ucb-people-list
   base-uri="{{ url('<front>')|render|trim('/') }}/jsonapi"
-  config="{{ config|json_encode }}">
+  config="{{ config|json_encode }}"
+  user-config="{}">
 </ucb-people-list>
 
 </article>

--- a/templates/content/node--ucb-people-list-page.html.twig
+++ b/templates/content/node--ucb-people-list-page.html.twig
@@ -21,6 +21,13 @@
 	]
 %}{% 
 	set config = {
+		'taxonomies' : {
+			'department': 'department',
+			'job_type': 'ucb_person_job_type',
+			'filter_1': 'filter_1',
+			'filter_2': 'filter_2',
+			'filter_3': 'filter_3'
+		},
 		'filters': {
 			'department': {
 				'includes': content.field_ucb_people_department|render|striptags|trim|split(' '),

--- a/templates/content/node--ucb-people-list-page.html.twig
+++ b/templates/content/node--ucb-people-list-page.html.twig
@@ -9,24 +9,6 @@
 #}
 {{ attach_library('boulderD9_base/ucb-page') }}
 {{ attach_library('boulderD9_base/ucb-people-list-page') }}
-
-{# Display format variable #}
-{% set displayFormat = content.field_ucb_people_display|render|striptags|trim|lower %}
-
-{# include filter options set by the user #}
-{% set myDepartments =
-  content.field_ucb_people_department|render|striptags|trim|split(' ')
-%}
-{% set myTypes =
-  content.field_ucb_people_job_type|render|striptags|trim|split(' ')
-%}
-
-{# Group By paramater #}
-{% set GroupBy = content.field_ucb_people_group_by|render|striptags|trim %}
-
-{# Order By paramater #}
-{% set OrderBy = content.field_ucb_people_order_by|render|striptags|trim %}
-
 {%
 	set classes = [
 		'node',
@@ -41,12 +23,12 @@
 	set config = {
 		'filters': {
 			'department': {
-				'includes': myDepartments,
+				'includes': content.field_ucb_people_department|render|striptags|trim|split(' '),
 				'userAccessible': content.field_ucb_people_department_s|render|striptags|trim == 'On',
 				'label': 'Department',
 			},
 			'job_type': {
-				'includes': myTypes,
+				'includes': content.field_ucb_people_job_type|render|striptags|trim|split(' '),
 				'userAccessible': content.field_ucb_people_job_type_s|render|striptags|trim == 'On',
 				'label': 'Job Type'
 			},
@@ -66,48 +48,18 @@
 				'label': 'Filter 3'
 			}
 		},
-		'format': displayFormat,
-		'groupby': GroupBy,
-		'orderby': OrderBy
+		'format': content.field_ucb_people_display|render|striptags|trim,
+		'groupby': content.field_ucb_people_group_by|render|striptags|trim,
+		'orderby': content.field_ucb_people_order_by|render|striptags|trim
 	}
 %}
-
-<article id="ucb-people-list-page"
-    {{attributes.addClass(classes)}}>
-
+<article id="ucb-people-list-page"{{attributes.addClass(classes)}}>
 	<div class="ucb-people-list-title">
 		<h1{{title_attributes}}>
 			{{ label }}
 		</h1>
 	</div>
-
-	<div id="ucb-pl-content" class="ucb-people-list-content">
-		<div class="row">
-			{{ content.body }}
-		</div>
-
-    {# Loading message #}
-    <div id="ucb-al-loading" class="ucb-list-msg ucb-loading-data">
-      <i class="fas fa-spinner fa-3x fa-pulse"></i>
-    </div>
-
-    {# No more Data #}
-    <div id="ucb-al-no-data" class="ucb-list-msg ucb-end-of-results">
-      No results matching your filters.
-    </div>
-
-    {# Error in the response from the API endpoint, display an error #}
-    <div id="ucb-al-error" class="ucb-list-msg ucb-error">
-      Error retrieving people from the API endpoint.  Please try again later.  
-    </div>
-	</div>
-
-  <ucb-people-list
-  base-uri="{{ url('<front>')|render|trim('/') }}/jsonapi"
-  config="{{ config|json_encode }}"
-  user-config="{}">
-</ucb-people-list>
-
+	<ucb-people-list base-uri="{{ url('<front>')|render|trim('/') }}/jsonapi" config="{{ config|json_encode }}" user-config="{}">
+		<noscript><div class="ucb-list-msg ucb-error">Please enable JavaScript to see this page.</div></noscript>
+	</ucb-people-list>
 </article>
-
-

--- a/templates/content/node--ucb-people-list-page.html.twig
+++ b/templates/content/node--ucb-people-list-page.html.twig
@@ -152,10 +152,6 @@
 %}
 
 <article id="ucb-people-list-page"
-    data-JSON={{peopleJSON}}{{ IncludeFilter }}{{ sortFilter}}
-    data-format={{ displayFormat|trim }}
-    data-groupby={{ GroupBy }}
-    data-orderby={{ OrderBy }}
     {{attributes.addClass(classes)}}>
 
 	<div class="ucb-people-list-title">
@@ -165,7 +161,6 @@
 	</div>
 
 	<div id="ucb-pl-content" class="ucb-people-list-content">
-    <!--  <h3>{{ peopleJSON }}{{ IncludeFilter }}{{ sortFilter }}</h3> -->
 		<div class="row">
 			{{ content.body }}
 		</div>
@@ -185,12 +180,15 @@
       Error retrieving people from the API endpoint.  Please try again later.  
     </div>
 	</div>
-</article>
 
-<ucb-people-list
+  <ucb-people-list
   JSON={{peopleJSON}}{{ IncludeFilter }}{{ sortFilter}}
   format={{ displayFormat|trim }}
   groupby={{ GroupBy }}
   orderby={{ OrderBy }}
 >
 </ucb-people-list>
+
+</article>
+
+

--- a/templates/content/node--ucb-people-list-page.html.twig
+++ b/templates/content/node--ucb-people-list-page.html.twig
@@ -11,127 +11,15 @@
 {{ attach_library('boulderD9_base/ucb-people-list-page') }}
 
 {# Display format variable #}
-{% set displayFormat = content.field_ucb_people_display|render|striptags|trim %}
-
-{# JSON API Endpoint information #}
-{% set peopleJSON = (url('<front>')|render|trim('/'))
-  ~ '/jsonapi/node/ucb_person'
-  ~ '?include[node--ucb_person]=uid,body,field_ucb_person_first_name,field_ucb_person_last_name,field_ucb_person_job_type,'
-  ~ 'field_ucb_person_department,field_ucb_person_email,field_ucb_person_phone,field_ucb_person_title,field_ucb_person_photo'
-  ~ '&include=field_ucb_person_photo.field_media_image'
-  ~ '&fields[file--file]=uri,url'
-%}
-
-{# Filter on only published (status = true) content #}
-{% set PublishedFilter = '&filter[publish-check][condition][path]=status'
-  ~ '&filter[publish-check][condition][value]=1'
-  ~ '&filter[publish-check][condition][memberOf]=published'
-%}
+{% set displayFormat = content.field_ucb_people_display|render|striptags|trim|lower %}
 
 {# include filter options set by the user #}
-{% set includeDepartments = [] %}
 {% set myDepartments =
   content.field_ucb_people_department|render|striptags|trim|split(' ')
 %}
-{% set includeTypes = [] %}
 {% set myTypes =
   content.field_ucb_people_job_type|render|striptags|trim|split(' ')
 %}
-
-{# two passes to clear out the blank entries that are mysteriously added by default #}
-{% for item in myDepartments %}
-  {% if item %}
-    {% set includeDepartments = includeDepartments|merge([item]) %}
-  {% endif %}
-{% endfor %}
-
-{% for item in myTypes %}
-  {% if item %}
-    {% set includeTypes = includeTypes|merge([item]) %}
-  {% endif %}
-{% endfor %}
-
-
-{# placeholder variables for our include and exclude filters, default to blank strings #}
-{% set IncludeFilter = '' %}
-{% set IncludeDeptFilter = '' %}
-{% set IncludeTypeFilter = '' %}
-
-{# Setup Include Department Filter using a logical OR between included department IDs #}
-{% if includeDepartments|length %}
-  {% set includeGroupMembers = '' %}
-  {% for item in includeDepartments %}
-    {% set includeGroupMembers = includeGroupMembers ~ '&filter[filter-dept'
-      ~ (item|trim)
-      ~ '][condition][path]=field_ucb_person_department.meta.drupal_internal__target_id'
-      ~ '&filter[filter-dept'
-      ~ (item|trim)
-      ~ '][condition][value]='
-      ~ (item|trim)
-      ~ '&filter[filter-dept'
-      ~ (item|trim)
-      ~ '][condition][memberOf]=dept-include'
-    %}
-  {% endfor %}
-  {% set IncludeDeptFilter = '&filter[dept-include][group][conjunction]=OR'
-    ~ includeGroupMembers
-  %}
-{% endif %}
-
-{# Setup Include Type Filter using a logical OR between included job type IDs #}
-{% if includeTypes|length %}
-  {% set includeGroupMembers = '' %}
-  {% for item in includeTypes %}
-    {% set includeGroupMembers = includeGroupMembers ~ '&filter[filter-type'
-      ~ (item|trim)
-      ~ '][condition][path]=field_ucb_person_job_type.meta.drupal_internal__target_id'
-      ~ '&filter[filter-type'
-      ~ (item|trim)
-      ~ '][condition][value]='
-      ~ (item|trim)
-      ~ '&filter[filter-type'
-      ~ (item|trim)
-      ~ '][condition][memberOf]=type-include'
-    %}
-  {% endfor %}
-  {% set IncludeTypeFilter = '&filter[type-include][group][conjunction]=OR'
-    ~ includeGroupMembers
-  %}
-{% endif %}
-
-{# check to see if we have both Departments and Types to filter on #}
-{# if so... setup a logicial AND Between both include filters #}
-{% if IncludeDeptFilter and IncludeTypeFilter %}
-  {% set IncludeFilter = '&filter[published][group][conjunction]=AND'
-    ~ PublishedFilter
-    ~ '&filter[include-group][group][conjunction]=AND'
-    ~ '&filter[include-group][group][memberOf]=published'
-    ~ IncludeDeptFilter
-    ~ '&filter[dept-include][group][memberOf]=include-group'
-    ~ IncludeTypeFilter
-    ~ '&filter[type-include][group][memberOf]=include-group'
-  %}
-  {# Otherwise default to either the Department filter or the Type filter as defined #}
-{% elseif IncludeDeptFilter %}
-  {% set IncludeFilter = '&filter[published][group][conjunction]=AND'
-    ~ '&filter[dept-include][group][memberOf]=published'
-    ~ PublishedFilter
-    ~ IncludeDeptFilter
-  %}
-{% elseif IncludeTypeFilter %}
-  {% set IncludeFilter = '&filter[published][group][conjunction]=AND'
-    ~ '&filter[type-include][group][memberOf]=published'
-    ~ PublishedFilter
-    ~ IncludeTypeFilter
-  %}
-
-{# no includeded Departments or Types ... still need to filter on published people #}
-{% else %}
-  {% set IncludeFilter = '&filter[status][value]=1' %}
-{% endif %}
-
-{# sorting filter #}
-{% set sortFilter = '&sort=field_ucb_person_last_name' %}
 
 {# Group By paramater #}
 {% set GroupBy = content.field_ucb_people_group_by|render|striptags|trim %}
@@ -153,21 +41,34 @@
 	set config = {
 		'filters': {
 			'department': {
-				'includes': myDepartments
+				'includes': myDepartments,
+				'userAccessible': content.field_ucb_people_department_s|render|striptags|trim == 'On',
+				'label': 'Department',
 			},
 			'job_type': {
-				'includes': myTypes
+				'includes': myTypes,
+				'userAccessible': content.field_ucb_people_job_type_s|render|striptags|trim == 'On',
+				'label': 'Job Type'
 			},
 			'filter_1': {
-				'includes': content.field_ucb_people_filter_1|render|striptags|trim|split(' ')
+				'includes': content.field_ucb_people_filter_1|render|striptags|trim|split(' '),
+				'userAccessible': content.field_ucb_people_filter_1_s|render|striptags|trim == 'On',
+				'label': 'Filter 1'
 			},
 			'filter_2': {
-				'includes': content.field_ucb_people_filter_2|render|striptags|trim|split(' ')
+				'includes': content.field_ucb_people_filter_2|render|striptags|trim|split(' '),
+				'userAccessible': content.field_ucb_people_filter_2_s|render|striptags|trim == 'On',
+				'label': 'Filter 2'
 			},
 			'filter_3': {
-				'includes': content.field_ucb_people_filter_3|render|striptags|trim|split(' ')
+				'includes': content.field_ucb_people_filter_3|render|striptags|trim|split(' '),
+				'userAccessible': content.field_ucb_people_filter_3_s|render|striptags|trim == 'On',
+				'label': 'Filter 3'
 			}
-		}
+		},
+		'format': displayFormat,
+		'groupby': GroupBy,
+		'orderby': OrderBy
 	}
 %}
 
@@ -202,28 +103,10 @@
 	</div>
 
   <ucb-people-list
-  base-uri={{ url('<front>')|render|trim('/') }}
-  config={{ config|json_encode }}
-  JSON={{peopleJSON}}{{ IncludeFilter }}{{ sortFilter}}
-  format={{ displayFormat|trim }}
-  groupby={{ GroupBy }}
-  orderby={{ OrderBy }}
-  allowUserDeptFilters={{content.field_ucb_people_department_s|render|striptags|trim}}
-  allowUserJobTypeFilters={{content.field_ucb_people_job_type_s|render|striptags|trim}}
-  allowUserFilter1={{content.field_ucb_people_filter_1_s|render|striptags|trim}}
-  allowUserFilter2={{content.field_ucb_people_filter_2_s|render|striptags|trim}}
-  allowUserFilter3={{content.field_ucb_people_filter_3_s|render|striptags|trim}}
->
+  base-uri="{{ url('<front>')|render|trim('/') }}/jsonapi"
+  config="{{ config|json_encode }}">
 </ucb-people-list>
 
 </article>
-
-<div>
-  <h3> Allow visitors filter on department : {{content.field_ucb_people_department_s}}</h3>
-  <h3> Allow visitors filter on Job Type : {{content.field_ucb_people_job_type_s}}</h3>
-  <h3> Allow visitors filter on Filter 1 : {{content.field_ucb_people_filter_1_s}}</h3>
-  <h3> Allow visitors filter on Filter 2 : {{content.field_ucb_people_filter_2_s}}</h3>
-  <h3> Allow visitors filter on Filter 3 : {{content.field_ucb_people_filter_3_s}}</h3>
-</div>
 
 

--- a/templates/content/node--ucb-people-list-page.html.twig
+++ b/templates/content/node--ucb-people-list-page.html.twig
@@ -171,7 +171,7 @@
     </div>
 
     {# No more Data #}
-    <div id="ucb-al-end-of-data" class="ucb-list-msg ucb-end-of-results">
+    <div id="ucb-al-no-data" class="ucb-list-msg ucb-end-of-results">
       No results matching your filters.
     </div>
 

--- a/templates/content/node--ucb-people-list-page.html.twig
+++ b/templates/content/node--ucb-people-list-page.html.twig
@@ -71,6 +71,11 @@
 			{{ label }}
 		</h1>
 	</div>
+	{% if content.body|render %}
+	<div class="ucb-person-section ucb-person-body">
+		{{ content.body }}
+	</div>
+	{% endif %}
 	<ucb-people-list base-uri="{{ url('<front>')|render|trim('/') }}/jsonapi" config="{{ config|json_encode }}" user-config="{}">
 		<noscript><div class="ucb-list-msg ucb-error">Please enable JavaScript to see this page.</div></noscript>
 	</ucb-people-list>

--- a/templates/content/node--ucb-people-list-page.html.twig
+++ b/templates/content/node--ucb-people-list-page.html.twig
@@ -33,26 +33,31 @@
 				'includes': content.field_ucb_people_department|render|striptags|trim|split(' '),
 				'userAccessible': content.field_ucb_people_department_s|render|striptags|trim == 'On',
 				'label': 'Department',
+				'restrict': content.field_ucb_people_department_r|render|striptags|trim == 'On'
 			},
 			'job_type': {
 				'includes': content.field_ucb_people_job_type|render|striptags|trim|split(' '),
 				'userAccessible': content.field_ucb_people_job_type_s|render|striptags|trim == 'On',
-				'label': 'Job Type'
+				'label': 'Job Type',
+				'restrict': content.field_ucb_people_job_type_r|render|striptags|trim == 'On'
 			},
 			'filter_1': {
 				'includes': content.field_ucb_people_filter_1|render|striptags|trim|split(' '),
 				'userAccessible': content.field_ucb_people_filter_1_s|render|striptags|trim == 'On',
-				'label': 'Filter 1'
+				'label': content.field_ucb_people_filter_1_label|render|striptags|trim,
+				'restrict': content.field_ucb_people_filter_1_r|render|striptags|trim == 'On'
 			},
 			'filter_2': {
 				'includes': content.field_ucb_people_filter_2|render|striptags|trim|split(' '),
 				'userAccessible': content.field_ucb_people_filter_2_s|render|striptags|trim == 'On',
-				'label': 'Filter 2'
+				'label': content.field_ucb_people_filter_2_label|render|striptags|trim,
+				'restrict': content.field_ucb_people_filter_2_r|render|striptags|trim == 'On'
 			},
 			'filter_3': {
 				'includes': content.field_ucb_people_filter_3|render|striptags|trim|split(' '),
 				'userAccessible': content.field_ucb_people_filter_3_s|render|striptags|trim == 'On',
-				'label': 'Filter 3'
+				'label': content.field_ucb_people_filter_3_label|render|striptags|trim,
+				'restrict': content.field_ucb_people_filter_3_r|render|striptags|trim == 'On'
 			}
 		},
 		'format': content.field_ucb_people_display|render|striptags|trim,

--- a/templates/content/node--ucb-person.html.twig
+++ b/templates/content/node--ucb-person.html.twig
@@ -24,34 +24,43 @@ view_mode ? 'node--view-mode-' ~ view_mode|clean_class,
 <article{{attributes.addClass(classes)}}>
 	<div class="container-fluid ucb-person-name">
 		<div class="container">
-		<h1 class="ucb-person-name ">
-			<span itemprop="givenName">{{ content.field_ucb_person_first_name }}</span> <span itemprop="familyName">{{ content.field_ucb_person_last_name }}</span>
-		</h1>
+			<h1 class="ucb-person-name ">
+				<span itemprop="givenName">{{ content.field_ucb_person_first_name }}</span>
+				<span itemprop="familyName">{{ content.field_ucb_person_last_name }}</span>
+			</h1>
 		</div>
 	</div>
 	<div class="container ucb-person" itemscope itemtype="https://schema.org/Person">
 		<div class="row ucb-person-personal">
 			<div class="col ucb-person-main">
 				{% if content.field_ucb_person_photo|render %}
-					<div itemprop="image"> {{ content.field_ucb_person_photo }} </div> 
+					<div itemprop="image">
+						{{ content.field_ucb_person_photo }}
+					</div>
 				{% endif %}
 				{% if content.field_ucb_person_title|render or content.field_ucb_person_department|render %}
 					<div class="ucb-person-section ucb-person-job">
 						{% if content.field_ucb_person_title|render %}
-							<span class="d-block" itemprop="jobTitle">{{ content.field_ucb_person_title|render|striptags|trim }}</span>
+							<span class="d-block">
+								{{ content.field_ucb_person_title}}
+							</span>
 						{% endif %}
 						{% if content.field_ucb_person_department|render %}
-							<span class="d-block">{{ content.field_ucb_person_department|render|striptags|trim }}</span>
+							<span class="d-block">{{ content.field_ucb_person_department}}</span>
 						{% endif %}
 					</div>
 				{% endif %}
 				{% if content.field_ucb_person_email|render or content.field_ucb_person_phone|render %}
 					<div class="ucb-person-section ucb-person-contact">
 						{% if content.field_ucb_person_email|render %}
-							<div itemprop="email"> {{ content.field_ucb_person_email }} </div> 
+							<div itemprop="email">
+								{{ content.field_ucb_person_email }}
+							</div>
 						{% endif %}
 						{% if content.field_ucb_person_phone|render %}
-							<div itemprop="telephone"> {{ content.field_ucb_person_phone }} </div> 
+							<div itemprop="telephone">
+								{{ content.field_ucb_person_phone }}
+							</div>
 						{% endif %}
 					</div>
 				{% endif %}

--- a/templates/field/field--field-ucb-people-department.html.twig
+++ b/templates/field/field--field-ucb-people-department.html.twig
@@ -1,0 +1,1 @@
+{% for item in items %}{{ item.content|render|striptags|trim }} {% endfor %}

--- a/templates/field/field--field-ucb-people-filter-1.html.twig
+++ b/templates/field/field--field-ucb-people-filter-1.html.twig
@@ -1,0 +1,1 @@
+{% for item in items %}{{ item.content|render|striptags|trim }} {% endfor %}

--- a/templates/field/field--field-ucb-people-filter-2.html.twig
+++ b/templates/field/field--field-ucb-people-filter-2.html.twig
@@ -1,0 +1,1 @@
+{% for item in items %}{{ item.content|render|striptags|trim }} {% endfor %}

--- a/templates/field/field--field-ucb-people-filter-3.html.twig
+++ b/templates/field/field--field-ucb-people-filter-3.html.twig
@@ -1,0 +1,1 @@
+{% for item in items %}{{ item.content|render|striptags|trim }} {% endfor %}

--- a/templates/field/field--field-ucb-people-job-type.html.twig
+++ b/templates/field/field--field-ucb-people-job-type.html.twig
@@ -1,0 +1,1 @@
+{% for item in items %}{{ item.content|render|striptags|trim }} {% endfor %}

--- a/templates/field/field--field-ucb-person-department.html.twig
+++ b/templates/field/field--field-ucb-person-department.html.twig
@@ -1,0 +1,8 @@
+
+<ul class="ucb-person-department">
+    {% for item in items %}
+        <li itemprop="department">
+            {{ item.content|render|striptags|trim }}
+        </li>
+    {% endfor %}
+</ul>

--- a/templates/field/field--field-ucb-person-title.html.twig
+++ b/templates/field/field--field-ucb-person-title.html.twig
@@ -1,0 +1,7 @@
+<ul class="ucb-person-title">
+	{% for item in items %}
+		<li itemprop="jobTitle">
+			{{ item.content|render|striptags|trim }}
+		</li>
+	{% endfor %}
+</ul>


### PR DESCRIPTION
Resolves #120 - Enhances People List Page design

Authored by @TeddyBearX and @patrickbrown-io 

Includes: 
## tiamat-custom-entities ( branch : tiamat-theme#120 )
### Person page (tiamat-custom-entities):

-  Adds taxonomy terms for "Filter 1", "Filter 2", "Filter 3"
-  Adds fields for "Filter 1", "Filter 2", "Filter 3"
-  The bio field on the person page has a summary option they can use (or ignore if they want to leave it blank)

### People List Page (tiamat-custom-entities):

-  Adds fields for filtering by "Filter 1", "Filter 2", "Filter 3"
-  Adds toggles for enabling filters to be user-accessible
-  "Child Terms" option

##  tiamat-theme (branch : tiamat-120)
### People List Page
-  Refactored as web component
-  Fixed no photo bug
-  The list view displays name, photo, job title(s), department, email, and phone number. and summary of bio field.
-  JavaScript and CSS UI for user-accessible filters