### PR TITLE
Adds a new "Content List" block type

### DIFF
--- a/boulderD9_base.libraries.yml
+++ b/boulderD9_base.libraries.yml
@@ -126,6 +126,12 @@ ucb-content-grid:
     theme:
       css/block/content-grid.css: {}
 
+ucb-content-list:
+  version: 1.x
+  css:
+    theme:
+      css/block/content-list.css: {}
+
 ucb-content-row:
   version: 1.x
   css:

--- a/css/block/content-list.css
+++ b/css/block/content-list.css
@@ -3,12 +3,8 @@
 	padding: 20px 0 0 0;
 }
 
-.ucb-content-list h2 {
-	margin-bottom: 20px;
-}
-
 .ucb-content-list-display-teaser h2, .ucb-content-list-display-title h2, .ucb-content-list-display-sidebar h2 {
-	font-size: 1.3em;
+	font-size: 1.3rem;
 }
 
 .ucb-content-list {
@@ -29,16 +25,18 @@
 	margin-bottom: 20px;
 }
 
-.ucb-content-list-display-full .ucb-content-list-title {
-	font-size: 1.45em;
+.ucb-content-list-display-full .ucb-content-list-title, .ucb-content-list-display-condensed .ucb-content-list-title, .ucb-content-list-display-teaser .ucb-content-list-title {
+	font-size: 1.2rem;
 }
 
-.ucb-content-list-display-condensed .ucb-content-list-title, .ucb-content-list-display-teaser .ucb-content-list-title {
-	font-size: 1.2em;
+@media screen and (min-width: 960px) {
+	.ucb-content-list-display-full .ucb-content-list-title {
+		font-size: 1.45rem;
+	}
 }
 
 .ucb-content-list-display-title .ucb-content-list-title, .ucb-content-list-display-sidebar .ucb-content-list-title {
-	font-size: 1em;
+	font-size: 1rem;
 	font-weight: 400;
 }
 

--- a/css/block/content-list.css
+++ b/css/block/content-list.css
@@ -1,0 +1,18 @@
+.ucb-content-list-display-teaser .ucb-content-list-row, .ucb-content-list-display-embed .ucb-content-list-row {
+	border-bottom: 1px solid rgba(20 20 20 / 20%);
+	margin-bottom: 20px;
+}
+
+.ucb-content-list-display-teaser .ucb-content-list-title, .ucb-content-list-display-embed .ucb-content-list-title {
+	font-size: 1.25rem;
+	font-weight: bolder;
+	margin-bottom: 10px;
+}
+
+.ucb-content-list-display-embed .ucb-content-list-title {
+	font-size: 1.2rem;
+}
+
+.ucb-content-list-display-embed .ucb-content-list-image-empty {
+	display: none;
+}

--- a/css/block/content-list.css
+++ b/css/block/content-list.css
@@ -17,6 +17,10 @@
 	margin-bottom: 10px;
 }
 
+.ucb-content-list-read-more {
+	white-space: nowrap;
+}
+
 .ucb-content-list-display-embed .ucb-content-list-title {
 	font-size: 1.2rem;
 }
@@ -28,10 +32,6 @@
 
 .ucb-content-list-display-sidebar .ucb-content-list-title {
 	display: block;
-}
-
-.ucb-content-list-display-embed .ucb-content-list-image-empty {
-	display: none;
 }
 
 .ucb-content-list-image-container {

--- a/css/block/content-list.css
+++ b/css/block/content-list.css
@@ -1,13 +1,13 @@
 .ucb-content-list-display-teaser .ucb-content-list-row, .ucb-content-list-display-embed .ucb-content-list-row, .ucb-content-list-display-sidebar .ucb-content-list-row {
-	border-bottom: 1px solid rgba(20, 20, 20, .2);
-	padding: 20px 0;
+	border-bottom: 1px solid rgba(128, 128, 128, 0.333);
+	padding: 20px 0 0 0;
 }
 
-.ucb-content-list-display-embed h2, .ucb-content-list-display-title h2, .ucb-content-list-display-sidebar h2 {
+.ucb-content-list-display-teaser h2, .ucb-content-list-display-title h2, .ucb-content-list-display-sidebar h2 {
 	font-size: 1.3em;
 }
 
-.ucb-content-list-container {
+.ucb-content-list {
 	margin-bottom: 20px;
 }
 
@@ -21,7 +21,11 @@
 	white-space: nowrap;
 }
 
-.ucb-content-list-display-embed .ucb-content-list-title {
+.ucb-content-list-image {
+	margin-bottom: 20px;
+}
+
+.ucb-content-list-display-teaser .ucb-content-list-title {
 	font-size: 1.2rem;
 }
 
@@ -34,6 +38,28 @@
 	display: block;
 }
 
-.ucb-content-list-image-container {
-	margin-bottom: 10px;
+.ucb-content-list-display-teaser, .ucb-content-list-display-title, .ucb-content-list-display-sidebar {
+	padding: 20px 20px 20px 20px;
+}
+
+.ucb-content-list-display-title {
+	border: 1px solid rgba(128, 128, 128, 0.333);
+	padding-bottom: 10px;
+}
+
+.ucb-content-list-row {
+	margin-left: 0;
+	margin-right: 0;
+}
+
+.ucb-content-list-display-embed .ucb-content-list-text-container, .ucb-content-list-display-teaser .ucb-content-list-image-container, .ucb-content-list-display-teaser .ucb-content-list-text-container, .ucb-content-list-display-sidebar .ucb-content-list-text-container {
+	padding-left: 0;
+}
+
+.ucb-content-list-display-embed .ucb-content-list-image-container, .ucb-content-list-display-teaser .ucb-content-list-text-container, .ucb-content-list-display-sidebar .ucb-content-list-text-container, .ucb-content-list-display-sidebar .ucb-content-list-image-container {
+	padding-right: 0;
+}
+
+.ucb-content-list-display-title .ucb-content-list-list {
+	margin-bottom: 0;
 }

--- a/css/block/content-list.css
+++ b/css/block/content-list.css
@@ -1,9 +1,17 @@
-.ucb-content-list-display-teaser .ucb-content-list-row, .ucb-content-list-display-embed .ucb-content-list-row {
-	border-bottom: 1px solid rgba(20 20 20 / 20%);
+.ucb-content-list-display-teaser .ucb-content-list-row, .ucb-content-list-display-embed .ucb-content-list-row, .ucb-content-list-display-sidebar .ucb-content-list-row {
+	border-bottom: 1px solid rgba(20, 20, 20, .2);
+	padding: 20px 0;
+}
+
+.ucb-content-list-display-embed h2, .ucb-content-list-display-title h2, .ucb-content-list-display-sidebar h2 {
+	font-size: 1.3em;
+}
+
+.ucb-content-list-container {
 	margin-bottom: 20px;
 }
 
-.ucb-content-list-display-teaser .ucb-content-list-title, .ucb-content-list-display-embed .ucb-content-list-title {
+.ucb-content-list-title {
 	font-size: 1.25rem;
 	font-weight: bolder;
 	margin-bottom: 10px;
@@ -13,6 +21,19 @@
 	font-size: 1.2rem;
 }
 
+.ucb-content-list-display-title .ucb-content-list-title, .ucb-content-list-display-sidebar .ucb-content-list-title {
+	font-size: 1rem;
+	font-weight: 400;
+}
+
+.ucb-content-list-display-sidebar .ucb-content-list-title {
+	display: block;
+}
+
 .ucb-content-list-display-embed .ucb-content-list-image-empty {
 	display: none;
+}
+
+.ucb-content-list-image-container {
+	margin-bottom: 10px;
 }

--- a/css/block/content-list.css
+++ b/css/block/content-list.css
@@ -1,6 +1,10 @@
-.ucb-content-list-display-teaser .ucb-content-list-row, .ucb-content-list-display-embed .ucb-content-list-row, .ucb-content-list-display-sidebar .ucb-content-list-row {
+.ucb-content-list-display-condensed .ucb-content-list-row, .ucb-content-list-display-teaser .ucb-content-list-row, .ucb-content-list-display-full .ucb-content-list-row, .ucb-content-list-display-sidebar .ucb-content-list-row {
 	border-bottom: 1px solid rgba(128, 128, 128, 0.333);
 	padding: 20px 0 0 0;
+}
+
+.ucb-content-list h2 {
+	margin-bottom: 20px;
 }
 
 .ucb-content-list-display-teaser h2, .ucb-content-list-display-title h2, .ucb-content-list-display-sidebar h2 {
@@ -25,12 +29,16 @@
 	margin-bottom: 20px;
 }
 
-.ucb-content-list-display-teaser .ucb-content-list-title {
-	font-size: 1.2rem;
+.ucb-content-list-display-full .ucb-content-list-title {
+	font-size: 1.45em;
+}
+
+.ucb-content-list-display-condensed .ucb-content-list-title, .ucb-content-list-display-teaser .ucb-content-list-title {
+	font-size: 1.2em;
 }
 
 .ucb-content-list-display-title .ucb-content-list-title, .ucb-content-list-display-sidebar .ucb-content-list-title {
-	font-size: 1rem;
+	font-size: 1em;
 	font-weight: 400;
 }
 
@@ -44,7 +52,10 @@
 
 .ucb-content-list-display-title {
 	border: 1px solid rgba(128, 128, 128, 0.333);
-	padding-bottom: 10px;
+}
+
+.ucb-content-list-display-sidebar .ucb-content-list-title {
+	padding-bottom: 20px;
 }
 
 .ucb-content-list-row {
@@ -52,11 +63,15 @@
 	margin-right: 0;
 }
 
-.ucb-content-list-display-embed .ucb-content-list-text-container, .ucb-content-list-display-teaser .ucb-content-list-image-container, .ucb-content-list-display-teaser .ucb-content-list-text-container, .ucb-content-list-display-sidebar .ucb-content-list-text-container {
+.ucb-content-list-row:first-child {
+	padding-top: 0;
+}
+
+.ucb-content-list-display-full .ucb-content-list-text-container, .ucb-content-list-display-condensed .ucb-content-list-image-container, .ucb-content-list-display-condensed .ucb-content-list-text-container, .ucb-content-list-display-teaser .ucb-content-list-image-container, .ucb-content-list-display-teaser .ucb-content-list-text-container, .ucb-content-list-display-sidebar .ucb-content-list-text-container {
 	padding-left: 0;
 }
 
-.ucb-content-list-display-embed .ucb-content-list-image-container, .ucb-content-list-display-teaser .ucb-content-list-text-container, .ucb-content-list-display-sidebar .ucb-content-list-text-container, .ucb-content-list-display-sidebar .ucb-content-list-image-container {
+.ucb-content-list-display-full .ucb-content-list-image-container, .ucb-content-list-display-condensed .ucb-content-list-text-container, .ucb-content-list-display-teaser .ucb-content-list-text-container, .ucb-content-list-display-sidebar .ucb-content-list-text-container, .ucb-content-list-display-sidebar .ucb-content-list-image-container {
 	padding-right: 0;
 }
 

--- a/templates/block/block--inline-block--content-list.html.twig
+++ b/templates/block/block--inline-block--content-list.html.twig
@@ -31,27 +31,38 @@
 		{% if display == 'teaser' %}{% for key, item in blockContent.field_content_list_content if key|first != '#' %}<div class="row ucb-content-list-row">
 			<div class="col-9">
 				<h4 class="ucb-content-list-title"><a href="{{ item.entity.path.alias }}">{{ item.entity.title.0.value }}</a></h4>
-				{% set summary = item.entity.body.0.summary %}{% if summary %}<p class="ucb-content-list-summary">{{ summary }}</p>{% endif %}
+				{% set summary = item.entity.body.0.summary ?? item.entity.field_ucb_article_summary.0.value %}
+				<p class="ucb-content-list-summary">{{ summary }} <a href="{{ item.entity.path.alias }}">Read&nbsp;more&nbsp;&raquo;</a></p>
 			</div>
-			{% set image = item.entity.field_ucb_person_photo.entity.field_media_image %}
+			{% set image = item.entity.field_ucb_person_photo.entity.field_media_image ?? item.entity.field_ucb_article_thumbnail.entity.field_media_image %}
 			<div class="ucb-content-list-image-container col-3{{ image ? '' : ' ucb-content-list-image-empty' }}">{% if image %}
 				{% set imageURI = image.entity.fileuri|image_style('focal_image_square') %}{% set imageAlt = image.alt|render %}
-				<img class="ucb-content-list-image" src="{{ imageURI }}" alt="{{ imageAlt }}">
+				<a href="{{ item.entity.path.alias }}"><img class="ucb-content-list-image" src="{{ imageURI }}" alt="{{ imageAlt }}"></a>
 			{% endif %}</div>
 		</div>{% endfor %}{% elseif display == 'embed' %}{% for key, item in blockContent.field_content_list_content if key|first != '#' %}<div class="row ucb-content-list-row">
-			{% set image = item.entity.field_ucb_person_photo.entity.field_media_image %}
-			<div class="ucb-content-list-image-container col-2{{ image ? '' : ' ucb-content-list-image-empty' }}">{% if image %}
+			{% set image = item.entity.field_ucb_person_photo.entity.field_media_image ?? item.entity.field_ucb_article_thumbnail.entity.field_media_image %}
+			<div class="ucb-content-list-image-container col-3{{ image ? '' : ' ucb-content-list-image-empty' }}">{% if image %}
 				{% set imageURI = image.entity.fileuri|image_style('focal_image_square') %}{% set imageAlt = image.alt|render %}
-				<img class="ucb-content-list-image" src="{{ imageURI }}" alt="{{ imageAlt }}">
+				<a href="{{ item.entity.path.alias }}"><img class="ucb-content-list-image" src="{{ imageURI }}" alt="{{ imageAlt }}"></a>
 			{% endif %}</div>
 			<div class="col-9">
-				<h4 class="ucb-content-list-title"><a href="{{ item.entity.path.alias }}">{{ item.entity.title.0.value }}</a></h4>
-				{% set summary = item.entity.body.0.summary %}{% if summary %}<p class="ucb-content-list-summary">{{ summary }}</p>{% endif %}
+				<h3 class="ucb-content-list-title"><a href="{{ item.entity.path.alias }}">{{ item.entity.title.0.value }}</a></h3>
+				{% set summary = item.entity.body.0.summary ?? item.entity.field_ucb_article_summary.0.value %}
+				<p class="ucb-content-list-summary">{{ summary }} <a href="{{ item.entity.path.alias }}">Read&nbsp;more&nbsp;&raquo;</a></p>
 			</div>
-		</div>{% endfor %}{% elseif display == 'title' %}<ul>{% for key, item in blockContent.field_content_list_content if key|first != '#' %}
+		</div>{% endfor %}{% elseif display == 'title' %}
+		<ul>{% for key, item in blockContent.field_content_list_content if key|first != '#' %}
 			<li class="ucb-content-list-row ucb-content-list-title"><a href="{{ item.entity.path.alias }}">{{ item.entity.title.0.value }}</a></li>
 		{% endfor %}</ul>
-		{% elseif display == 'sidebar' %}{# TODO Sidebar #}
-		{% endif %}
+		{% elseif display == 'sidebar' %}{% for key, item in blockContent.field_content_list_content if key|first != '#' %}<div class="row ucb-content-list-row">
+			<div class="col-9">
+				<span class="ucb-content-list-title"><a href="{{ item.entity.path.alias }}">{{ item.entity.title.0.value }}</a></span>
+			</div>
+			{% set image = item.entity.field_ucb_person_photo.entity.field_media_image ?? item.entity.field_ucb_article_thumbnail.entity.field_media_image %}
+			<div class="ucb-content-list-image-container col-3{{ image ? '' : ' ucb-content-list-image-empty' }}">{% if image %}
+				{% set imageURI = image.entity.fileuri|image_style('focal_image_square') %}{% set imageAlt = image.alt|render %}
+				<a href="{{ item.entity.path.alias }}"><img class="ucb-content-list-image" src="{{ imageURI }}" alt="{{ imageAlt }}"></a>
+			{% endif %}</div>
+		</div>{% endfor %}{% endif %}
 	</div>
 </div>{% endblock content %}

--- a/templates/block/block--inline-block--content-list.html.twig
+++ b/templates/block/block--inline-block--content-list.html.twig
@@ -41,7 +41,7 @@
 	{% if label %}<h2{{ title_attributes }}>{{ label }}</h2>{% endif %}
 	{{ title_suffix }}
 	<div class="ucb-content-list-container">
-		{% if display == 'embed' %}{% for key, item in content %}<div class="row ucb-content-list-row">
+		{% if display == 'full' %}{% for key, item in content %}<div class="row ucb-content-list-row">
 			{% set image = item.entity.field_ucb_article_thumbnail.entity.field_media_image ?? item.entity.field_ucb_person_photo.entity.field_media_image ?? item.entity.field_how_to_initial_image.entity.field_media_image %}
 			<div class="ucb-content-list-text-container{{ image ? ' col-9' : ' container' }}">
 				<h4 class="ucb-content-list-title"><a href="{{ item.entity.path.alias }}">{{ item.entity.title.0.value }}</a></h4>
@@ -52,13 +52,13 @@
 				{% set imageURI = image.entity.fileuri|image_style('focal_image_square') %}{% set imageAlt = image.alt|render %}
 				<a href="{{ item.entity.path.alias }}"><img class="ucb-content-list-image" src="{{ imageURI }}" alt="{{ imageAlt }}"></a>
 			{% endif %}</div>
-		</div>{% endfor %}{% elseif display == 'teaser' %}{% for key, item in content %}<div class="row ucb-content-list-row">
+		</div>{% endfor %}{% elseif display == 'condensed' or display == 'teaser' %}{% for key, item in content %}<div class="row ucb-content-list-row">
 			{% set image = item.entity.field_ucb_article_thumbnail.entity.field_media_image ?? item.entity.field_ucb_person_photo.entity.field_media_image ?? item.entity.field_how_to_initial_image.entity.field_media_image %}
-			<div class="ucb-content-list-image-container{{ image ? ' col-3' : '' }}">{% if image %}
+			<div class="ucb-content-list-image-container{{ image ? (display == 'condensed' ? ' col-2' : ' col-lg-3 col-2') : '' }}">{% if image %}
 				{% set imageURI = image.entity.fileuri|image_style('focal_image_square') %}{% set imageAlt = image.alt|render %}
 				<a href="{{ item.entity.path.alias }}"><img class="ucb-content-list-image" src="{{ imageURI }}" alt="{{ imageAlt }}"></a>
 			{% endif %}</div>
-			<div class="ucb-content-list-text-container{{ image ? ' col-9' : ' container' }}">
+			<div class="ucb-content-list-text-container{{ image ? (display == 'condensed' ? ' col-10' : ' col-lg-9 col-10') : ' container' }}">
 				<h4 class="ucb-content-list-title"><a href="{{ item.entity.path.alias }}">{{ item.entity.title.0.value }}</a></h4>
 				{% set summary = item.entity.body.0.summary ?? item.entity.field_ucb_article_summary.0.value %}
 				<p class="ucb-content-list-summary">{{ summary }} <a class="ucb-content-list-read-more" href="{{ item.entity.path.alias }}">Read more &raquo;</a></p>
@@ -69,10 +69,10 @@
 		{% endfor %}</ul>
 		{% elseif display == 'sidebar' %}{% for key, item in content %}<div class="row ucb-content-list-row">
 			{% set image = item.entity.field_ucb_article_thumbnail.entity.field_media_image ?? item.entity.field_ucb_person_photo.entity.field_media_image ?? item.entity.field_how_to_initial_image.entity.field_media_image %}
-			<div class="ucb-content-list-text-container{{ image ? ' col-9' : ' container' }}">
+			<div class="ucb-content-list-text-container{{ image ? ' col-lg-9 col-10' : ' container' }}">
 				<span class="ucb-content-list-title"><a href="{{ item.entity.path.alias }}">{{ item.entity.title.0.value }}</a></span>
 			</div>
-			<div class="ucb-content-list-image-container{{ image ? ' col-3' : '' }}">{% if image %}
+			<div class="ucb-content-list-image-container{{ image ? ' col-lg-3 col-2' : '' }}">{% if image %}
 				{% set imageURI = image.entity.fileuri|image_style('focal_image_square') %}{% set imageAlt = image.alt|render %}
 				<a href="{{ item.entity.path.alias }}"><img class="ucb-content-list-image" src="{{ imageURI }}" alt="{{ imageAlt }}"></a>
 			{% endif %}</div>

--- a/templates/block/block--inline-block--content-list.html.twig
+++ b/templates/block/block--inline-block--content-list.html.twig
@@ -56,7 +56,7 @@
 				<a href="{{ item.entity.path.alias }}"><img class="ucb-content-list-image" src="{{ imageURI }}" alt="{{ imageAlt }}"></a>
 			{% endif %}</div>
 			<div class="col-9">
-				<h3 class="ucb-content-list-title"><a href="{{ item.entity.path.alias }}">{{ item.entity.title.0.value }}</a></h3>
+				<h4 class="ucb-content-list-title"><a href="{{ item.entity.path.alias }}">{{ item.entity.title.0.value }}</a></h4>
 				{% set summary = item.entity.body.0.summary ?? item.entity.field_ucb_article_summary.0.value %}
 				<p class="ucb-content-list-summary">{{ summary }} <a href="{{ item.entity.path.alias }}">Read&nbsp;more&nbsp;&raquo;</a></p>
 			</div>

--- a/templates/block/block--inline-block--content-list.html.twig
+++ b/templates/block/block--inline-block--content-list.html.twig
@@ -38,38 +38,38 @@
 	{% if label %}<h2{{ title_attributes }}>{{ label }}</h2>{% endif %}
 	{{ title_suffix }}
 	<div class="ucb-content-list-container">
-		{% if display == 'teaser' %}{% for key, item in content %}<div class="row ucb-content-list-row">
-			<div class="col-9">
+		{% if display == 'embed' %}{% for key, item in content %}<div class="row ucb-content-list-row">
+			{% set image = item.entity.field_ucb_article_thumbnail.entity.field_media_image ?? item.entity.field_ucb_person_photo.entity.field_media_image ?? item.entity.field_how_to_initial_image.entity.field_media_image %}
+			<div class="{{ image ? 'col-9' : 'container' }}">
 				<h4 class="ucb-content-list-title"><a href="{{ item.entity.path.alias }}">{{ item.entity.title.0.value }}</a></h4>
 				{% set summary = item.entity.body.0.summary ?? item.entity.field_ucb_article_summary.0.value %}
-				<p class="ucb-content-list-summary">{{ summary }} <a href="{{ item.entity.path.alias }}">Read&nbsp;more&nbsp;&raquo;</a></p>
+				<p class="ucb-content-list-summary">{{ summary }} <a class="ucb-content-list-read-more" href="{{ item.entity.path.alias }}">Read more &raquo;</a></p>
 			</div>
-			{% set image = item.entity.field_ucb_article_thumbnail.entity.field_media_image ?? item.entity.field_ucb_person_photo.entity.field_media_image ?? item.entity.field_how_to_initial_image.entity.field_media_image %}
-			<div class="ucb-content-list-image-container col-3{{ image ? '' : ' ucb-content-list-image-empty' }}">{% if image %}
+			<div class="ucb-content-list-image-container{{ image ? ' col-3' : '' }}">{% if image %}
 				{% set imageURI = image.entity.fileuri|image_style('focal_image_square') %}{% set imageAlt = image.alt|render %}
 				<a href="{{ item.entity.path.alias }}"><img class="ucb-content-list-image" src="{{ imageURI }}" alt="{{ imageAlt }}"></a>
 			{% endif %}</div>
-		</div>{% endfor %}{% elseif display == 'embed' %}{% for key, item in content %}<div class="row ucb-content-list-row">
+		</div>{% endfor %}{% elseif display == 'teaser' %}{% for key, item in content %}<div class="row ucb-content-list-row">
 			{% set image = item.entity.field_ucb_article_thumbnail.entity.field_media_image ?? item.entity.field_ucb_person_photo.entity.field_media_image ?? item.entity.field_how_to_initial_image.entity.field_media_image %}
-			<div class="ucb-content-list-image-container col-3{{ image ? '' : ' ucb-content-list-image-empty' }}">{% if image %}
+			<div class="ucb-content-list-image-container{{ image ? ' col-3' : '' }}">{% if image %}
 				{% set imageURI = image.entity.fileuri|image_style('focal_image_square') %}{% set imageAlt = image.alt|render %}
 				<a href="{{ item.entity.path.alias }}"><img class="ucb-content-list-image" src="{{ imageURI }}" alt="{{ imageAlt }}"></a>
 			{% endif %}</div>
-			<div class="col-9">
+			<div class="{{ image ? 'col-9' : 'container' }}">
 				<h4 class="ucb-content-list-title"><a href="{{ item.entity.path.alias }}">{{ item.entity.title.0.value }}</a></h4>
 				{% set summary = item.entity.body.0.summary ?? item.entity.field_ucb_article_summary.0.value %}
-				<p class="ucb-content-list-summary">{{ summary }} <a href="{{ item.entity.path.alias }}">Read&nbsp;more&nbsp;&raquo;</a></p>
+				<p class="ucb-content-list-summary">{{ summary }} <a class="ucb-content-list-read-more" href="{{ item.entity.path.alias }}">Read more &raquo;</a></p>
 			</div>
 		</div>{% endfor %}{% elseif display == 'title' %}
 		<ul>{% for key, item in content %}
 			<li class="ucb-content-list-row ucb-content-list-title"><a href="{{ item.entity.path.alias }}">{{ item.entity.title.0.value }}</a></li>
 		{% endfor %}</ul>
 		{% elseif display == 'sidebar' %}{% for key, item in content %}<div class="row ucb-content-list-row">
-			<div class="col-9">
+			{% set image = item.entity.field_ucb_article_thumbnail.entity.field_media_image ?? item.entity.field_ucb_person_photo.entity.field_media_image ?? item.entity.field_how_to_initial_image.entity.field_media_image %}
+			<div class="{{ image ? 'col-9' : 'container' }}">
 				<span class="ucb-content-list-title"><a href="{{ item.entity.path.alias }}">{{ item.entity.title.0.value }}</a></span>
 			</div>
-			{% set image = item.entity.field_ucb_article_thumbnail.entity.field_media_image ?? item.entity.field_ucb_person_photo.entity.field_media_image ?? item.entity.field_how_to_initial_image.entity.field_media_image %}
-			<div class="ucb-content-list-image-container col-3{{ image ? '' : ' ucb-content-list-image-empty' }}">{% if image %}
+			<div class="ucb-content-list-image-container{{ image ? ' col-3' : '' }}">{% if image %}
 				{% set imageURI = image.entity.fileuri|image_style('focal_image_square') %}{% set imageAlt = image.alt|render %}
 				<a href="{{ item.entity.path.alias }}"><img class="ucb-content-list-image" src="{{ imageURI }}" alt="{{ imageAlt }}"></a>
 			{% endif %}</div>

--- a/templates/block/block--inline-block--content-list.html.twig
+++ b/templates/block/block--inline-block--content-list.html.twig
@@ -10,6 +10,16 @@
 {% set blockContent = content['#block_content'] %}
 {% set sort = blockContent.field_content_list_sort.value %}
 {% set display = blockContent.field_content_list_display.value %}
+{% set content = blockContent.field_content_list_content %}
+
+{# sorting #}
+{% if sort == 'created_asc' %}
+	{% set content = content|sort((a, b) => a.entity.created.value <=> b.entity.created.value) %}
+{% elseif sort == 'created_desc' %}
+	{% set content = content|sort((a, b) => b.entity.created.value <=> a.entity.created.value) %}
+{% elseif sort == 'alphabetical' %}
+	{% set content = content|sort((a, b) => a.entity.title.0.value|trim <=> b.entity.title.0.value|trim) %}
+{% endif %}
 
 {%
 	set classes = [
@@ -28,7 +38,7 @@
 	{% if label %}<h2{{ title_attributes }}>{{ label }}</h2>{% endif %}
 	{{ title_suffix }}
 	<div class="ucb-content-list-container">
-		{% if display == 'teaser' %}{% for key, item in blockContent.field_content_list_content if key|first != '#' %}<div class="row ucb-content-list-row">
+		{% if display == 'teaser' %}{% for key, item in content %}<div class="row ucb-content-list-row">
 			<div class="col-9">
 				<h4 class="ucb-content-list-title"><a href="{{ item.entity.path.alias }}">{{ item.entity.title.0.value }}</a></h4>
 				{% set summary = item.entity.body.0.summary ?? item.entity.field_ucb_article_summary.0.value %}
@@ -39,7 +49,7 @@
 				{% set imageURI = image.entity.fileuri|image_style('focal_image_square') %}{% set imageAlt = image.alt|render %}
 				<a href="{{ item.entity.path.alias }}"><img class="ucb-content-list-image" src="{{ imageURI }}" alt="{{ imageAlt }}"></a>
 			{% endif %}</div>
-		</div>{% endfor %}{% elseif display == 'embed' %}{% for key, item in blockContent.field_content_list_content if key|first != '#' %}<div class="row ucb-content-list-row">
+		</div>{% endfor %}{% elseif display == 'embed' %}{% for key, item in content %}<div class="row ucb-content-list-row">
 			{% set image = item.entity.field_ucb_person_photo.entity.field_media_image ?? item.entity.field_ucb_article_thumbnail.entity.field_media_image %}
 			<div class="ucb-content-list-image-container col-3{{ image ? '' : ' ucb-content-list-image-empty' }}">{% if image %}
 				{% set imageURI = image.entity.fileuri|image_style('focal_image_square') %}{% set imageAlt = image.alt|render %}
@@ -51,10 +61,10 @@
 				<p class="ucb-content-list-summary">{{ summary }} <a href="{{ item.entity.path.alias }}">Read&nbsp;more&nbsp;&raquo;</a></p>
 			</div>
 		</div>{% endfor %}{% elseif display == 'title' %}
-		<ul>{% for key, item in blockContent.field_content_list_content if key|first != '#' %}
+		<ul>{% for key, item in content %}
 			<li class="ucb-content-list-row ucb-content-list-title"><a href="{{ item.entity.path.alias }}">{{ item.entity.title.0.value }}</a></li>
 		{% endfor %}</ul>
-		{% elseif display == 'sidebar' %}{% for key, item in blockContent.field_content_list_content if key|first != '#' %}<div class="row ucb-content-list-row">
+		{% elseif display == 'sidebar' %}{% for key, item in content %}<div class="row ucb-content-list-row">
 			<div class="col-9">
 				<span class="ucb-content-list-title"><a href="{{ item.entity.path.alias }}">{{ item.entity.title.0.value }}</a></span>
 			</div>

--- a/templates/block/block--inline-block--content-list.html.twig
+++ b/templates/block/block--inline-block--content-list.html.twig
@@ -1,0 +1,55 @@
+{#
+/**
+ * @file Template to implement the "Content List" block type
+ * @author Timur Tripp
+*/
+#}
+
+{#{ attach_library('boulderD9_base/ucb-content-list') }#}
+
+{% set blockContent = content['#block_content'] %}
+{% set sort = blockContent.field_content_list_sort.value %}
+{% set display = blockContent.field_content_list_display.value %}
+
+{%
+	set classes = [
+		'container',
+		'block',
+		'block-' ~ configuration.provider|clean_class,
+		'block-' ~ plugin_id|clean_class,
+		bundle ? 'block--type-' ~ bundle|clean_class,
+		view_mode ? 'block--view-mode-' ~ view_mode|clean_class,
+		'ucb-content-list-display-' ~ display
+	]
+%}
+
+{% block content %}<div{{ attributes.addClass(classes) }}>
+	{{ title_prefix }}
+	{% if label %}<h2{{ title_attributes }}>{{ label }}</h2>{% endif %}
+	{{ title_suffix }}
+	{% if display == 'teaser' %}{% for key, item in blockContent.field_content_list_content if key|first != '#' %}<div class="row ucb-content-list-row">
+		<div class="col-9">
+			<h3 class="ucb-content-list-header"><a href="{{ item.entity.path.alias }}">{{ item.entity.title.0.value }}</a></h3>
+			<p class="ucb-content-list-body">{{ item.entity.body.0.summary }}</p>
+		</div>
+		<div class="col-3">
+			{% set imageURI = item.entity.field_ucb_person_photo.entity.field_media_image.entity.fileuri|image_style('focal_image_square') %}
+			{% set imageAlt = item.entity.field_ucb_person_photo.entity.field_media_image.alt|render %}
+			<img class="ucb-content-list-image" src="{{ imageURI }}" alt="{{ imageAlt }}">
+		</div>
+	</div>{% endfor %}{% elseif display == 'embed' %}{% for key, item in blockContent.field_content_list_content if key|first != '#' %}<div class="row ucb-content-list-row">
+		<div class="col-2">
+			{% set imageURI = item.entity.field_ucb_person_photo.entity.field_media_image.entity.fileuri|image_style('focal_image_square') %}
+			{% set imageAlt = item.entity.field_ucb_person_photo.entity.field_media_image.alt|render %}
+			<img class="ucb-content-list-image" src="{{ imageURI }}" alt="{{ imageAlt }}">
+		</div>
+		<div class="col-9">
+			<h4 class="ucb-content-list-header"><a href="{{ item.entity.path.alias }}">{{ item.entity.title.0.value }}</a></h4>
+			<p class="ucb-content-list-body">{{ item.entity.body.0.summary }}</p>
+		</div>
+	</div>{% endfor %}{% elseif display == 'title' %}<ul>{% for key, item in blockContent.field_content_list_content if key|first != '#' %}
+		<li><a href="{{ item.entity.path.alias }}">{{ item.entity.title.0.value }}</a></li>
+	{% endfor %}</ul>
+	{% elseif display == 'sidebar' %}{# TODO Sidebar #}
+	{% endif %}
+</div>{% endblock content %}

--- a/templates/block/block--inline-block--content-list.html.twig
+++ b/templates/block/block--inline-block--content-list.html.twig
@@ -44,13 +44,13 @@
 				{% set summary = item.entity.body.0.summary ?? item.entity.field_ucb_article_summary.0.value %}
 				<p class="ucb-content-list-summary">{{ summary }} <a href="{{ item.entity.path.alias }}">Read&nbsp;more&nbsp;&raquo;</a></p>
 			</div>
-			{% set image = item.entity.field_ucb_person_photo.entity.field_media_image ?? item.entity.field_ucb_article_thumbnail.entity.field_media_image %}
+			{% set image = item.entity.field_ucb_article_thumbnail.entity.field_media_image ?? item.entity.field_ucb_person_photo.entity.field_media_image ?? item.entity.field_how_to_initial_image.entity.field_media_image %}
 			<div class="ucb-content-list-image-container col-3{{ image ? '' : ' ucb-content-list-image-empty' }}">{% if image %}
 				{% set imageURI = image.entity.fileuri|image_style('focal_image_square') %}{% set imageAlt = image.alt|render %}
 				<a href="{{ item.entity.path.alias }}"><img class="ucb-content-list-image" src="{{ imageURI }}" alt="{{ imageAlt }}"></a>
 			{% endif %}</div>
 		</div>{% endfor %}{% elseif display == 'embed' %}{% for key, item in content %}<div class="row ucb-content-list-row">
-			{% set image = item.entity.field_ucb_person_photo.entity.field_media_image ?? item.entity.field_ucb_article_thumbnail.entity.field_media_image %}
+			{% set image = item.entity.field_ucb_article_thumbnail.entity.field_media_image ?? item.entity.field_ucb_person_photo.entity.field_media_image ?? item.entity.field_how_to_initial_image.entity.field_media_image %}
 			<div class="ucb-content-list-image-container col-3{{ image ? '' : ' ucb-content-list-image-empty' }}">{% if image %}
 				{% set imageURI = image.entity.fileuri|image_style('focal_image_square') %}{% set imageAlt = image.alt|render %}
 				<a href="{{ item.entity.path.alias }}"><img class="ucb-content-list-image" src="{{ imageURI }}" alt="{{ imageAlt }}"></a>
@@ -68,7 +68,7 @@
 			<div class="col-9">
 				<span class="ucb-content-list-title"><a href="{{ item.entity.path.alias }}">{{ item.entity.title.0.value }}</a></span>
 			</div>
-			{% set image = item.entity.field_ucb_person_photo.entity.field_media_image ?? item.entity.field_ucb_article_thumbnail.entity.field_media_image %}
+			{% set image = item.entity.field_ucb_article_thumbnail.entity.field_media_image ?? item.entity.field_ucb_person_photo.entity.field_media_image ?? item.entity.field_how_to_initial_image.entity.field_media_image %}
 			<div class="ucb-content-list-image-container col-3{{ image ? '' : ' ucb-content-list-image-empty' }}">{% if image %}
 				{% set imageURI = image.entity.fileuri|image_style('focal_image_square') %}{% set imageAlt = image.alt|render %}
 				<a href="{{ item.entity.path.alias }}"><img class="ucb-content-list-image" src="{{ imageURI }}" alt="{{ imageAlt }}"></a>

--- a/templates/block/block--inline-block--content-list.html.twig
+++ b/templates/block/block--inline-block--content-list.html.twig
@@ -5,7 +5,7 @@
 */
 #}
 
-{#{ attach_library('boulderD9_base/ucb-content-list') }#}
+{{ attach_library('boulderD9_base/ucb-content-list') }}
 
 {% set blockContent = content['#block_content'] %}
 {% set sort = blockContent.field_content_list_sort.value %}
@@ -27,29 +27,31 @@
 	{{ title_prefix }}
 	{% if label %}<h2{{ title_attributes }}>{{ label }}</h2>{% endif %}
 	{{ title_suffix }}
-	{% if display == 'teaser' %}{% for key, item in blockContent.field_content_list_content if key|first != '#' %}<div class="row ucb-content-list-row">
-		<div class="col-9">
-			<h3 class="ucb-content-list-header"><a href="{{ item.entity.path.alias }}">{{ item.entity.title.0.value }}</a></h3>
-			<p class="ucb-content-list-body">{{ item.entity.body.0.summary }}</p>
-		</div>
-		<div class="col-3">
-			{% set imageURI = item.entity.field_ucb_person_photo.entity.field_media_image.entity.fileuri|image_style('focal_image_square') %}
-			{% set imageAlt = item.entity.field_ucb_person_photo.entity.field_media_image.alt|render %}
-			<img class="ucb-content-list-image" src="{{ imageURI }}" alt="{{ imageAlt }}">
-		</div>
-	</div>{% endfor %}{% elseif display == 'embed' %}{% for key, item in blockContent.field_content_list_content if key|first != '#' %}<div class="row ucb-content-list-row">
-		<div class="col-2">
-			{% set imageURI = item.entity.field_ucb_person_photo.entity.field_media_image.entity.fileuri|image_style('focal_image_square') %}
-			{% set imageAlt = item.entity.field_ucb_person_photo.entity.field_media_image.alt|render %}
-			<img class="ucb-content-list-image" src="{{ imageURI }}" alt="{{ imageAlt }}">
-		</div>
-		<div class="col-9">
-			<h4 class="ucb-content-list-header"><a href="{{ item.entity.path.alias }}">{{ item.entity.title.0.value }}</a></h4>
-			<p class="ucb-content-list-body">{{ item.entity.body.0.summary }}</p>
-		</div>
-	</div>{% endfor %}{% elseif display == 'title' %}<ul>{% for key, item in blockContent.field_content_list_content if key|first != '#' %}
-		<li><a href="{{ item.entity.path.alias }}">{{ item.entity.title.0.value }}</a></li>
-	{% endfor %}</ul>
-	{% elseif display == 'sidebar' %}{# TODO Sidebar #}
-	{% endif %}
+	<div class="ucb-content-list-container">
+		{% if display == 'teaser' %}{% for key, item in blockContent.field_content_list_content if key|first != '#' %}<div class="row ucb-content-list-row">
+			<div class="col-9">
+				<h4 class="ucb-content-list-title"><a href="{{ item.entity.path.alias }}">{{ item.entity.title.0.value }}</a></h4>
+				{% set summary = item.entity.body.0.summary %}{% if summary %}<p class="ucb-content-list-summary">{{ summary }}</p>{% endif %}
+			</div>
+			{% set image = item.entity.field_ucb_person_photo.entity.field_media_image %}
+			<div class="ucb-content-list-image-container col-3{{ image ? '' : ' ucb-content-list-image-empty' }}">{% if image %}
+				{% set imageURI = image.entity.fileuri|image_style('focal_image_square') %}{% set imageAlt = image.alt|render %}
+				<img class="ucb-content-list-image" src="{{ imageURI }}" alt="{{ imageAlt }}">
+			{% endif %}</div>
+		</div>{% endfor %}{% elseif display == 'embed' %}{% for key, item in blockContent.field_content_list_content if key|first != '#' %}<div class="row ucb-content-list-row">
+			{% set image = item.entity.field_ucb_person_photo.entity.field_media_image %}
+			<div class="ucb-content-list-image-container col-2{{ image ? '' : ' ucb-content-list-image-empty' }}">{% if image %}
+				{% set imageURI = image.entity.fileuri|image_style('focal_image_square') %}{% set imageAlt = image.alt|render %}
+				<img class="ucb-content-list-image" src="{{ imageURI }}" alt="{{ imageAlt }}">
+			{% endif %}</div>
+			<div class="col-9">
+				<h4 class="ucb-content-list-title"><a href="{{ item.entity.path.alias }}">{{ item.entity.title.0.value }}</a></h4>
+				{% set summary = item.entity.body.0.summary %}{% if summary %}<p class="ucb-content-list-summary">{{ summary }}</p>{% endif %}
+			</div>
+		</div>{% endfor %}{% elseif display == 'title' %}<ul>{% for key, item in blockContent.field_content_list_content if key|first != '#' %}
+			<li class="ucb-content-list-row ucb-content-list-title"><a href="{{ item.entity.path.alias }}">{{ item.entity.title.0.value }}</a></li>
+		{% endfor %}</ul>
+		{% elseif display == 'sidebar' %}{# TODO Sidebar #}
+		{% endif %}
+	</div>
 </div>{% endblock content %}

--- a/templates/block/block--inline-block--content-list.html.twig
+++ b/templates/block/block--inline-block--content-list.html.twig
@@ -29,7 +29,10 @@
 		'block-' ~ plugin_id|clean_class,
 		bundle ? 'block--type-' ~ bundle|clean_class,
 		view_mode ? 'block--view-mode-' ~ view_mode|clean_class,
-		'ucb-content-list-display-' ~ display
+		'ucb-content-list',
+		'ucb-content-list-display-' ~ display,
+		display == 'teaser' ? 'background-gray-light',
+		display == 'sidebar' ? 'background-gray-dark'
 	]
 %}
 
@@ -40,7 +43,7 @@
 	<div class="ucb-content-list-container">
 		{% if display == 'embed' %}{% for key, item in content %}<div class="row ucb-content-list-row">
 			{% set image = item.entity.field_ucb_article_thumbnail.entity.field_media_image ?? item.entity.field_ucb_person_photo.entity.field_media_image ?? item.entity.field_how_to_initial_image.entity.field_media_image %}
-			<div class="{{ image ? 'col-9' : 'container' }}">
+			<div class="ucb-content-list-text-container{{ image ? ' col-9' : ' container' }}">
 				<h4 class="ucb-content-list-title"><a href="{{ item.entity.path.alias }}">{{ item.entity.title.0.value }}</a></h4>
 				{% set summary = item.entity.body.0.summary ?? item.entity.field_ucb_article_summary.0.value %}
 				<p class="ucb-content-list-summary">{{ summary }} <a class="ucb-content-list-read-more" href="{{ item.entity.path.alias }}">Read more &raquo;</a></p>
@@ -55,18 +58,18 @@
 				{% set imageURI = image.entity.fileuri|image_style('focal_image_square') %}{% set imageAlt = image.alt|render %}
 				<a href="{{ item.entity.path.alias }}"><img class="ucb-content-list-image" src="{{ imageURI }}" alt="{{ imageAlt }}"></a>
 			{% endif %}</div>
-			<div class="{{ image ? 'col-9' : 'container' }}">
+			<div class="ucb-content-list-text-container{{ image ? ' col-9' : ' container' }}">
 				<h4 class="ucb-content-list-title"><a href="{{ item.entity.path.alias }}">{{ item.entity.title.0.value }}</a></h4>
 				{% set summary = item.entity.body.0.summary ?? item.entity.field_ucb_article_summary.0.value %}
 				<p class="ucb-content-list-summary">{{ summary }} <a class="ucb-content-list-read-more" href="{{ item.entity.path.alias }}">Read more &raquo;</a></p>
 			</div>
 		</div>{% endfor %}{% elseif display == 'title' %}
-		<ul>{% for key, item in content %}
+		<ul class="ucb-content-list-list">{% for key, item in content %}
 			<li class="ucb-content-list-row ucb-content-list-title"><a href="{{ item.entity.path.alias }}">{{ item.entity.title.0.value }}</a></li>
 		{% endfor %}</ul>
 		{% elseif display == 'sidebar' %}{% for key, item in content %}<div class="row ucb-content-list-row">
 			{% set image = item.entity.field_ucb_article_thumbnail.entity.field_media_image ?? item.entity.field_ucb_person_photo.entity.field_media_image ?? item.entity.field_how_to_initial_image.entity.field_media_image %}
-			<div class="{{ image ? 'col-9' : 'container' }}">
+			<div class="ucb-content-list-text-container{{ image ? ' col-9' : ' container' }}">
 				<span class="ucb-content-list-title"><a href="{{ item.entity.path.alias }}">{{ item.entity.title.0.value }}</a></span>
 			</div>
 			<div class="ucb-content-list-image-container{{ image ? ' col-3' : '' }}">{% if image %}


### PR DESCRIPTION
Resolves #166

The _Content List_ block type can be used to display a fixed list of content which can be any mixture of any of the following pages: 
- _Article_
- _Person_
- _How-To_
- _Basic Page_ (thumbnail image not supported)

Display options exist that can change the stylization of the block. These are:
- _Full_ (equivalent to _Embed_ in D7 Express)
- _Compact_ (equivalent to the stylization of the _Content List Page_ in D7 Express)
- _Teaser_
- _Title_
- _Sidebar_

As in D7 Express, content can be sorted by:
- _Custom_
- _Date created (newest first)_
- _Date created (oldest first)_
- _Alphabetical_

The _Content List Page_ node type can be replaced using this block added to a _Basic Page_ using Layout Builder.

Sister PR in: [tiamat-custom-entites](https://github.com/CuBoulder/tiamat-custom-entities/pull/28) (merge that one first)