### PR TITLE
Issue/188

### DIFF
--- a/templates/block/block--inline-block--content-grid.html.twig
+++ b/templates/block/block--inline-block--content-grid.html.twig
@@ -45,20 +45,20 @@
 		{# Column Grid Layout #}
 		{% if layoutSelection == 0 %}
 			<div class="row row-cols-lg-{{ columnNumbers }} row-cols-md-2 row-cols-1 justify-content-evenly">
-				{% for key, item in content['#block_content'].field_grid_layout_content if key|first != '#' %}
+				{% for child in content['#block_content'].field_grid_layout_content|children %}
 					{% if imgStyle == "square-img" %}
-						{% set imgUrl = item.entity.field_grid_layout_content_image.entity.field_media_image.entity.fileuri|image_style('focal_image_square') %}
-						{% set imgAlt = item.entity.field_grid_layout_content_image.entity.field_media_image.alt|render %}
+						{% set imgUrl = child.entity.field_grid_layout_content_image.entity.field_media_image.entity.fileuri|image_style('focal_image_square') %}
+						{% set imgAlt = child.entity.field_grid_layout_content_image.entity.field_media_image.alt|render %}
 					{% else %}
-						{% set imgUrl = item.entity.field_grid_layout_content_image.entity.field_media_image.entity.fileuri|image_style('focal_image_wide') %}
-						{% set imgAlt = item.entity.field_grid_layout_content_image.entity.field_media_image.alt|render %}
+						{% set imgUrl = child.entity.field_grid_layout_content_image.entity.field_media_image.entity.fileuri|image_style('focal_image_wide') %}
+						{% set imgAlt = child.entity.field_grid_layout_content_image.entity.field_media_image.alt|render %}
 					{% endif %}
-					{% set gridLink = item.entity.field_grid_layout_content_link.0.url|render %}
+					{% set gridLink = child.entity.field_grid_layout_content_link.0.url|render %}
 					<div class="col">
 						<div class="grid-column">
-							{% if item.entity.field_grid_layout_content_image|view %}
+							{% if child.entity.field_grid_layout_content_image|view %}
 								<div class="grid-image-container grid-fill {{ imgStyle }}">
-									{% if item.entity.field_grid_layout_content_link.0.url|render %}
+									{% if child.entity.field_grid_layout_content_link.0.url|render %}
 										<a href=" {{ gridLink }} ">
 											<img src="{{ imgUrl }}" alt="{{ imgAlt }}"/>
 										</a>
@@ -67,16 +67,16 @@
 									{% endif %}
 								</div>
 							{% endif %}
-							{% if (item.entity.field_grid_layout_content_title.value|render|striptags|trim) or (item.entity.field_grid_layout_content_text|view) %}
+							{% if (child.entity.field_grid_layout_content_title.value|render|striptags|trim) or (child.entity.field_grid_layout_content_text|view) %}
 								<div class="grid-text-container">
-									{% if item.entity.field_grid_layout_content_link.0.url|render %}
+									{% if child.entity.field_grid_layout_content_link.0.url|render %}
 										<a href=" {{ gridLink }} ">
-											<h3>{{item.entity.field_grid_layout_content_title.value|render|striptags|trim}}</h3>
+											<h3>{{child.entity.field_grid_layout_content_title.value|render|striptags|trim}}</h3>
 										</a>
 									{% else %}
-										<h3>{{item.entity.field_grid_layout_content_title.value|render|striptags|trim}}</h3>
+										<h3>{{child.entity.field_grid_layout_content_title.value|render|striptags|trim}}</h3>
 									{% endif %}
-									{{item.entity.field_grid_layout_content_text|view}}
+									{{child.entity.field_grid_layout_content_text|view}}
 								</div>
 							{% endif %}
 						</div>
@@ -86,20 +86,20 @@
 			{# Card Grid Layout #}
 		{% elseif layoutSelection == 1 %}
 			<div class="row row-cols-lg-{{ columnNumbers }} row-cols-md-2 row-cols-1 justify-content-evenly">
-				{% for key, item in content['#block_content'].field_grid_layout_content if key|first != '#' %}
+				{% for child in content['#block_content'].field_grid_layout_content|children %}
 					{% if imgStyle == "square-img" %}
-						{% set imgUrl = item.entity.field_grid_layout_content_image.entity.field_media_image.entity.fileuri|image_style('focal_image_square') %}
-						{% set imgAlt = item.entity.field_grid_layout_content_image.entity.field_media_image.alt|render %}
+						{% set imgUrl = child.entity.field_grid_layout_content_image.entity.field_media_image.entity.fileuri|image_style('focal_image_square') %}
+						{% set imgAlt = child.entity.field_grid_layout_content_image.entity.field_media_image.alt|render %}
 					{% else %}
-						{% set imgUrl = item.entity.field_grid_layout_content_image.entity.field_media_image.entity.fileuri|image_style('focal_image_wide') %}
-						{% set imgAlt = item.entity.field_grid_layout_content_image.entity.field_media_image.alt|render %}
+						{% set imgUrl = child.entity.field_grid_layout_content_image.entity.field_media_image.entity.fileuri|image_style('focal_image_wide') %}
+						{% set imgAlt = child.entity.field_grid_layout_content_image.entity.field_media_image.alt|render %}
 					{% endif %}
-					{% set gridLink = item.entity.field_grid_layout_content_link.0.url|render %}
+					{% set gridLink = child.entity.field_grid_layout_content_link.0.url|render %}
 					<div class="col">
 						<div class="grid-card">
-							{% if item.entity.field_grid_layout_content_image|view %}
+							{% if child.entity.field_grid_layout_content_image|view %}
 								<div class="grid-image-container grid-fill {{ imgStyle }}">
-									{% if item.entity.field_grid_layout_content_link.0.url|render %}
+									{% if child.entity.field_grid_layout_content_link.0.url|render %}
 										<a href=" {{ gridLink }} ">
 											<img src="{{ imgUrl }}" alt="{{ imgAlt }}"/>
 										</a>
@@ -108,16 +108,16 @@
 									{% endif %}
 								</div>
 							{% endif %}
-							{% if (item.entity.field_grid_layout_content_title.value|render|striptags|trim) or (item.entity.field_grid_layout_content_text|view) %}
+							{% if (child.entity.field_grid_layout_content_title.value|render|striptags|trim) or (child.entity.field_grid_layout_content_text|view) %}
 								<div class="grid-text-container">
-									{% if item.entity.field_grid_layout_content_link.0.url|render %}
+									{% if child.entity.field_grid_layout_content_link.0.url|render %}
 										<a href=" {{ gridLink }} ">
-											<h3>{{item.entity.field_grid_layout_content_title.value|render|striptags|trim}}</h3>
+											<h3>{{child.entity.field_grid_layout_content_title.value|render|striptags|trim}}</h3>
 										</a>
 									{% else %}
-										<h3>{{item.entity.field_grid_layout_content_title.value|render|striptags|trim}}</h3>
+										<h3>{{child.entity.field_grid_layout_content_title.value|render|striptags|trim}}</h3>
 									{% endif %}
-									{{item.entity.field_grid_layout_content_text|view}}
+									{{child.entity.field_grid_layout_content_text|view}}
 								</div>
 							{% endif %}
 						</div>
@@ -127,33 +127,33 @@
 			{# Overlay Grid Layout #}
 		{% elseif layoutSelection == 2 %}
 			<div class="row row-cols-lg-{{ columnNumbers }} row-cols-md-2 row-cols-1 justify-content-evenly">
-				{% for key, item in content['#block_content'].field_grid_layout_content if key|first != '#' %}
+				{% for child in content['#block_content'].field_grid_layout_content|children %}
 					{% if imgStyle == "square-img" %}
-						{% set imgUrl = item.entity.field_grid_layout_content_image.entity.field_media_image.entity.fileuri|image_style('focal_image_square') %}
-						{% set imgAlt = item.entity.field_grid_layout_content_image.entity.field_media_image.alt|render %}
+						{% set imgUrl = child.entity.field_grid_layout_content_image.entity.field_media_image.entity.fileuri|image_style('focal_image_square') %}
+						{% set imgAlt = child.entity.field_grid_layout_content_image.entity.field_media_image.alt|render %}
 					{% else %}
-						{% set imgUrl = item.entity.field_grid_layout_content_image.entity.field_media_image.entity.fileuri|image_style('focal_image_wide') %}
-						{% set imgAlt = item.entity.field_grid_layout_content_image.entity.field_media_image.alt|render %}
+						{% set imgUrl = child.entity.field_grid_layout_content_image.entity.field_media_image.entity.fileuri|image_style('focal_image_wide') %}
+						{% set imgAlt = child.entity.field_grid_layout_content_image.entity.field_media_image.alt|render %}
 					{% endif %}
-					{% set gridLink = item.entity.field_grid_layout_content_link.0.url|render %}
+					{% set gridLink = child.entity.field_grid_layout_content_link.0.url|render %}
 					<div class="col">
 						<div class="grid-column">
-							{% if item.entity.field_grid_layout_content_image|view %}
+							{% if child.entity.field_grid_layout_content_image|view %}
 								<div class="overlay-grid-image-container grid-fill {{ imgStyle }}">
-									{% if item.entity.field_grid_layout_content_link.0.url|render %}
+									{% if child.entity.field_grid_layout_content_link.0.url|render %}
 										<a href=" {{ gridLink }} ">
 											<img src="{{ imgUrl }}" alt="{{ imgAlt }}"/>
-											<h3>{{item.entity.field_grid_layout_content_title.value|render|striptags|trim}}</h3>
+											<h3>{{child.entity.field_grid_layout_content_title.value|render|striptags|trim}}</h3>
 										</a>
 									{% else %}
 										<img src="{{ imgUrl }}" alt="{{ imgAlt }}"/>
-										<h3>{{item.entity.field_grid_layout_content_title.value|render|striptags|trim}}</h3>
+										<h3>{{child.entity.field_grid_layout_content_title.value|render|striptags|trim}}</h3>
 									{% endif %}
 								</div>
 							{% endif %}
-							{% if item.entity.field_grid_layout_content_text|view %}
+							{% if child.entity.field_grid_layout_content_text|view %}
 								<div class="overlay-grid-text">
-									{{item.entity.field_grid_layout_content_text|view}}
+									{{child.entity.field_grid_layout_content_text|view}}
 								</div>
 							{% endif %}
 						</div>
@@ -163,21 +163,21 @@
 			{# Offset Grid Layout #}
 		{% else %}
 			<div class="row row-cols-lg-2 row-cols-1">
-				{% for key, item in content['#block_content'].field_grid_layout_content if key|first != '#' %}
+				{% for child in content['#block_content'].field_grid_layout_content|children %}
 					{% if imgStyle == "square-img" %}
-						{% set imgUrl = item.entity.field_grid_layout_content_image.entity.field_media_image.entity.fileuri|image_style('focal_image_square') %}
-						{% set imgAlt = item.entity.field_grid_layout_content_image.entity.field_media_image.alt|render %}
+						{% set imgUrl = child.entity.field_grid_layout_content_image.entity.field_media_image.entity.fileuri|image_style('focal_image_square') %}
+						{% set imgAlt = child.entity.field_grid_layout_content_image.entity.field_media_image.alt|render %}
 					{% else %}
-						{% set imgUrl = item.entity.field_grid_layout_content_image.entity.field_media_image.entity.fileuri|image_style('focal_image_wide') %}
-						{% set imgAlt = item.entity.field_grid_layout_content_image.entity.field_media_image.alt|render %}
+						{% set imgUrl = child.entity.field_grid_layout_content_image.entity.field_media_image.entity.fileuri|image_style('focal_image_wide') %}
+						{% set imgAlt = child.entity.field_grid_layout_content_image.entity.field_media_image.alt|render %}
 					{% endif %}
-					{% set gridLink = item.entity.field_grid_layout_content_link.0.url|render %}
+					{% set gridLink = child.entity.field_grid_layout_content_link.0.url|render %}
 					{% if (loop.index0 % 3 == 0) and ((loop.index0 is even) or (loop.index0 == 0)) %}
 						<div class="col">
 							<div class="grid-image-container-large">
-								{% if item.entity.field_grid_layout_content_image|view %}
+								{% if child.entity.field_grid_layout_content_image|view %}
 									<div class="grid-image-container grid-fill {{ imgStyle }}">
-										{% if item.entity.field_grid_layout_content_link.0.url|render %}
+										{% if child.entity.field_grid_layout_content_link.0.url|render %}
 											<a href=" {{ gridLink }} ">
 												<img src="{{ imgUrl }}" alt="{{ imgAlt }}"/>
 											</a>
@@ -186,16 +186,16 @@
 										{% endif %}
 									</div>
 								{% endif %}
-								{% if (item.entity.field_grid_layout_content_title.value|render|striptags|trim) or (item.entity.field_grid_layout_content_text|view) %}
+								{% if (child.entity.field_grid_layout_content_title.value|render|striptags|trim) or (child.entity.field_grid_layout_content_text|view) %}
 									<div class="grid-text-container">
-										{% if item.entity.field_grid_layout_content_link.0.url|render %}
+										{% if child.entity.field_grid_layout_content_link.0.url|render %}
 											<a href=" {{ gridLink }} ">
-												<h3>{{item.entity.field_grid_layout_content_title.value|render|striptags|trim}}</h3>
+												<h3>{{child.entity.field_grid_layout_content_title.value|render|striptags|trim}}</h3>
 											</a>
 										{% else %}
-											<h3>{{item.entity.field_grid_layout_content_title.value|render|striptags|trim}}</h3>
+											<h3>{{child.entity.field_grid_layout_content_title.value|render|striptags|trim}}</h3>
 										{% endif %}
-										{{item.entity.field_grid_layout_content_text|view}}
+										{{child.entity.field_grid_layout_content_text|view}}
 									</div>
 								{% endif %}
 							</div>
@@ -203,9 +203,9 @@
 					{% elseif (loop.index % 3 == 0) and (loop.index != 3) and (loop.index0 is odd) %}
 						<div class="col">
 							<div class="grid-image-container-large">
-								{% if item.entity.field_grid_layout_content_image|view %}
+								{% if child.entity.field_grid_layout_content_image|view %}
 									<div class="grid-image-container grid-fill {{ imgStyle }}">
-										{% if item.entity.field_grid_layout_content_link.0.url|render %}
+										{% if child.entity.field_grid_layout_content_link.0.url|render %}
 											<a href=" {{ gridLink }} ">
 												<img src="{{ imgUrl }}" alt="{{ imgAlt }}"/>
 											</a>
@@ -214,16 +214,16 @@
 										{% endif %}
 									</div>
 								{% endif %}
-								{% if (item.entity.field_grid_layout_content_title.value|render|striptags|trim) or (item.entity.field_grid_layout_content_text|view) %}
+								{% if (child.entity.field_grid_layout_content_title.value|render|striptags|trim) or (child.entity.field_grid_layout_content_text|view) %}
 									<div class="grid-text-container">
-										{% if item.entity.field_grid_layout_content_link.0.url|render %}
+										{% if child.entity.field_grid_layout_content_link.0.url|render %}
 											<a href=" {{ gridLink }} ">
-												<h3>{{item.entity.field_grid_layout_content_title.value|render|striptags|trim}}</h3>
+												<h3>{{child.entity.field_grid_layout_content_title.value|render|striptags|trim}}</h3>
 											</a>
 										{% else %}
-											<h3>{{item.entity.field_grid_layout_content_title.value|render|striptags|trim}}</h3>
+											<h3>{{child.entity.field_grid_layout_content_title.value|render|striptags|trim}}</h3>
 										{% endif %}
-										{{item.entity.field_grid_layout_content_text|view}}
+										{{child.entity.field_grid_layout_content_text|view}}
 									</div>
 								{% endif %}
 							</div>
@@ -231,9 +231,9 @@
 					{% else %}
 						<div class="col-lg-3 col-md-6 col">
 							<div class="grid-image-container-small">
-								{% if item.entity.field_grid_layout_content_image|view %}
+								{% if child.entity.field_grid_layout_content_image|view %}
 									<div class="grid-image-container grid-fill {{ imgStyle }}">
-										{% if item.entity.field_grid_layout_content_image|view %}
+										{% if child.entity.field_grid_layout_content_image|view %}
 											<a href=" {{ gridLink }} ">
 												<img src="{{ imgUrl }}" alt="{{ imgAlt }}"/>
 											</a>
@@ -242,16 +242,16 @@
 										{% endif %}
 									</div>
 								{% endif %}
-								{% if (item.entity.field_grid_layout_content_title.value|render|striptags|trim) or (item.entity.field_grid_layout_content_text|view) %}
+								{% if (child.entity.field_grid_layout_content_title.value|render|striptags|trim) or (child.entity.field_grid_layout_content_text|view) %}
 									<div class="grid-text-container">
-										{% if item.entity.field_grid_layout_content_link.0.url|render %}
+										{% if child.entity.field_grid_layout_content_link.0.url|render %}
 											<a href=" {{ gridLink }} ">
-												<h3>{{item.entity.field_grid_layout_content_title.value|render|striptags|trim}}</h3>
+												<h3>{{child.entity.field_grid_layout_content_title.value|render|striptags|trim}}</h3>
 											</a>
 										{% else %}
-											<h3>{{item.entity.field_grid_layout_content_title.value|render|striptags|trim}}</h3>
+											<h3>{{child.entity.field_grid_layout_content_title.value|render|striptags|trim}}</h3>
 										{% endif %}
-										{{item.entity.field_grid_layout_content_text|view}}
+										{{child.entity.field_grid_layout_content_text|view}}
 									</div>
 								{% endif %}
 							</div>

--- a/templates/block/block--inline-block--content-grid.html.twig
+++ b/templates/block/block--inline-block--content-grid.html.twig
@@ -45,6 +45,7 @@
 		{# Column Grid Layout #}
 		{% if layoutSelection == 0 %}
 			<div class="row row-cols-lg-{{ columnNumbers }} row-cols-md-2 row-cols-1 justify-content-evenly">
+<<<<<<< Updated upstream
 				{% for child in content['#block_content'].field_grid_layout_content|children %}
 					{% if imgStyle == "square-img" %}
 						{% set imgUrl = child.entity.field_grid_layout_content_image.entity.field_media_image.entity.fileuri|image_style('focal_image_square') %}
@@ -176,6 +177,21 @@
 						<div class="col">
 							<div class="grid-image-container-large">
 								{% if child.entity.field_grid_layout_content_image|view %}
+=======
+				{% for key, item in content['#block_content'].field_grid_layout_content %}
+					{%  if key|first != '#' %}
+						{% if imgStyle == "square-img" %}
+							{% set imgUrl = item.entity.field_grid_layout_content_image.entity.field_media_image.entity.fileuri|image_style('focal_image_square') %}
+							{% set imgAlt = item.entity.field_grid_layout_content_image.entity.field_media_image.alt|render %}
+						{% else %}
+							{% set imgUrl = item.entity.field_grid_layout_content_image.entity.field_media_image.entity.fileuri|image_style('focal_image_wide') %}
+							{% set imgAlt = item.entity.field_grid_layout_content_image.entity.field_media_image.alt|render %}
+						{% endif %}
+						{% set gridLink = item.entity.field_grid_layout_content_link.0.url|render %}
+						<div class="col">
+							<div class="grid-column">
+								{% if item.entity.field_grid_layout_content_image|view %}
+>>>>>>> Stashed changes
 									<div class="grid-image-container grid-fill {{ imgStyle }}">
 										{% if child.entity.field_grid_layout_content_link.0.url|render %}
 											<a href=" {{ gridLink }} ">
@@ -200,10 +216,30 @@
 								{% endif %}
 							</div>
 						</div>
-					{% elseif (loop.index % 3 == 0) and (loop.index != 3) and (loop.index0 is odd) %}
+					{% endif %}
+				{% endfor %}
+			</div>
+			{# Card Grid Layout #}
+		{% elseif layoutSelection == 1 %}
+			<div class="row row-cols-lg-{{ columnNumbers }} row-cols-md-2 row-cols-1 justify-content-evenly">
+				{% for key, item in content['#block_content'].field_grid_layout_content %}
+					{%  if key|first != '#' %}
+						{% if imgStyle == "square-img" %}
+							{% set imgUrl = item.entity.field_grid_layout_content_image.entity.field_media_image.entity.fileuri|image_style('focal_image_square') %}
+							{% set imgAlt = item.entity.field_grid_layout_content_image.entity.field_media_image.alt|render %}
+						{% else %}
+							{% set imgUrl = item.entity.field_grid_layout_content_image.entity.field_media_image.entity.fileuri|image_style('focal_image_wide') %}
+							{% set imgAlt = item.entity.field_grid_layout_content_image.entity.field_media_image.alt|render %}
+						{% endif %}
+						{% set gridLink = item.entity.field_grid_layout_content_link.0.url|render %}
 						<div class="col">
+<<<<<<< Updated upstream
 							<div class="grid-image-container-large">
 								{% if child.entity.field_grid_layout_content_image|view %}
+=======
+							<div class="grid-card">
+								{% if item.entity.field_grid_layout_content_image|view %}
+>>>>>>> Stashed changes
 									<div class="grid-image-container grid-fill {{ imgStyle }}">
 										{% if child.entity.field_grid_layout_content_link.0.url|render %}
 											<a href=" {{ gridLink }} ">
@@ -228,20 +264,47 @@
 								{% endif %}
 							</div>
 						</div>
+<<<<<<< Updated upstream
 					{% else %}
 						<div class="col-lg-3 col-md-6 col">
 							<div class="grid-image-container-small">
 								{% if child.entity.field_grid_layout_content_image|view %}
 									<div class="grid-image-container grid-fill {{ imgStyle }}">
 										{% if child.entity.field_grid_layout_content_image|view %}
+=======
+					{% endif %}
+				{% endfor %}
+			</div>
+			{# Overlay Grid Layout #}
+		{% elseif layoutSelection == 2 %}
+			<div class="row row-cols-lg-{{ columnNumbers }} row-cols-md-2 row-cols-1 justify-content-evenly">
+				{% for key, item in content['#block_content'].field_grid_layout_content %}
+					{%  if key|first != '#' %}
+						{% if imgStyle == "square-img" %}
+							{% set imgUrl = item.entity.field_grid_layout_content_image.entity.field_media_image.entity.fileuri|image_style('focal_image_square') %}
+							{% set imgAlt = item.entity.field_grid_layout_content_image.entity.field_media_image.alt|render %}
+						{% else %}
+							{% set imgUrl = item.entity.field_grid_layout_content_image.entity.field_media_image.entity.fileuri|image_style('focal_image_wide') %}
+							{% set imgAlt = item.entity.field_grid_layout_content_image.entity.field_media_image.alt|render %}
+						{% endif %}
+						{% set gridLink = item.entity.field_grid_layout_content_link.0.url|render %}
+						<div class="col">
+							<div class="grid-column">
+								{% if item.entity.field_grid_layout_content_image|view %}
+									<div class="overlay-grid-image-container grid-fill {{ imgStyle }}">
+										{% if item.entity.field_grid_layout_content_link.0.url|render %}
+>>>>>>> Stashed changes
 											<a href=" {{ gridLink }} ">
 												<img src="{{ imgUrl }}" alt="{{ imgAlt }}"/>
+												<h3>{{item.entity.field_grid_layout_content_title.value|render|striptags|trim}}</h3>
 											</a>
 										{% else %}
 											<img src="{{ imgUrl }}" alt="{{ imgAlt }}"/>
+											<h3>{{item.entity.field_grid_layout_content_title.value|render|striptags|trim}}</h3>
 										{% endif %}
 									</div>
 								{% endif %}
+<<<<<<< Updated upstream
 								{% if (child.entity.field_grid_layout_content_title.value|render|striptags|trim) or (child.entity.field_grid_layout_content_text|view) %}
 									<div class="grid-text-container">
 										{% if child.entity.field_grid_layout_content_link.0.url|render %}
@@ -252,10 +315,116 @@
 											<h3>{{child.entity.field_grid_layout_content_title.value|render|striptags|trim}}</h3>
 										{% endif %}
 										{{child.entity.field_grid_layout_content_text|view}}
+=======
+								{% if item.entity.field_grid_layout_content_text|view %}
+									<div class="overlay-grid-text">
+										{{item.entity.field_grid_layout_content_text|view}}
+>>>>>>> Stashed changes
 									</div>
 								{% endif %}
 							</div>
 						</div>
+					{% endif %}
+				{% endfor %}
+			</div>
+			{# Offset Grid Layout #}
+		{% else %}
+			<div class="row row-cols-lg-2 row-cols-1">
+				{% for key, item in content['#block_content'].field_grid_layout_content %}
+					{%  if key|first != '#' %}
+						{% if imgStyle == "square-img" %}
+							{% set imgUrl = item.entity.field_grid_layout_content_image.entity.field_media_image.entity.fileuri|image_style('focal_image_square') %}
+							{% set imgAlt = item.entity.field_grid_layout_content_image.entity.field_media_image.alt|render %}
+						{% else %}
+							{% set imgUrl = item.entity.field_grid_layout_content_image.entity.field_media_image.entity.fileuri|image_style('focal_image_wide') %}
+							{% set imgAlt = item.entity.field_grid_layout_content_image.entity.field_media_image.alt|render %}
+						{% endif %}
+						{% set gridLink = item.entity.field_grid_layout_content_link.0.url|render %}
+						{% if (loop.index0 % 3 == 0) and ((loop.index0 is even) or (loop.index0 == 0)) %}
+							<div class="col">
+								<div class="grid-image-container-large">
+									{% if item.entity.field_grid_layout_content_image|view %}
+										<div class="grid-image-container grid-fill {{ imgStyle }}">
+											{% if item.entity.field_grid_layout_content_link.0.url|render %}
+												<a href=" {{ gridLink }} ">
+													<img src="{{ imgUrl }}" alt="{{ imgAlt }}"/>
+												</a>
+											{% else %}
+												<img src="{{ imgUrl }}" alt="{{ imgAlt }}"/>
+											{% endif %}
+										</div>
+									{% endif %}
+									{% if (item.entity.field_grid_layout_content_title.value|render|striptags|trim) or (item.entity.field_grid_layout_content_text|view) %}
+										<div class="grid-text-container">
+											{% if item.entity.field_grid_layout_content_link.0.url|render %}
+												<a href=" {{ gridLink }} ">
+													<h3>{{item.entity.field_grid_layout_content_title.value|render|striptags|trim}}</h3>
+												</a>
+											{% else %}
+												<h3>{{item.entity.field_grid_layout_content_title.value|render|striptags|trim}}</h3>
+											{% endif %}
+											{{item.entity.field_grid_layout_content_text|view}}
+										</div>
+									{% endif %}
+								</div>
+							</div>
+						{% elseif (loop.index % 3 == 0) and (loop.index != 3) and (loop.index0 is odd) %}
+							<div class="col">
+								<div class="grid-image-container-large">
+									{% if item.entity.field_grid_layout_content_image|view %}
+										<div class="grid-image-container grid-fill {{ imgStyle }}">
+											{% if item.entity.field_grid_layout_content_link.0.url|render %}
+												<a href=" {{ gridLink }} ">
+													<img src="{{ imgUrl }}" alt="{{ imgAlt }}"/>
+												</a>
+											{% else %}
+												<img src="{{ imgUrl }}" alt="{{ imgAlt }}"/>
+											{% endif %}
+										</div>
+									{% endif %}
+									{% if (item.entity.field_grid_layout_content_title.value|render|striptags|trim) or (item.entity.field_grid_layout_content_text|view) %}
+										<div class="grid-text-container">
+											{% if item.entity.field_grid_layout_content_link.0.url|render %}
+												<a href=" {{ gridLink }} ">
+													<h3>{{item.entity.field_grid_layout_content_title.value|render|striptags|trim}}</h3>
+												</a>
+											{% else %}
+												<h3>{{item.entity.field_grid_layout_content_title.value|render|striptags|trim}}</h3>
+											{% endif %}
+											{{item.entity.field_grid_layout_content_text|view}}
+										</div>
+									{% endif %}
+								</div>
+							</div>
+						{% else %}
+							<div class="col-lg-3 col-md-6 col">
+								<div class="grid-image-container-small">
+									{% if item.entity.field_grid_layout_content_image|view %}
+										<div class="grid-image-container grid-fill {{ imgStyle }}">
+											{% if item.entity.field_grid_layout_content_image|view %}
+												<a href=" {{ gridLink }} ">
+													<img src="{{ imgUrl }}" alt="{{ imgAlt }}"/>
+												</a>
+											{% else %}
+												<img src="{{ imgUrl }}" alt="{{ imgAlt }}"/>
+											{% endif %}
+										</div>
+									{% endif %}
+									{% if (item.entity.field_grid_layout_content_title.value|render|striptags|trim) or (item.entity.field_grid_layout_content_text|view) %}
+										<div class="grid-text-container">
+											{% if item.entity.field_grid_layout_content_link.0.url|render %}
+												<a href=" {{ gridLink }} ">
+													<h3>{{item.entity.field_grid_layout_content_title.value|render|striptags|trim}}</h3>
+												</a>
+											{% else %}
+												<h3>{{item.entity.field_grid_layout_content_title.value|render|striptags|trim}}</h3>
+											{% endif %}
+											{{item.entity.field_grid_layout_content_text|view}}
+										</div>
+									{% endif %}
+								</div>
+							</div>
+						{% endif %}
 					{% endif %}
 				{% endfor %}
 			</div>

--- a/templates/block/block--inline-block--content-row.html.twig
+++ b/templates/block/block--inline-block--content-row.html.twig
@@ -32,73 +32,73 @@
 		{{ title_suffix }}
 		{# Teaser Row Layout #}
 		{% if layoutSelection == 0 %}
-			{% for key, item in content['#block_content'].field_row_layout_content if key|first != '#' %}
-				{% set rowLink = item.entity.field_row_layout_content_link.0.url|render %}
+			{% for child in content['#block_content'].field_row_layout_content|children %}
+				{% set rowLink = child.entity.field_row_layout_content_link.0.url|render %}
 				<div class="row row-content">
 					<div class="col-4 row-image-container">
-						{% if item.entity.field_row_layout_content_link.0.url|render %}
+						{% if child.entity.field_row_layout_content_link.0.url|render %}
 							<a href=" {{ rowLink }} ">
-								{{ item.entity.field_row_layout_content_image|view }}
+								{{ child.entity.field_row_layout_content_image|view }}
 							</a>
 						{% else %}
-							{{ item.entity.field_row_layout_content_image|view }}
+							{{ child.entity.field_row_layout_content_image|view }}
 						{% endif %}
 					</div>
 					<div class="col-8 row-text-container">
-						{% if item.entity.field_row_layout_content_link.0.url|render %}
+						{% if child.entity.field_row_layout_content_link.0.url|render %}
 							<a href=" {{ rowLink }} ">
-								<h3>{{item.entity.field_row_layout_content_title.value|render|striptags|trim}}</h3>
+								<h3>{{child.entity.field_row_layout_content_title.value|render|striptags|trim}}</h3>
 							</a>
 						{% else %}
-							<h3>{{item.entity.field_row_layout_content_title.value|render|striptags|trim}}</h3>
+							<h3>{{child.entity.field_row_layout_content_title.value|render|striptags|trim}}</h3>
 						{% endif %}
-						{{item.entity.field_row_layout_content_text|view}}
+						{{child.entity.field_row_layout_content_text|view}}
 					</div>
 				</div>
 			{% endfor %}
 			{# Teaser Alternate Row Layout #}
 		{% elseif layoutSelection == 1 %}
-			{% for key, item in content['#block_content'].field_row_layout_content if key|first != '#' %}
-				{% set rowLink = item.entity.field_row_layout_content_link.0.url|render %}
+			{% for child in content['#block_content'].field_row_layout_content|children %}
+				{% set rowLink = child.entity.field_row_layout_content_link.0.url|render %}
 				<div class="row d-flex row-content">
 					{% if (loop.index is odd) %}
 						<div class="col-4 row-image-container">
-							{% if item.entity.field_row_layout_content_link.0.url|render %}
+							{% if child.entity.field_row_layout_content_link.0.url|render %}
 								<a href=" {{ rowLink }} ">
-									{{ item.entity.field_row_layout_content_image|view }}
+									{{ child.entity.field_row_layout_content_image|view }}
 								</a>
 							{% else %}
-								{{ item.entity.field_row_layout_content_image|view }}
+								{{ child.entity.field_row_layout_content_image|view }}
 							{% endif %}
 						</div>
 						<div class="col-8 row-text-container">
-							{% if item.entity.field_row_layout_content_link.0.url|render %}
+							{% if child.entity.field_row_layout_content_link.0.url|render %}
 								<a href=" {{ rowLink }} ">
-									<h3>{{item.entity.field_row_layout_content_title.value|render|striptags|trim}}</h3>
+									<h3>{{child.entity.field_row_layout_content_title.value|render|striptags|trim}}</h3>
 								</a>
 							{% else %}
-								<h3>{{item.entity.field_row_layout_content_title.value|render|striptags|trim}}</h3>
+								<h3>{{child.entity.field_row_layout_content_title.value|render|striptags|trim}}</h3>
 							{% endif %}
-							{{item.entity.field_row_layout_content_text|view}}
+							{{child.entity.field_row_layout_content_text|view}}
 						</div>
 					{% else %}
 						<div class="col-8 row-text-container">
-							{% if item.entity.field_row_layout_content_link.0.url|render %}
+							{% if child.entity.field_row_layout_content_link.0.url|render %}
 								<a href=" {{ rowLink }} ">
-									<h3>{{item.entity.field_row_layout_content_title.value|render|striptags|trim}}</h3>
+									<h3>{{child.entity.field_row_layout_content_title.value|render|striptags|trim}}</h3>
 								</a>
 							{% else %}
-								<h3>{{item.entity.field_row_layout_content_title.value|render|striptags|trim}}</h3>
+								<h3>{{child.entity.field_row_layout_content_title.value|render|striptags|trim}}</h3>
 							{% endif %}
-							{{item.entity.field_row_layout_content_text|view}}
+							{{child.entity.field_row_layout_content_text|view}}
 						</div>
 						<div class="col-4 row-image-container">
-							{% if item.entity.field_row_layout_content_link.0.url|render %}
+							{% if child.entity.field_row_layout_content_link.0.url|render %}
 								<a href=" {{ rowLink }} ">
-									{{ item.entity.field_row_layout_content_image|view }}
+									{{ child.entity.field_row_layout_content_image|view }}
 								</a>
 							{% else %}
-								{{ item.entity.field_row_layout_content_image|view }}
+								{{ child.entity.field_row_layout_content_image|view }}
 							{% endif %}
 						</div>
 					{% endif %}
@@ -106,47 +106,47 @@
 			{% endfor %}
 			{# Tiles Row Layout #}
 		{% elseif layoutSelection == 2 %}
-			{% for key, item in content['#block_content'].field_row_layout_content if key|first != '#' %}
-				{% set rowLink = item.entity.field_row_layout_content_link.0.url|render %}
+			{% for child in content['#block_content'].field_row_layout_content|children %}
+				{% set rowLink = child.entity.field_row_layout_content_link.0.url|render %}
 				<div class="row d-flex row-content">
 					{% if (loop.index is odd) %}
 						<div class="col-6 row-image-container">
-							{% if item.entity.field_row_layout_content_link.0.url|render %}
+							{% if child.entity.field_row_layout_content_link.0.url|render %}
 								<a href=" {{ rowLink }} ">
-									{{ item.entity.field_row_layout_content_image|view }}
+									{{ child.entity.field_row_layout_content_image|view }}
 								</a>
 							{% else %}
-								{{ item.entity.field_row_layout_content_image|view }}
+								{{ child.entity.field_row_layout_content_image|view }}
 							{% endif %}
 						</div>
 						<div class="col-6 row-text-container">
-							{% if item.entity.field_row_layout_content_link.0.url|render %}
+							{% if child.entity.field_row_layout_content_link.0.url|render %}
 								<a href=" {{ rowLink }} ">
-									<h3>{{item.entity.field_row_layout_content_title.value|render|striptags|trim}}</h3>
+									<h3>{{child.entity.field_row_layout_content_title.value|render|striptags|trim}}</h3>
 								</a>
 							{% else %}
-								<h3>{{item.entity.field_row_layout_content_title.value|render|striptags|trim}}</h3>
+								<h3>{{child.entity.field_row_layout_content_title.value|render|striptags|trim}}</h3>
 							{% endif %}
-							{{item.entity.field_row_layout_content_text|view}}
+							{{child.entity.field_row_layout_content_text|view}}
 						</div>
 					{% else %}
 						<div class="col-6 row-text-container">
-							{% if item.entity.field_row_layout_content_link.0.url|render %}
+							{% if child.entity.field_row_layout_content_link.0.url|render %}
 								<a href=" {{ rowLink }} ">
-									<h3>{{item.entity.field_row_layout_content_title.value|render|striptags|trim}}</h3>
+									<h3>{{child.entity.field_row_layout_content_title.value|render|striptags|trim}}</h3>
 								</a>
 							{% else %}
-								<h3>{{item.entity.field_row_layout_content_title.value|render|striptags|trim}}</h3>
+								<h3>{{child.entity.field_row_layout_content_title.value|render|striptags|trim}}</h3>
 							{% endif %}
-							{{item.entity.field_row_layout_content_text|view}}
+							{{child.entity.field_row_layout_content_text|view}}
 						</div>
 						<div class="col-6 row-image-container">
-							{% if item.entity.field_row_layout_content_link.0.url|render %}
+							{% if child.entity.field_row_layout_content_link.0.url|render %}
 								<a href=" {{ rowLink }} ">
-									{{ item.entity.field_row_layout_content_image|view }}
+									{{ child.entity.field_row_layout_content_image|view }}
 								</a>
 							{% else %}
-								{{ item.entity.field_row_layout_content_image|view }}
+								{{ child.entity.field_row_layout_content_image|view }}
 							{% endif %}
 						</div>
 					{% endif %}
@@ -155,28 +155,28 @@
 			{# Features Row Layout #}
 		{% else %}
 			<div class="row row-cols-lg-2 row-cols-1 feature-row">
-				{% for key, item in content['#block_content'].field_row_layout_content if key|first != '#' %}
-					{% set rowLink = item.entity.field_row_layout_content_link.0.url|render %}
-					{% set smallFeatureBGValue = "background-image:url(#{ file_url( item.entity.field_row_layout_content_image.entity.field_media_image.entity.fileuri ) });background-repeat:no-repeat;background-position:center;background-size:cover;" %}
+				{% for child in content['#block_content'].field_row_layout_content|children %}
+					{% set rowLink = child.entity.field_row_layout_content_link.0.url|render %}
+					{% set smallFeatureBGValue = "background-image:url(#{ file_url( child.entity.field_row_layout_content_image.entity.field_media_image.entity.fileuri ) });background-repeat:no-repeat;background-position:center;background-size:cover;" %}
 					{% if (loop.index0 % 3 == 0) or (loop.index0 == 0) %}
 						<div class="col">
 							<div class="feature-row-image-container feature-row-fill">
-								{% if item.entity.field_row_layout_content_link.0.url|render %}
+								{% if child.entity.field_row_layout_content_link.0.url|render %}
 									<a href=" {{ rowLink }} ">
-										{{ item.entity.field_row_layout_content_image|view }}
+										{{ child.entity.field_row_layout_content_image|view }}
 									</a>
 								{% else %}
-									{{ item.entity.field_row_layout_content_image|view }}
+									{{ child.entity.field_row_layout_content_image|view }}
 								{% endif %}
 								<div class="feature-row-text">
-									{% if item.entity.field_row_layout_content_link.0.url|render %}
+									{% if child.entity.field_row_layout_content_link.0.url|render %}
 										<a href=" {{ rowLink }} ">
-											<h3>{{item.entity.field_row_layout_content_title.value|render|striptags|trim}}</h3>
+											<h3>{{child.entity.field_row_layout_content_title.value|render|striptags|trim}}</h3>
 										</a>
 									{% else %}
-										<h3>{{item.entity.field_row_layout_content_title.value|render|striptags|trim}}</h3>
+										<h3>{{child.entity.field_row_layout_content_title.value|render|striptags|trim}}</h3>
 									{% endif %}
-									{{ item.entity.field_row_layout_content_text|view }}
+									{{ child.entity.field_row_layout_content_text|view }}
 								</div>
 							</div>
 						</div>
@@ -185,14 +185,14 @@
 							<div class="col-lg-12 small-feature">
 								<div class="small-feature-row-image-container" style={{ smallFeatureBGValue }}>
 									<div class="feature-row-text">
-										{% if item.entity.field_row_layout_content_link.0.url|render %}
+										{% if child.entity.field_row_layout_content_link.0.url|render %}
 											<a href=" {{ rowLink }} ">
-												<h3>{{item.entity.field_row_layout_content_title.value|render|striptags|trim}}</h3>
+												<h3>{{child.entity.field_row_layout_content_title.value|render|striptags|trim}}</h3>
 											</a>
 										{% else %}
-											<h3>{{item.entity.field_row_layout_content_title.value|render|striptags|trim}}</h3>
+											<h3>{{child.entity.field_row_layout_content_title.value|render|striptags|trim}}</h3>
 										{% endif %}
-										{{ item.entity.field_row_layout_content_text|view }}
+										{{ child.entity.field_row_layout_content_text|view }}
 									</div>
 								</div>
 							</div>
@@ -200,14 +200,14 @@
 							<div class="col-lg-12 small-feature">
 								<div class="small-feature-row-image-container" style={{ smallFeatureBGValue }}>
 									<div class="feature-row-text">
-										{% if item.entity.field_row_layout_content_link.0.url|render %}
+										{% if child.entity.field_row_layout_content_link.0.url|render %}
 											<a href=" {{ rowLink }} ">
-												<h3>{{item.entity.field_row_layout_content_title.value|render|striptags|trim}}</h3>
+												<h3>{{child.entity.field_row_layout_content_title.value|render|striptags|trim}}</h3>
 											</a>
 										{% else %}
-											<h3>{{item.entity.field_row_layout_content_title.value|render|striptags|trim}}</h3>
+											<h3>{{child.entity.field_row_layout_content_title.value|render|striptags|trim}}</h3>
 										{% endif %}
-										{{ item.entity.field_row_layout_content_text|view }}
+										{{ child.entity.field_row_layout_content_text|view }}
 									</div>
 								</div>
 							</div>

--- a/templates/block/block--inline-block--content-row.html.twig
+++ b/templates/block/block--inline-block--content-row.html.twig
@@ -32,6 +32,7 @@
 		{{ title_suffix }}
 		{# Teaser Row Layout #}
 		{% if layoutSelection == 0 %}
+<<<<<<< Updated upstream
 			{% for child in content['#block_content'].field_row_layout_content|children %}
 				{% set rowLink = child.entity.field_row_layout_content_link.0.url|render %}
 				<div class="row row-content">
@@ -62,6 +63,12 @@
 				{% set rowLink = child.entity.field_row_layout_content_link.0.url|render %}
 				<div class="row d-flex row-content">
 					{% if (loop.index is odd) %}
+=======
+			{% for key, item in content['#block_content'].field_row_layout_content %}
+				{%  if key|first != '#' %}
+					{% set rowLink = item.entity.field_row_layout_content_link.0.url|render %}
+					<div class="row row-content">
+>>>>>>> Stashed changes
 						<div class="col-4 row-image-container">
 							{% if child.entity.field_row_layout_content_link.0.url|render %}
 								<a href=" {{ rowLink }} ">
@@ -81,6 +88,7 @@
 							{% endif %}
 							{{child.entity.field_row_layout_content_text|view}}
 						</div>
+<<<<<<< Updated upstream
 					{% else %}
 						<div class="col-8 row-text-container">
 							{% if child.entity.field_row_layout_content_link.0.url|render %}
@@ -162,12 +170,107 @@
 						<div class="col">
 							<div class="feature-row-image-container feature-row-fill">
 								{% if child.entity.field_row_layout_content_link.0.url|render %}
+=======
+					</div>
+				{% endif %}
+			{% endfor %}
+			{# Teaser Alternate Row Layout #}
+		{% elseif layoutSelection == 1 %}
+			{% for key, item in content['#block_content'].field_row_layout_content %}
+				{%  if key|first != '#' %}
+					{% set rowLink = item.entity.field_row_layout_content_link.0.url|render %}
+					<div class="row d-flex row-content">
+						{% if (loop.index is odd) %}
+							<div class="col-4 row-image-container">
+								{% if item.entity.field_row_layout_content_link.0.url|render %}
+									<a href=" {{ rowLink }} ">
+										{{ item.entity.field_row_layout_content_image|view }}
+									</a>
+								{% else %}
+									{{ item.entity.field_row_layout_content_image|view }}
+								{% endif %}
+							</div>
+							<div class="col-8 row-text-container">
+								{% if item.entity.field_row_layout_content_link.0.url|render %}
+									<a href=" {{ rowLink }} ">
+										<h3>{{item.entity.field_row_layout_content_title.value|render|striptags|trim}}</h3>
+									</a>
+								{% else %}
+									<h3>{{item.entity.field_row_layout_content_title.value|render|striptags|trim}}</h3>
+								{% endif %}
+								{{item.entity.field_row_layout_content_text|view}}
+							</div>
+						{% else %}
+							<div class="col-8 row-text-container">
+								{% if item.entity.field_row_layout_content_link.0.url|render %}
+									<a href=" {{ rowLink }} ">
+										<h3>{{item.entity.field_row_layout_content_title.value|render|striptags|trim}}</h3>
+									</a>
+								{% else %}
+									<h3>{{item.entity.field_row_layout_content_title.value|render|striptags|trim}}</h3>
+								{% endif %}
+								{{item.entity.field_row_layout_content_text|view}}
+							</div>
+							<div class="col-4 row-image-container">
+								{% if item.entity.field_row_layout_content_link.0.url|render %}
+									<a href=" {{ rowLink }} ">
+										{{ item.entity.field_row_layout_content_image|view }}
+									</a>
+								{% else %}
+									{{ item.entity.field_row_layout_content_image|view }}
+								{% endif %}
+							</div>
+						{% endif %}
+					</div>
+				{% endif %}
+			{% endfor %}
+			{# Tiles Row Layout #}
+		{% elseif layoutSelection == 2 %}
+			{% for key, item in content['#block_content'].field_row_layout_content %}
+				{%  if key|first != '#' %}
+					{% set rowLink = item.entity.field_row_layout_content_link.0.url|render %}
+					<div class="row d-flex row-content">
+						{% if (loop.index is odd) %}
+							<div class="col-6 row-image-container">
+								{% if item.entity.field_row_layout_content_link.0.url|render %}
+									<a href=" {{ rowLink }} ">
+										{{ item.entity.field_row_layout_content_image|view }}
+									</a>
+								{% else %}
+									{{ item.entity.field_row_layout_content_image|view }}
+								{% endif %}
+							</div>
+							<div class="col-6 row-text-container">
+								{% if item.entity.field_row_layout_content_link.0.url|render %}
+									<a href=" {{ rowLink }} ">
+										<h3>{{item.entity.field_row_layout_content_title.value|render|striptags|trim}}</h3>
+									</a>
+								{% else %}
+									<h3>{{item.entity.field_row_layout_content_title.value|render|striptags|trim}}</h3>
+								{% endif %}
+								{{item.entity.field_row_layout_content_text|view}}
+							</div>
+						{% else %}
+							<div class="col-6 row-text-container">
+								{% if item.entity.field_row_layout_content_link.0.url|render %}
+									<a href=" {{ rowLink }} ">
+										<h3>{{item.entity.field_row_layout_content_title.value|render|striptags|trim}}</h3>
+									</a>
+								{% else %}
+									<h3>{{item.entity.field_row_layout_content_title.value|render|striptags|trim}}</h3>
+								{% endif %}
+								{{item.entity.field_row_layout_content_text|view}}
+							</div>
+							<div class="col-6 row-image-container">
+								{% if item.entity.field_row_layout_content_link.0.url|render %}
+>>>>>>> Stashed changes
 									<a href=" {{ rowLink }} ">
 										{{ child.entity.field_row_layout_content_image|view }}
 									</a>
 								{% else %}
 									{{ child.entity.field_row_layout_content_image|view }}
 								{% endif %}
+<<<<<<< Updated upstream
 								<div class="feature-row-text">
 									{% if child.entity.field_row_layout_content_link.0.url|render %}
 										<a href=" {{ rowLink }} ">
@@ -184,6 +287,30 @@
 						{% elseif loop.index0 is odd %}
 							<div class="col-lg-12 small-feature">
 								<div class="small-feature-row-image-container" style={{ smallFeatureBGValue }}>
+=======
+							</div>
+						{% endif %}
+					</div>
+				{% endif %}
+			{% endfor %}
+			{# Features Row Layout #}
+		{% else %}
+			<div class="row row-cols-lg-2 row-cols-1 feature-row">
+				{% for key, item in content['#block_content'].field_row_layout_content %}
+					{%  if key|first != '#' %}
+						{% set rowLink = item.entity.field_row_layout_content_link.0.url|render %}
+						{% set smallFeatureBGValue = "background-image:url(#{ file_url( item.entity.field_row_layout_content_image.entity.field_media_image.entity.fileuri ) });background-repeat:no-repeat;background-position:center;background-size:cover;" %}
+						{% if (loop.index0 % 3 == 0) or (loop.index0 == 0) %}
+							<div class="col">
+								<div class="feature-row-image-container feature-row-fill">
+									{% if item.entity.field_row_layout_content_link.0.url|render %}
+										<a href=" {{ rowLink }} ">
+											{{ item.entity.field_row_layout_content_image|view }}
+										</a>
+									{% else %}
+										{{ item.entity.field_row_layout_content_image|view }}
+									{% endif %}
+>>>>>>> Stashed changes
 									<div class="feature-row-text">
 										{% if child.entity.field_row_layout_content_link.0.url|render %}
 											<a href=" {{ rowLink }} ">
@@ -196,6 +323,7 @@
 									</div>
 								</div>
 							</div>
+<<<<<<< Updated upstream
 						{% else %}
 							<div class="col-lg-12 small-feature">
 								<div class="small-feature-row-image-container" style={{ smallFeatureBGValue }}>
@@ -208,10 +336,41 @@
 											<h3>{{child.entity.field_row_layout_content_title.value|render|striptags|trim}}</h3>
 										{% endif %}
 										{{ child.entity.field_row_layout_content_text|view }}
+=======
+							<div class="row small-feature-row">
+							{% elseif loop.index0 is odd %}
+								<div class="col-lg-12 small-feature">
+									<div class="small-feature-row-image-container" style={{ smallFeatureBGValue }}>
+										<div class="feature-row-text">
+											{% if item.entity.field_row_layout_content_link.0.url|render %}
+												<a href=" {{ rowLink }} ">
+													<h3>{{item.entity.field_row_layout_content_title.value|render|striptags|trim}}</h3>
+												</a>
+											{% else %}
+												<h3>{{item.entity.field_row_layout_content_title.value|render|striptags|trim}}</h3>
+											{% endif %}
+											{{ item.entity.field_row_layout_content_text|view }}
+										</div>
+									</div>
+								</div>
+							{% else %}
+								<div class="col-lg-12 small-feature">
+									<div class="small-feature-row-image-container" style={{ smallFeatureBGValue }}>
+										<div class="feature-row-text">
+											{% if item.entity.field_row_layout_content_link.0.url|render %}
+												<a href=" {{ rowLink }} ">
+													<h3>{{item.entity.field_row_layout_content_title.value|render|striptags|trim}}</h3>
+												</a>
+											{% else %}
+												<h3>{{item.entity.field_row_layout_content_title.value|render|striptags|trim}}</h3>
+											{% endif %}
+											{{ item.entity.field_row_layout_content_text|view }}
+										</div>
+>>>>>>> Stashed changes
 									</div>
 								</div>
 							</div>
-						</div>
+						{% endif %}
 					{% endif %}
 				{% endfor %}
 			</div>

--- a/templates/block/block--inline-block--expandable-content.html.twig
+++ b/templates/block/block--inline-block--expandable-content.html.twig
@@ -32,16 +32,16 @@
 		<!-- Accordion -->
 		{% if layoutSelection == 0 %}
 			<div class="accordion accordion-flush ucb-accordion-content" id="ucb-accordion{{ content['#block_content'].id() }}">
-				{% for key, item in content['#block_content'].field_expandable_content_copy if key|first != '#' %}
+				{% for child in content['#block_content'].field_expandable_content_copy|children %}
 					<div class="accordion-item">
 						<h2 class="accordion-header" id="ucb-accordion{{ content['#block_content'].id() }}-title{{ loop.index }}">
 							<button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#ucb-accordion{{ content['#block_content'].id() }}-content{{ loop.index }}" aria-expanded="false" aria-controls="ucb-accordion{{ content['#block_content'].id() }}-content{{ loop.index }}">
-								{{ item.entity.field_expandable_content_title|view }}
+								{{ child.entity.field_expandable_content_title|view }}
 							</button>
 						</h2>
 						<div id="ucb-accordion{{ content['#block_content'].id() }}-content{{ loop.index }}" class="accordion-collapse collapse" aria-labelledby="ucb-accordion{{ content['#block_content'].id() }}-title{{ loop.index }}" data-bs-parent="#ucb-accordion{{ content['#block_content'].id() }}">
 							<div class="accordion-body">
-								{{ item.entity.field_expandable_content_body|view }}
+								{{ child.entity.field_expandable_content_body|view }}
 							</div>
 						</div>
 					</div>
@@ -52,14 +52,14 @@
 		{% elseif layoutSelection == 1 %}
 			<!-- horizontal tab/accordion tabs -->
 			<ul class="nav nav-tabs justify-content-center" id="ucb-horizontal-tabs{{ content['#block_content'].id() }}" role="tablist">
-				{% for key, item in content['#block_content'].field_expandable_content_copy if key|first != '#' %}
+				{% for child in content['#block_content'].field_expandable_content_copy|children %}
 					{% if loop.first == true %}
 						<li class="nav-item" role="presentation">
-							<button class="nav-link horizontal-tab-link active" id="ucb-horizontal-tabs{{ content['#block_content'].id() }}-title{{ loop.index }}-tab" data-bs-toggle="tab" data-bs-target="#ucb-horizontal-tabs{{ content['#block_content'].id() }}-title{{ loop.index }}" type="button" role="tab" aria-controls="ucb-horizontal-tabs{{ content['#block_content'].id() }}-title{{ loop.index }}" aria-selected="true">{{ item.entity.field_expandable_content_title|view }}</button>
+							<button class="nav-link horizontal-tab-link active" id="ucb-horizontal-tabs{{ content['#block_content'].id() }}-title{{ loop.index }}-tab" data-bs-toggle="tab" data-bs-target="#ucb-horizontal-tabs{{ content['#block_content'].id() }}-title{{ loop.index }}" type="button" role="tab" aria-controls="ucb-horizontal-tabs{{ content['#block_content'].id() }}-title{{ loop.index }}" aria-selected="true">{{ child.entity.field_expandable_content_title|view }}</button>
 						</li>
 					{% else %}
 						<li class="nav-item" role="presentation">
-							<button class="nav-link horizontal-tab-link" id="ucb-horizontal-tabs{{ content['#block_content'].id() }}-title{{ loop.index }}-tab" data-bs-toggle="tab" data-bs-target="#ucb-horizontal-tabs{{ content['#block_content'].id() }}-title{{ loop.index }}" type="button" role="tab" aria-controls="ucb-horizontal-tabs{{ content['#block_content'].id() }}-title{{ loop.index }}" aria-selected="true">{{ item.entity.field_expandable_content_title|view }}</button>
+							<button class="nav-link horizontal-tab-link" id="ucb-horizontal-tabs{{ content['#block_content'].id() }}-title{{ loop.index }}-tab" data-bs-toggle="tab" data-bs-target="#ucb-horizontal-tabs{{ content['#block_content'].id() }}-title{{ loop.index }}" type="button" role="tab" aria-controls="ucb-horizontal-tabs{{ content['#block_content'].id() }}-title{{ loop.index }}" aria-selected="true">{{ child.entity.field_expandable_content_title|view }}</button>
 						</li>
 					{% endif %}
 				{% endfor %}
@@ -67,19 +67,19 @@
 			<!-- horizontal tab/accordion tabs ends -->
 			<!-- horizontal tab/accordion content -->
 			<div id="ucb-tab-accordion{{ content['#block_content'].id() }}" class="tab-content accordion-flush horizontal-tab-content" role="tablist">
-				{% for key, item in content['#block_content'].field_expandable_content_copy if key|first != '#' %}
+				{% for child in content['#block_content'].field_expandable_content_copy|children %}
 					{% if loop.first == true %}
 						<div class="tab-pane fade show active accordion-item" id="ucb-horizontal-tabs{{ content['#block_content'].id() }}-title{{ loop.index }}" role="tabpanel" aria-labelledby="ucb-horizontal-tabs{{ content['#block_content'].id() }}-title{{ loop.index }}-tab">
 							<div class="horizontal-accordion-tab" role="tab" id="ucb-tab-accordion{{ content['#block_content'].id() }}-title{{ loop.index }}">
 								<h5 class="mb-0">
 									<button class="accordion-button collapsed" data-bs-toggle="collapse" href="#ucb-tab-accordion{{ content['#block_content'].id() }}-content{{ loop.index }}" aria-expanded="true" aria-controls="ucb-tab-accordion{{ content['#block_content'].id() }}-content{{ loop.index }}">
-										{{ item.entity.field_expandable_content_title|view }}
+										{{ child.entity.field_expandable_content_title|view }}
 									</a>
 								</h5>
 							</div>
 							<div id="ucb-tab-accordion{{ content['#block_content'].id() }}-content{{ loop.index }}" class="collapse" data-bs-parent="#ucb-tab-accordion{{ content['#block_content'].id() }}" role="tabpanel" aria-labelledby="ucb-tab-accordion{{ content['#block_content'].id() }}-title{{ loop.index }}">
 								<div class="card-body">
-									{{ item.entity.field_expandable_content_body|view }}
+									{{ child.entity.field_expandable_content_body|view }}
 								</div>
 							</div>
 						</div>
@@ -88,13 +88,13 @@
 							<div class="horizontal-accordion-tab" role="tab" id="ucb-tab-accordion{{ content['#block_content'].id() }}-title{{ loop.index }}">
 								<h5 class="mb-0">
 									<button class="accordion-button collapsed" data-bs-toggle="collapse" href="#ucb-tab-accordion{{ content['#block_content'].id() }}-content{{ loop.index }}" aria-expanded="false" aria-controls="ucb-tab-accordion{{ content['#block_content'].id() }}-content{{ loop.index }}">
-										{{ item.entity.field_expandable_content_title|view }}
+										{{ child.entity.field_expandable_content_title|view }}
 									</a>
 								</h5>
 							</div>
 							<div id="ucb-tab-accordion{{ content['#block_content'].id() }}-content{{ loop.index }}" class="collapse" data-bs-parent="#ucb-tab-accordion{{ content['#block_content'].id() }}" role="tabpanel" aria-labelledby="ucb-tab-accordion{{ content['#block_content'].id() }}-title{{ loop.index }}">
 								<div class="card-body">
-									{{ item.entity.field_expandable_content_body|view }}
+									{{ child.entity.field_expandable_content_body|view }}
 								</div>
 							</div>
 						</div>
@@ -109,30 +109,30 @@
 				class="vertical-tab-accordion d-flex align-items-start">
 				<!-- vertical tab/accordion tabs -->
 				<div class="vertical-tabs nav flex-column nav-pills" id="ucb-vertical-tabs{{ content['#block_content'].id() }}" role="tablist" aria-orientation="vertical">
-					{% for key, item in content['#block_content'].field_expandable_content_copy if key|first != '#' %}
+					{% for child in content['#block_content'].field_expandable_content_copy|children %}
 						{% if loop.first == true %}
-							<button class="nav-link vertical-tab-link active" id="ucb-vertical-tabs{{ content['#block_content'].id() }}-title{{ loop.index }}-tab" data-bs-toggle="pill" data-bs-target="#ucb-vertical-tabs{{ content['#block_content'].id() }}-title{{ loop.index }}" type="button" role="tab" aria-controls="ucb-vertical-tabs{{ content['#block_content'].id() }}-title{{ loop.index }}" aria-selected="true">{{ item.entity.field_expandable_content_title|view }}</button>
+							<button class="nav-link vertical-tab-link active" id="ucb-vertical-tabs{{ content['#block_content'].id() }}-title{{ loop.index }}-tab" data-bs-toggle="pill" data-bs-target="#ucb-vertical-tabs{{ content['#block_content'].id() }}-title{{ loop.index }}" type="button" role="tab" aria-controls="ucb-vertical-tabs{{ content['#block_content'].id() }}-title{{ loop.index }}" aria-selected="true">{{ child.entity.field_expandable_content_title|view }}</button>
 						{% else %}
-							<button class="nav-link vertical-tab-link" id="ucb-vertical-tabs{{ content['#block_content'].id() }}-title{{ loop.index }}-tab" data-bs-toggle="pill" data-bs-target="#ucb-vertical-tabs{{ content['#block_content'].id() }}-title{{ loop.index }}" type="button" role="tab" aria-controls="ucb-vertical-tabs{{ content['#block_content'].id() }}-title{{ loop.index }}" aria-selected="true">{{ item.entity.field_expandable_content_title|view }}</button>
+							<button class="nav-link vertical-tab-link" id="ucb-vertical-tabs{{ content['#block_content'].id() }}-title{{ loop.index }}-tab" data-bs-toggle="pill" data-bs-target="#ucb-vertical-tabs{{ content['#block_content'].id() }}-title{{ loop.index }}" type="button" role="tab" aria-controls="ucb-vertical-tabs{{ content['#block_content'].id() }}-title{{ loop.index }}" aria-selected="true">{{ child.entity.field_expandable_content_title|view }}</button>
 						{% endif %}
 					{% endfor %}
 				</div>
 				<!-- vertical tab/accordion tabs ends -->
 				<!-- vertical tab/accordion content -->
 				<div id="ucb-tab-accordion{{ content['#block_content'].id() }}" class="tab-content vertical-tab-content accordion-flush" role="tablist">
-					{% for key, item in content['#block_content'].field_expandable_content_copy if key|first != '#' %}
+					{% for child in content['#block_content'].field_expandable_content_copy|children %}
 						{% if loop.first == true %}
 							<div class="accordion-item tab-pane fade show active" id="ucb-vertical-tabs{{ content['#block_content'].id() }}-title{{ loop.index }}" role="tabpanel" aria-labelledby="ucb-vertical-tabs{{ content['#block_content'].id() }}-title{{ loop.index }}-tab">
 								<div class="vertical-accordion-tab" role="tab" id="ucb-tab-accordion{{ content['#block_content'].id() }}-title{{ loop.index }}">
 									<h5 class="mb-0">
 										<button class="accordion-button collapsed" data-bs-toggle="collapse" href="#ucb-tab-accordion{{ content['#block_content'].id() }}-content{{ loop.index }}" aria-expanded="true" aria-controls="ucb-tab-accordion{{ content['#block_content'].id() }}-content{{ loop.index }}">
-											{{ item.entity.field_expandable_content_title|view }}
+											{{ child.entity.field_expandable_content_title|view }}
 										</a>
 									</h5>
 								</div>
 								<div id="ucb-tab-accordion{{ content['#block_content'].id() }}-content{{ loop.index }}" class="collapse" data-bs-parent="#ucb-tab-accordion{{ content['#block_content'].id() }}" role="tabpanel" aria-labelledby="ucb-tab-accordion{{ content['#block_content'].id() }}-title{{ loop.index }}">
 									<div class="card-body">
-										{{ item.entity.field_expandable_content_body|view }}
+										{{ child.entity.field_expandable_content_body|view }}
 									</div>
 								</div>
 							</div>
@@ -141,13 +141,13 @@
 								<div class="vertical-accordion-tab" role="tab" id="ucb-tab-accordion{{ content['#block_content'].id() }}-title{{ loop.index }}">
 									<h5 class="mb-0">
 										<button class="accordion-button collapsed" data-bs-toggle="collapse" href="#ucb-tab-accordion{{ content['#block_content'].id() }}-content{{ loop.index }}" aria-expanded="false" aria-controls="ucb-tab-accordion{{ content['#block_content'].id() }}-content{{ loop.index }}">
-											{{ item.entity.field_expandable_content_title|view }}
+											{{ child.entity.field_expandable_content_title|view }}
 										</a>
 									</h5>
 								</div>
 								<div id="ucb-tab-accordion{{ content['#block_content'].id() }}-content{{ loop.index }}" class="collapse" data-bs-parent="#ucb-tab-accordion{{ content['#block_content'].id() }}" role="tabpanel" aria-labelledby="ucb-tab-accordion{{ content['#block_content'].id() }}-title{{ loop.index }}">
 									<div class="card-body">
-										{{ item.entity.field_expandable_content_body|view }}
+										{{ child.entity.field_expandable_content_body|view }}
 									</div>
 								</div>
 							</div>

--- a/templates/block/block--inline-block--expandable-content.html.twig
+++ b/templates/block/block--inline-block--expandable-content.html.twig
@@ -32,6 +32,7 @@
 		<!-- Accordion -->
 		{% if layoutSelection == 0 %}
 			<div class="accordion accordion-flush ucb-accordion-content" id="ucb-accordion{{ content['#block_content'].id() }}">
+<<<<<<< Updated upstream
 				{% for child in content['#block_content'].field_expandable_content_copy|children %}
 					<div class="accordion-item">
 						<h2 class="accordion-header" id="ucb-accordion{{ content['#block_content'].id() }}-title{{ loop.index }}">
@@ -42,9 +43,23 @@
 						<div id="ucb-accordion{{ content['#block_content'].id() }}-content{{ loop.index }}" class="accordion-collapse collapse" aria-labelledby="ucb-accordion{{ content['#block_content'].id() }}-title{{ loop.index }}" data-bs-parent="#ucb-accordion{{ content['#block_content'].id() }}">
 							<div class="accordion-body">
 								{{ child.entity.field_expandable_content_body|view }}
+=======
+				{% for key, item in content['#block_content'].field_expandable_content_copy %}
+					{%  if key|first != '#' %}
+						<div class="accordion-item">
+							<h2 class="accordion-header" id="ucb-accordion{{ content['#block_content'].id() }}-title{{ loop.index }}">
+								<button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#ucb-accordion{{ content['#block_content'].id() }}-content{{ loop.index }}" aria-expanded="false" aria-controls="ucb-accordion{{ content['#block_content'].id() }}-content{{ loop.index }}">
+									{{ item.entity.field_expandable_content_title|view }}
+								</button>
+							</h2>
+							<div id="ucb-accordion{{ content['#block_content'].id() }}-content{{ loop.index }}" class="accordion-collapse collapse" aria-labelledby="ucb-accordion{{ content['#block_content'].id() }}-title{{ loop.index }}" data-bs-parent="#ucb-accordion{{ content['#block_content'].id() }}">
+								<div class="accordion-body">
+									{{ item.entity.field_expandable_content_body|view }}
+								</div>
+>>>>>>> Stashed changes
 							</div>
 						</div>
-					</div>
+					{% endif %}
 				{% endfor %}
 			</div>
 			<!-- Accordion ends -->
@@ -52,6 +67,7 @@
 		{% elseif layoutSelection == 1 %}
 			<!-- horizontal tab/accordion tabs -->
 			<ul class="nav nav-tabs justify-content-center" id="ucb-horizontal-tabs{{ content['#block_content'].id() }}" role="tablist">
+<<<<<<< Updated upstream
 				{% for child in content['#block_content'].field_expandable_content_copy|children %}
 					{% if loop.first == true %}
 						<li class="nav-item" role="presentation">
@@ -61,12 +77,26 @@
 						<li class="nav-item" role="presentation">
 							<button class="nav-link horizontal-tab-link" id="ucb-horizontal-tabs{{ content['#block_content'].id() }}-title{{ loop.index }}-tab" data-bs-toggle="tab" data-bs-target="#ucb-horizontal-tabs{{ content['#block_content'].id() }}-title{{ loop.index }}" type="button" role="tab" aria-controls="ucb-horizontal-tabs{{ content['#block_content'].id() }}-title{{ loop.index }}" aria-selected="true">{{ child.entity.field_expandable_content_title|view }}</button>
 						</li>
+=======
+				{% for key, item in content['#block_content'].field_expandable_content_copy %}
+					{%  if key|first != '#' %}
+						{% if loop.first == true %}
+							<li class="nav-item" role="presentation">
+								<button class="nav-link horizontal-tab-link active" id="ucb-horizontal-tabs{{ content['#block_content'].id() }}-title{{ loop.index }}-tab" data-bs-toggle="tab" data-bs-target="#ucb-horizontal-tabs{{ content['#block_content'].id() }}-title{{ loop.index }}" type="button" role="tab" aria-controls="ucb-horizontal-tabs{{ content['#block_content'].id() }}-title{{ loop.index }}" aria-selected="true">{{ item.entity.field_expandable_content_title|view }}</button>
+							</li>
+						{% else %}
+							<li class="nav-item" role="presentation">
+								<button class="nav-link horizontal-tab-link" id="ucb-horizontal-tabs{{ content['#block_content'].id() }}-title{{ loop.index }}-tab" data-bs-toggle="tab" data-bs-target="#ucb-horizontal-tabs{{ content['#block_content'].id() }}-title{{ loop.index }}" type="button" role="tab" aria-controls="ucb-horizontal-tabs{{ content['#block_content'].id() }}-title{{ loop.index }}" aria-selected="true">{{ item.entity.field_expandable_content_title|view }}</button>
+							</li>
+						{% endif %}
+>>>>>>> Stashed changes
 					{% endif %}
 				{% endfor %}
 			</ul>
 			<!-- horizontal tab/accordion tabs ends -->
 			<!-- horizontal tab/accordion content -->
 			<div id="ucb-tab-accordion{{ content['#block_content'].id() }}" class="tab-content accordion-flush horizontal-tab-content" role="tablist">
+<<<<<<< Updated upstream
 				{% for child in content['#block_content'].field_expandable_content_copy|children %}
 					{% if loop.first == true %}
 						<div class="tab-pane fade show active accordion-item" id="ucb-horizontal-tabs{{ content['#block_content'].id() }}-title{{ loop.index }}" role="tabpanel" aria-labelledby="ucb-horizontal-tabs{{ content['#block_content'].id() }}-title{{ loop.index }}-tab">
@@ -124,6 +154,13 @@
 						{% if loop.first == true %}
 							<div class="accordion-item tab-pane fade show active" id="ucb-vertical-tabs{{ content['#block_content'].id() }}-title{{ loop.index }}" role="tabpanel" aria-labelledby="ucb-vertical-tabs{{ content['#block_content'].id() }}-title{{ loop.index }}-tab">
 								<div class="vertical-accordion-tab" role="tab" id="ucb-tab-accordion{{ content['#block_content'].id() }}-title{{ loop.index }}">
+=======
+				{% for key, item in content['#block_content'].field_expandable_content_copy %}
+					{%  if key|first != '#' %}
+						{% if loop.first == true %}
+							<div class="tab-pane fade show active accordion-item" id="ucb-horizontal-tabs{{ content['#block_content'].id() }}-title{{ loop.index }}" role="tabpanel" aria-labelledby="ucb-horizontal-tabs{{ content['#block_content'].id() }}-title{{ loop.index }}-tab">
+								<div class="horizontal-accordion-tab" role="tab" id="ucb-tab-accordion{{ content['#block_content'].id() }}-title{{ loop.index }}">
+>>>>>>> Stashed changes
 									<h5 class="mb-0">
 										<button class="accordion-button collapsed" data-bs-toggle="collapse" href="#ucb-tab-accordion{{ content['#block_content'].id() }}-content{{ loop.index }}" aria-expanded="true" aria-controls="ucb-tab-accordion{{ content['#block_content'].id() }}-content{{ loop.index }}">
 											{{ child.entity.field_expandable_content_title|view }}
@@ -137,8 +174,8 @@
 								</div>
 							</div>
 						{% else %}
-							<div class="accordion-item tab-pane fade" id="ucb-vertical-tabs{{ content['#block_content'].id() }}-title{{ loop.index }}" role="tabpanel" aria-labelledby="ucb-vertical-tabs{{ content['#block_content'].id() }}-title{{ loop.index }}-tab">
-								<div class="vertical-accordion-tab" role="tab" id="ucb-tab-accordion{{ content['#block_content'].id() }}-title{{ loop.index }}">
+							<div class="tab-pane fade accordion-item" id="ucb-horizontal-tabs{{ content['#block_content'].id() }}-title{{ loop.index }}" role="tabpanel" aria-labelledby="ucb-horizontal-tabs{{ content['#block_content'].id() }}-title{{ loop.index }}-tab">
+								<div class="horizontal-accordion-tab" role="tab" id="ucb-tab-accordion{{ content['#block_content'].id() }}-title{{ loop.index }}">
 									<h5 class="mb-0">
 										<button class="accordion-button collapsed" data-bs-toggle="collapse" href="#ucb-tab-accordion{{ content['#block_content'].id() }}-content{{ loop.index }}" aria-expanded="false" aria-controls="ucb-tab-accordion{{ content['#block_content'].id() }}-content{{ loop.index }}">
 											{{ child.entity.field_expandable_content_title|view }}
@@ -151,6 +188,64 @@
 									</div>
 								</div>
 							</div>
+							<!-- horizontal tab/accordion content ends -->
+						{% endif %}
+					{% endif %}
+				{% endfor %}
+			</div>
+			<!-- horizontal tab/accordion ends -->
+			<!-- vertical tab/accordion -->
+		{% else %}
+			<div
+				class="vertical-tab-accordion d-flex align-items-start">
+				<!-- vertical tab/accordion tabs -->
+				<div class="vertical-tabs nav flex-column nav-pills" id="ucb-vertical-tabs{{ content['#block_content'].id() }}" role="tablist" aria-orientation="vertical">
+					{% for key, item in content['#block_content'].field_expandable_content_copy %}
+						{%  if key|first != '#' %}
+							{% if loop.first == true %}
+								<button class="nav-link vertical-tab-link active" id="ucb-vertical-tabs{{ content['#block_content'].id() }}-title{{ loop.index }}-tab" data-bs-toggle="pill" data-bs-target="#ucb-vertical-tabs{{ content['#block_content'].id() }}-title{{ loop.index }}" type="button" role="tab" aria-controls="ucb-vertical-tabs{{ content['#block_content'].id() }}-title{{ loop.index }}" aria-selected="true">{{ item.entity.field_expandable_content_title|view }}</button>
+							{% else %}
+								<button class="nav-link vertical-tab-link" id="ucb-vertical-tabs{{ content['#block_content'].id() }}-title{{ loop.index }}-tab" data-bs-toggle="pill" data-bs-target="#ucb-vertical-tabs{{ content['#block_content'].id() }}-title{{ loop.index }}" type="button" role="tab" aria-controls="ucb-vertical-tabs{{ content['#block_content'].id() }}-title{{ loop.index }}" aria-selected="true">{{ item.entity.field_expandable_content_title|view }}</button>
+							{% endif %}
+						{% endif %}
+					{% endfor %}
+				</div>
+				<!-- vertical tab/accordion tabs ends -->
+				<!-- vertical tab/accordion content -->
+				<div id="ucb-tab-accordion{{ content['#block_content'].id() }}" class="tab-content vertical-tab-content accordion-flush" role="tablist">
+					{% for key, item in content['#block_content'].field_expandable_content_copy %}
+						{%  if key|first != '#' %}
+							{% if loop.first == true %}
+								<div class="accordion-item tab-pane fade show active" id="ucb-vertical-tabs{{ content['#block_content'].id() }}-title{{ loop.index }}" role="tabpanel" aria-labelledby="ucb-vertical-tabs{{ content['#block_content'].id() }}-title{{ loop.index }}-tab">
+									<div class="vertical-accordion-tab" role="tab" id="ucb-tab-accordion{{ content['#block_content'].id() }}-title{{ loop.index }}">
+										<h5 class="mb-0">
+											<button class="accordion-button collapsed" data-bs-toggle="collapse" href="#ucb-tab-accordion{{ content['#block_content'].id() }}-content{{ loop.index }}" aria-expanded="true" aria-controls="ucb-tab-accordion{{ content['#block_content'].id() }}-content{{ loop.index }}">
+												{{ item.entity.field_expandable_content_title|view }}
+											</a>
+										</h5>
+									</div>
+									<div id="ucb-tab-accordion{{ content['#block_content'].id() }}-content{{ loop.index }}" class="collapse" data-bs-parent="#ucb-tab-accordion{{ content['#block_content'].id() }}" role="tabpanel" aria-labelledby="ucb-tab-accordion{{ content['#block_content'].id() }}-title{{ loop.index }}">
+										<div class="card-body">
+											{{ item.entity.field_expandable_content_body|view }}
+										</div>
+									</div>
+								</div>
+							{% else %}
+								<div class="accordion-item tab-pane fade" id="ucb-vertical-tabs{{ content['#block_content'].id() }}-title{{ loop.index }}" role="tabpanel" aria-labelledby="ucb-vertical-tabs{{ content['#block_content'].id() }}-title{{ loop.index }}-tab">
+									<div class="vertical-accordion-tab" role="tab" id="ucb-tab-accordion{{ content['#block_content'].id() }}-title{{ loop.index }}">
+										<h5 class="mb-0">
+											<button class="accordion-button collapsed" data-bs-toggle="collapse" href="#ucb-tab-accordion{{ content['#block_content'].id() }}-content{{ loop.index }}" aria-expanded="false" aria-controls="ucb-tab-accordion{{ content['#block_content'].id() }}-content{{ loop.index }}">
+												{{ item.entity.field_expandable_content_title|view }}
+											</a>
+										</h5>
+									</div>
+									<div id="ucb-tab-accordion{{ content['#block_content'].id() }}-content{{ loop.index }}" class="collapse" data-bs-parent="#ucb-tab-accordion{{ content['#block_content'].id() }}" role="tabpanel" aria-labelledby="ucb-tab-accordion{{ content['#block_content'].id() }}-title{{ loop.index }}">
+										<div class="card-body">
+											{{ item.entity.field_expandable_content_body|view }}
+										</div>
+									</div>
+								</div>
+							{% endif %}
 						{% endif %}
 					{% endfor %}
 				</div>

--- a/templates/block/block--site-info.html.twig
+++ b/templates/block/block--site-info.html.twig
@@ -42,36 +42,42 @@
     <div class="ucb-site-contact-info-footer">
       {% if data.address_visible == '1' %}
       <div class="ucb-site-contact-info-footer-left">
-        {% for address in data.address if address.visible == '1' %}
-          <div class="ucb-site-contact-info-footer-address">
-            {% if address.label %}
-              <span class="ucb-site-contact-info-footer-label ucb-site-contact-info-footer-address-label">{{ address.label }}: </span>
-            {% endif %}
-            <span class="ucb-site-contact-info-footer-content ucb-site-contact-info-footer-address-content">{{ address.value | nl2br }}</span>
-          </div>
+        {% for address in data.address %}
+          {% if address.visible == '1' %}
+            <div class="ucb-site-contact-info-footer-address">
+              {% if address.label %}
+                <span class="ucb-site-contact-info-footer-label ucb-site-contact-info-footer-address-label">{{ address.label }}: </span>
+              {% endif %}
+              <span class="ucb-site-contact-info-footer-content ucb-site-contact-info-footer-address-content">{{ address.value | nl2br }}</span>
+            </div>
+          {% endif %}
         {% endfor %}
       </div>
       {% endif %}
       <div class="ucb-site-contact-info-footer-right">
         {% if data.email_visible == '1' %}
         <div class="ucb-site-contact-info-footer-emails">
-          {% for email in data.email if email.visible == '1' %}
-            <div class="ucb-site-contact-info-footer-email">
-            {% if email.label %}
-              <span class="ucb-site-contact-info-footer-label ucb-site-contact-info-footer-email-label">{% if icons_visible %}<i class="fas fa-envelope-open"></i> {% endif %}{{ email.label }}: </span>
+          {% for email in data.email %}
+            {% if email.visible == '1' %}
+              <div class="ucb-site-contact-info-footer-email">
+              {% if email.label %}
+                <span class="ucb-site-contact-info-footer-label ucb-site-contact-info-footer-email-label">{% if icons_visible %}<i class="fas fa-envelope-open"></i> {% endif %}{{ email.label }}: </span>
+              {% endif %}
+              <a class="ucb-site-contact-info-footer-content ucb-site-contact-info-footer-email-content" href="mailto:{{ email.value }}">{% if not email.label and icons_visible %}<i class="fas fa-envelope-open"></i> {% endif %}{{ email.value }}</a></div>
             {% endif %}
-            <a class="ucb-site-contact-info-footer-content ucb-site-contact-info-footer-email-content" href="mailto:{{ email.value }}">{% if not email.label and icons_visible %}<i class="fas fa-envelope-open"></i> {% endif %}{{ email.value }}</a></div>
           {% endfor %}
         </div>
         {% endif %}
         {% if data.phone_visible == '1' %}
         <div class="ucb-site-contact-info-footer-phones">
-          {% for phone in data.phone if phone.visible == '1' %}
-            <div class="ucb-site-contact-info-footer-phone">
-            {% if phone.label %}
-              <span class="ucb-site-contact-info-footer-label ucb-site-contact-info-footer-phone-label">{% if icons_visible %}<i class="fas fa-phone-alt"></i> {% endif %}{{ phone.label }}: </span>
+          {% for phone in data.phone %}
+            {% if phone.visible == '1' %}
+              <div class="ucb-site-contact-info-footer-phone">
+              {% if phone.label %}
+                <span class="ucb-site-contact-info-footer-label ucb-site-contact-info-footer-phone-label">{% if icons_visible %}<i class="fas fa-phone-alt"></i> {% endif %}{{ phone.label }}: </span>
+              {% endif %}
+              <a class="ucb-site-contact-info-footer-content ucb-site-contact-info-footer-phone-content" href="tel:{{ phone.value }}">{% if not phone.label and icons_visible %}<i class="fas fa-phone-alt"></i> {% endif %}{{ phone.value }}</a></div>
             {% endif %}
-            <a class="ucb-site-contact-info-footer-content ucb-site-contact-info-footer-phone-content" href="tel:{{ phone.value }}">{% if not phone.label and icons_visible %}<i class="fas fa-phone-alt"></i> {% endif %}{{ phone.value }}</a></div>
           {% endfor %}
         </div>
         {% endif %}

--- a/templates/content/node--how-to-page.html.twig
+++ b/templates/content/node--how-to-page.html.twig
@@ -36,9 +36,9 @@
 							</h2>
 							{% set matList = '"supply": [' %}
 							<ul>
-								{% for key, item in content.field_how_to_materials if key|first != '#' %}
-									{% set matList = matList ~ '{ "@type": "HowToSupply", "name": ' ~ item|render|striptags|trim|json_encode ~ ' },' %}
-									<li>{{item|render}}</li>
+								{% for child in content.field_how_to_materials|children %}
+									{% set matList = matList ~ '{ "@type": "HowToSupply", "name": ' ~ child|render|striptags|trim|json_encode ~ ' },' %}
+									<li>{{child|render}}</li>
 								{% endfor %}
 							</ul>
 							{% set matList = matList|slice(0, -1) ~ '],' %}
@@ -49,10 +49,10 @@
 							</h2>
 							{% set toolList = '"tool": [' %}
 							<ul>
-								{% for key, item in content.field_how_to_tools if key|first != '#' %}
+								{% for child in content.field_how_to_tools|children %}
 
-									{% set toolList = toolList ~ '{ "@type": "HowToTool", "name": ' ~ item|render|striptags|trim|json_encode ~ ' },' %}
-									<li>{{item|render}}</li>
+									{% set toolList = toolList ~ '{ "@type": "HowToTool", "name": ' ~ child|render|striptags|trim|json_encode ~ ' },' %}
+									<li>{{child|render}}</li>
 
 								{% endfor %}
 							</ul>
@@ -63,9 +63,9 @@
 								<span id="estimatedCostValue">
 
 							{% set estimatedC = '' %}
-									{% for key, item in content.field_how_to_estimated_costs if key|first != '#' %}
-										{% set estimatedC = '"estimatedCost": { "@type": "MonetaryAmount", "currency": "USD", "value": ' ~item|render|striptags|trim|json_encode ~' },'  %}
-										${{item|render}}
+									{% for child in content.field_how_to_estimated_costs|children %}
+										{% set estimatedC = '"estimatedCost": { "@type": "MonetaryAmount", "currency": "USD", "value": ' ~ child|render|striptags|trim|json_encode ~' },'  %}
+										${{child|render}}
 									{% endfor %}
 								</span>
 							</h2>
@@ -74,33 +74,33 @@
 
 				</div>
 				<div class="initialImage">
-					{% for key, item in node.field_how_to_initial_image if key|first != '#' %}
-						{% set initialImageJSON = '"image": { "@type": "ImageObject","url": "' ~ file_url(item.entity.field_media_image.entity.fileuri) ~ '", "height": "406", "width": "305"},' %}
+					{% for child in node.field_how_to_initial_image|children %}
+						{% set initialImageJSON = '"image": { "@type": "ImageObject","url": "' ~ file_url(child.entity.field_media_image.entity.fileuri) ~ '", "height": "406", "width": "305"},' %}
 						{{item|view}}
 					{% endfor %}
 				</div>
 			</div>
 			{% set stepList = '"step": [' %}
-			{% for key, item in node.field_how_to_steps if key|first != '#' %}
+			{% for child in node.field_how_to_steps|children %}
 				<div class="howToStep eachStepDiv">
 					<div class="eachStepImage">
-						{{item.entity.field_how_to_step_image|view}}
-						{% set imgURL =  file_url(item.entity.field_how_to_step_image.entity.field_media_image.entity.fileuri) %}
+						{{child.entity.field_how_to_step_image|view}}
+						{% set imgURL =  file_url(child.entity.field_how_to_step_image.entity.field_media_image.entity.fileuri) %}
 						{% set stepImage = '"image": { "@type": "ImageObject","url": "' ~ imgURL ~ '", "height": "406", "width": "305"}' %}
 					</div>
 					<div class="eachStepContentDiv stepFlex">
 						{% set stepList = stepList ~ '{"@type": "HowToStep",' %}
 						<h1 id="step{{key}}">{{item.entity.field_how_to_step_title|view}}</h1>
 						{% set stepList = stepList ~ '"url": "' ~ url("<current>")|render ~ '#step' ~ key ~'",' %}
-						{% set stepList = stepList ~ '"name": ' ~ item.entity.field_how_to_step_title.value|render|striptags|trim|json_encode ~ ',' %}
+						{% set stepList = stepList ~ '"name": ' ~ child.entity.field_how_to_step_title.value|render|striptags|trim|json_encode ~ ',' %}
 
 
 						{% set stepList = stepList ~ '"itemListElement": [' %}
 						<ul>
-							{% for key2, item2 in item.entity.field_how_to_sub_steps if key2|first != '#' %}
+							{% for child2 child.entity.field_how_to_sub_steps|children %}
 
-								<li>{{item2|view}}</li>
-								{% set stepList = stepList ~  '{ "@type": "HowToDirection", "text": ' ~ item2.value|render|striptags|trim|json_encode ~ '},' %}
+								<li>{{child2|view}}</li>
+								{% set stepList = stepList ~  '{ "@type": "HowToDirection", "text": ' ~ child2.value|render|striptags|trim|json_encode ~ '},' %}
 							{% endfor %}
 						</ul>
 						{% set stepList = stepList|slice(0,-1) ~ '],' %}

--- a/templates/content/node--how-to-page.html.twig
+++ b/templates/content/node--how-to-page.html.twig
@@ -36,9 +36,17 @@
 							</h2>
 							{% set matList = '"supply": [' %}
 							<ul>
+<<<<<<< Updated upstream
 								{% for child in content.field_how_to_materials|children %}
 									{% set matList = matList ~ '{ "@type": "HowToSupply", "name": ' ~ child|render|striptags|trim|json_encode ~ ' },' %}
 									<li>{{child|render}}</li>
+=======
+								{% for key, item in content.field_how_to_materials %}
+									{%  if key|first != '#' %}
+										{% set matList = matList ~ '{ "@type": "HowToSupply", "name": ' ~ item|render|striptags|trim|json_encode ~ ' },' %}
+										<li>{{item|render}}</li>
+									{% endif %}
+>>>>>>> Stashed changes
 								{% endfor %}
 							</ul>
 							{% set matList = matList|slice(0, -1) ~ '],' %}
@@ -49,11 +57,19 @@
 							</h2>
 							{% set toolList = '"tool": [' %}
 							<ul>
+<<<<<<< Updated upstream
 								{% for child in content.field_how_to_tools|children %}
 
 									{% set toolList = toolList ~ '{ "@type": "HowToTool", "name": ' ~ child|render|striptags|trim|json_encode ~ ' },' %}
 									<li>{{child|render}}</li>
 
+=======
+								{% for key, item in content.field_how_to_tools %}
+									{%  if key|first != '#' %}
+										{% set toolList = toolList ~ '{ "@type": "HowToTool", "name": ' ~ item|render|striptags|trim|json_encode ~ ' },' %}
+										<li>{{item|render}}</li>
+									{% endif %}
+>>>>>>> Stashed changes
 								{% endfor %}
 							</ul>
 							{% set toolList = toolList|slice(0, -1) ~ '],' %}
@@ -63,9 +79,17 @@
 								<span id="estimatedCostValue">
 
 							{% set estimatedC = '' %}
+<<<<<<< Updated upstream
 									{% for child in content.field_how_to_estimated_costs|children %}
 										{% set estimatedC = '"estimatedCost": { "@type": "MonetaryAmount", "currency": "USD", "value": ' ~ child|render|striptags|trim|json_encode ~' },'  %}
 										${{child|render}}
+=======
+									{% for key, item in content.field_how_to_estimated_costs %}
+										{%  if key|first != '#' %}
+											{% set estimatedC = '"estimatedCost": { "@type": "MonetaryAmount", "currency": "USD", "value": ' ~item|render|striptags|trim|json_encode ~' },'  %}
+											${{item|render}}
+										{% endif %}
+>>>>>>> Stashed changes
 									{% endfor %}
 								</span>
 							</h2>
@@ -74,13 +98,22 @@
 
 				</div>
 				<div class="initialImage">
+<<<<<<< Updated upstream
 					{% for child in node.field_how_to_initial_image|children %}
 						{% set initialImageJSON = '"image": { "@type": "ImageObject","url": "' ~ file_url(child.entity.field_media_image.entity.fileuri) ~ '", "height": "406", "width": "305"},' %}
 						{{item|view}}
+=======
+					{% for key, item in node.field_how_to_initial_image %}
+						{%  if key|first != '#' %}
+							{% set initialImageJSON = '"image": { "@type": "ImageObject","url": "' ~ file_url(item.entity.field_media_image.entity.fileuri) ~ '", "height": "406", "width": "305"},' %}
+							{{item|view}}
+						{% endif %}
+>>>>>>> Stashed changes
 					{% endfor %}
 				</div>
 			</div>
 			{% set stepList = '"step": [' %}
+<<<<<<< Updated upstream
 			{% for child in node.field_how_to_steps|children %}
 				<div class="howToStep eachStepDiv">
 					<div class="eachStepImage">
@@ -106,9 +139,38 @@
 						{% set stepList = stepList|slice(0,-1) ~ '],' %}
 						{% set stepList = stepList ~ stepImage %}
 						{% set stepList = stepList ~ '},' %}
-					</div>
-				</div>
+=======
+			{% for key, item in node.field_how_to_steps %}
+				{%  if key|first != '#' %}
+					<div class="howToStep eachStepDiv">
+						<div class="eachStepImage">
+							{{item.entity.field_how_to_step_image|view}}
+							{% set imgURL =  file_url(item.entity.field_how_to_step_image.entity.field_media_image.entity.fileuri) %}
+							{% set stepImage = '"image": { "@type": "ImageObject","url": "' ~ imgURL ~ '", "height": "406", "width": "305"}' %}
+						</div>
+						<div class="eachStepContentDiv stepFlex">
+							{% set stepList = stepList ~ '{"@type": "HowToStep",' %}
+							<h1 id="step{{key}}">{{item.entity.field_how_to_step_title|view}}</h1>
+							{% set stepList = stepList ~ '"url": "' ~ url("<current>")|render ~ '#step' ~ key ~'",' %}
+							{% set stepList = stepList ~ '"name": ' ~ item.entity.field_how_to_step_title.value|render|striptags|trim|json_encode ~ ',' %}
 
+
+							{% set stepList = stepList ~ '"itemListElement": [' %}
+							<ul>
+								{% for key2, item2 in item.entity.field_how_to_sub_steps %}
+									{%  if key2|first != '#' %}
+										<li>{{item2|view}}</li>
+										{% set stepList = stepList ~  '{ "@type": "HowToDirection", "text": ' ~ item2.value|render|striptags|trim|json_encode ~ '},' %}
+									{% endif %}
+								{% endfor %}
+							</ul>
+							{% set stepList = stepList|slice(0,-1) ~ '],' %}
+							{% set stepList = stepList ~ stepImage %}
+							{% set stepList = stepList ~ '},' %}
+						</div>
+>>>>>>> Stashed changes
+					</div>
+				{% endif %}
 			{% endfor %}
 			{% set stepList = stepList|slice(0,-1) ~ ']' %}
 		</div>

--- a/templates/navigation/breadcrumb.html.twig
+++ b/templates/navigation/breadcrumb.html.twig
@@ -20,15 +20,17 @@
 		<nav role="navigation" aria-labelledby="system-breadcrumb">
 			<h2 id="system-breadcrumb" class="visually-hidden">{{ 'Breadcrumb'|t }}</h2>
 			<ul>
-				{% for item in breadcrumb if item.text %}
-					{% if item.url %}
-						<li class="ucb-breadcrumb-link">
-							<a href="{{ item.url }}">{{ item.text }}</a>
-						</li>
-					{% else %}
-						<li class="ucb-breadcrumb-static">
-							<span>{{ item.text }}</span>
-						</li>
+				{% for item in breadcrumb %}
+					{% if item.text %}
+						{% if item.url %}
+							<li class="ucb-breadcrumb-link">
+								<a href="{{ item.url }}">{{ item.text }}</a>
+							</li>
+						{% else %}
+							<li class="ucb-breadcrumb-static">
+								<span>{{ item.text }}</span>
+							</li>
+						{% endif %}
 					{% endif %}
 				{% endfor %}
 				{% if current_page_title %}

--- a/templates/paragraphs/paragraph--newsletter-section.html.twig
+++ b/templates/paragraphs/paragraph--newsletter-section.html.twig
@@ -20,141 +20,141 @@
 	<div{{attributes.addClass(classes)}}>
 		<h2>{{ content.field_newsletter_section_title }}</h2>
 		{% if paragraph.field_newsletter_section_style.value is same as("0") %}
-			{% for key, item in paragraph.field_newsletter_section_select if key|first != '#' %}
+			{% for child in paragraph.field_newsletter_section_select|children %}
 				{# Code to render selected article content (thumbnail) #}
-				{% if item.entity.field_newsletter_article_select.entity.field_ucb_article_thumbnail.entity.field_media_image.alt|render %}
-					<div id='feature-article-thumbnail-{{key}}'> {{ item.entity.field_newsletter_article_select.entity.field_ucb_article_thumbnail|view }} </div>
+				{% if child.entity.field_newsletter_article_select.entity.field_ucb_article_thumbnail.entity.field_media_image.alt|render %}
+					<div id='feature-article-thumbnail-{{key}}'> {{ child.entity.field_newsletter_article_select.entity.field_ucb_article_thumbnail|view }} </div>
 
 					{# Code to render selected article content (!thumbnail) #}
-				{% elseif item.entity.field_newsletter_article_select.entity.field_ucb_article_content.entity.field_article_media_selection.entity.field_media.entity.field_media_image.alt|render %}
-					<div id='feature-article-content-{{key}}'>{{ item.entity.field_newsletter_article_select.entity.field_ucb_article_content.entity.field_article_media_selection.entity.field_media|view }}</div>
+				{% elseif child.entity.field_newsletter_article_select.entity.field_ucb_article_content.entity.field_article_media_selection.entity.field_media.entity.field_media_image.alt|render %}
+					<div id='feature-article-content-{{key}}'>{{ child.entity.field_newsletter_article_select.entity.field_ucb_article_content.entity.field_article_media_selection.entity.field_media|view }}</div>
 
 					{# Code to render user made content #}
-				{% elseif item.entity.field_newsletter_content_image.entity.field_media_image.alt|render %}
-					<div id='feature-article-media-img-{{key}}'>{{ item.entity.field_newsletter_content_image|view }}</div>
+				{% elseif child.entity.field_newsletter_content_image.entity.field_media_image.alt|render %}
+					<div id='feature-article-media-img-{{key}}'>{{ child.entity.field_newsletter_content_image|view }}</div>
 				{% endif %}
 
 				{# Code to render selected article title/url #}
-				{% if item.entity.field_newsletter_article_select.entity.title.value|render %}
+				{% if child.entity.field_newsletter_article_select.entity.title.value|render %}
 				<div id="feature-article-title-{{key}}">
 					<h3>
-						<a href="{{ path('entity.node.canonical', {'node': item.entity.field_newsletter_article_select.target_id}) }}">
-							{{ item.entity.field_newsletter_article_select.entity.title.value|render|striptags|trim }}
+						<a href="{{ path('entity.node.canonical', {'node': child.entity.field_newsletter_article_select.target_id}) }}">
+							{{ child.entity.field_newsletter_article_select.entity.title.value|render|striptags|trim }}
 						</a>
 					</h3>
 				</div>
 					{# Code to render user made content (title) #}
-				{% elseif item.entity.field_newsletter_content_title.value|render %}
+				{% elseif child.entity.field_newsletter_content_title.value|render %}
 				<div id="feature-article-user-title-{{key}}">
 					<h3>
-						{{ item.entity.field_newsletter_content_title|view }}
+						{{ child.entity.field_newsletter_content_title|view }}
 					</h3>
 				</div>
 				{% endif %}
 
 
 				{# Code to render selected article content (categories) #}
-				{% if item.entity.field_newsletter_article_select.entity.field_ucb_article_categories is not empty %}
+				{% if child.entity.field_newsletter_article_select.entity.field_ucb_article_categories is not empty %}
 					<div class="article-teaser-meta">
-						{{ item.entity.field_newsletter_article_select.entity.field_ucb_article_categories|view }}
+						{{ child.entity.field_newsletter_article_select.entity.field_ucb_article_categories|view }}
 					</div>
 
 					{# Code to render user made content (categories) #}
-				{% elseif item.entity.field_news_content_categories is not empty %}
+				{% elseif child.entity.field_news_content_categories is not empty %}
 					<div class="article-teaser-meta">
-						{{ item.entity.field_news_content_categories|view }}
+						{{ child.entity.field_news_content_categories|view }}
 					</div>
 				{% endif %}
 
 
 				{# Code to render selected article content (summary) #}
-				{% if item.entity.field_newsletter_article_select.entity.field_ucb_article_summary.value|render %}
+				{% if child.entity.field_newsletter_article_select.entity.field_ucb_article_summary.value|render %}
 					<div class="article-summary" id="feature-article-summary-{{key}}">
-						{{ item.entity.field_newsletter_article_select.entity.field_ucb_article_summary|view }}
+						{{ child.entity.field_newsletter_article_select.entity.field_ucb_article_summary|view }}
 					</div>
 
 					{# Code to render selected article content (article text) #}
-				{% elseif item.entity.field_newsletter_article_select.entity.field_ucb_article_content.entity.field_article_text.value|render %}
+				{% elseif child.entity.field_newsletter_article_select.entity.field_ucb_article_content.entity.field_article_text.value|render %}
 					<div class="article-summary" id="feature-article-summary-text-{{key}}">
-						{{ item.entity.field_newsletter_article_select.entity.field_ucb_article_content.entity.field_article_text|view }}
+						{{ child.entity.field_newsletter_article_select.entity.field_ucb_article_content.entity.field_article_text|view }}
 					</div>
 
 					{# Code to render user made content (content text) #}
-				{% elseif item.entity.field_newsletter_content_text.value|render %}
+				{% elseif child.entity.field_newsletter_content_text.value|render %}
 					<div class="article-summary" id="feature-article-summary-user-text-{{key}}">
-						{{ item.entity.field_newsletter_content_text|view }}
+						{{ child.entity.field_newsletter_content_text|view }}
 					</div>
 				{% endif %}
 			{% endfor %}
 		{% else %}
 			<div class="row row-content">
-				{% for key, item in paragraph.field_newsletter_section_select if key|first != '#' %}
+				{% for child in paragraph.field_newsletter_section_select|children %}
 					<div class="col-lg-5 col-8">
 
 						{# Code to render selected article title/url #}
-						{% if item.entity.field_newsletter_article_select.entity.title.value|render %}
+						{% if child.entity.field_newsletter_article_select.entity.title.value|render %}
 							<h3>
-								<a href="{{ path('entity.node.canonical', {'node': item.entity.field_newsletter_article_select.target_id}) }}">
-									{{ item.entity.field_newsletter_article_select.entity.title.value|render|striptags|trim }}
+								<a href="{{ path('entity.node.canonical', {'node': child.entity.field_newsletter_article_select.target_id}) }}">
+									{{ child.entity.field_newsletter_article_select.entity.title.value|render|striptags|trim }}
 								</a>
 							</h3>
 
 							{# Code to render user made content (title) #}
-						{% elseif item.entity.field_newsletter_content_title.value|render %}
+						{% elseif child.entity.field_newsletter_content_title.value|render %}
 							<h3>
-								{{ item.entity.field_newsletter_content_title|view }}
+								{{ child.entity.field_newsletter_content_title|view }}
 							</h3>
 						{% endif %}
 
 
 						{# Code to render selected article content (categories) #}
-						{% if item.entity.field_newsletter_article_select.entity.field_ucb_article_categories is not empty %}
+						{% if child.entity.field_newsletter_article_select.entity.field_ucb_article_categories is not empty %}
 							<div class="article-teaser-meta">
-								{{ item.entity.field_newsletter_article_select.entity.field_ucb_article_categories|view }}
+								{{ child.entity.field_newsletter_article_select.entity.field_ucb_article_categories|view }}
 							</div>
 
 							{# Code to render user made content (categories) #}
-						{% elseif item.entity.field_news_content_categories is not empty %}
+						{% elseif child.entity.field_news_content_categories is not empty %}
 							<div class="article-teaser-meta">
-								{{ item.entity.field_news_content_categories|view }}
+								{{ child.entity.field_news_content_categories|view }}
 							</div>
 						{% endif %}
 
 
 						{# Code to render selected article content (summary) #}
-						{% if item.entity.field_newsletter_article_select.entity.field_ucb_article_summary.value|render %}
+						{% if child.entity.field_newsletter_article_select.entity.field_ucb_article_summary.value|render %}
 							<div class="article-summary">
-								{{ item.entity.field_newsletter_article_select.entity.field_ucb_article_summary|view }}
+								{{ child.entity.field_newsletter_article_select.entity.field_ucb_article_summary|view }}
 							</div>
 
 							{# Code to render selected article content (article text) #}
-						{% elseif item.entity.field_newsletter_article_select.entity.field_ucb_article_content.entity.field_article_text.value|render %}
+						{% elseif child.entity.field_newsletter_article_select.entity.field_ucb_article_content.entity.field_article_text.value|render %}
 							<div class="article-summary">
-								{{ item.entity.field_newsletter_article_select.entity.field_ucb_article_content.entity.field_article_text|view }}
+								{{ child.entity.field_newsletter_article_select.entity.field_ucb_article_content.entity.field_article_text|view }}
 							</div>
 
 							{# Code to render user made content (content text) #}
-						{% elseif item.entity.field_newsletter_content_text.value|render %}
+						{% elseif child.entity.field_newsletter_content_text.value|render %}
 							<div class="article-summary">
-								{{ item.entity.field_newsletter_content_text|view }}
+								{{ child.entity.field_newsletter_content_text|view }}
 							</div>
 						{% endif %}
 					</div>
 					<div
 						class="col-lg-1 col-4 align-self-center">
 						{# Code to render selected article content (thumbnail) #}
-						{% if item.entity.field_newsletter_article_select.entity.field_ucb_article_thumbnail.entity.field_media_image.alt|render %}
+						{% if child.entity.field_newsletter_article_select.entity.field_ucb_article_thumbnail.entity.field_media_image.alt|render %}
 							<img
-							src="{{ item.entity.field_newsletter_article_select.entity.field_ucb_article_thumbnail.entity.field_media_image.entity.fileuri|image_style('focal_image_square') }}" alt="{{ item.entity.field_newsletter_article_select.entity.field_ucb_article_thumbnail.entity.field_media_image.alt|render }}"/>
+							src="{{ child.entity.field_newsletter_article_select.entity.field_ucb_article_thumbnail.entity.field_media_image.entity.fileuri|image_style('focal_image_square') }}" alt="{{ child.entity.field_newsletter_article_select.entity.field_ucb_article_thumbnail.entity.field_media_image.alt|render }}"/>
 
 							{# Code to render selected article content (!thumbnail) #}
-						{% elseif item.entity.field_newsletter_article_select.entity.field_ucb_article_content.entity.field_article_media_selection.entity.field_media.entity.field_media_image.alt|render %}
+						{% elseif child.entity.field_newsletter_article_select.entity.field_ucb_article_content.entity.field_article_media_selection.entity.field_media.entity.field_media_image.alt|render %}
 							<img
-							src="{{ item.entity.field_newsletter_article_select.entity.field_ucb_article_content.entity.field_article_media_selection.entity.field_media.entity.field_media_image.entity.fileuri|image_style('focal_image_square') }}" alt="{{ item.entity.field_newsletter_article_select.entity.field_ucb_article_content.entity.field_article_media_selection.entity.field_media.entity.field_media_image.alt|render }}"/>
+							src="{{ child.entity.field_newsletter_article_select.entity.field_ucb_article_content.entity.field_article_media_selection.entity.field_media.entity.field_media_image.entity.fileuri|image_style('focal_image_square') }}" alt="{{ child.entity.field_newsletter_article_select.entity.field_ucb_article_content.entity.field_article_media_selection.entity.field_media.entity.field_media_image.alt|render }}"/>
 
 							{# Code to render user made content #}
-						{% elseif item.entity.field_newsletter_content_image.entity.field_media_image.alt|render %}
-							<img src="{{ item.entity.field_newsletter_content_image.entity.field_media_image.entity.fileuri|image_style('focal_image_square') }}" alt="{{ item.entity.field_newsletter_content_image.entity.field_media_image.alt|render }}"/>
+						{% elseif child.entity.field_newsletter_content_image.entity.field_media_image.alt|render %}
+							<img src="{{ child.entity.field_newsletter_content_image.entity.field_media_image.entity.fileuri|image_style('focal_image_square') }}" alt="{{ child.entity.field_newsletter_content_image.entity.field_media_image.alt|render }}"/>
 						{% endif %}
 					</div>
 				{% endfor %}

--- a/templates/paragraphs/paragraph--newsletter-section.html.twig
+++ b/templates/paragraphs/paragraph--newsletter-section.html.twig
@@ -20,6 +20,7 @@
 	<div{{attributes.addClass(classes)}}>
 		<h2>{{ content.field_newsletter_section_title }}</h2>
 		{% if paragraph.field_newsletter_section_style.value is same as("0") %}
+<<<<<<< Updated upstream
 			{% for child in paragraph.field_newsletter_section_select|children %}
 				{# Code to render selected article content (thumbnail) #}
 				{% if child.entity.field_newsletter_article_select.entity.field_ucb_article_thumbnail.entity.field_media_image.alt|render %}
@@ -83,11 +84,79 @@
 				{% elseif child.entity.field_newsletter_content_text.value|render %}
 					<div class="article-summary" id="feature-article-summary-user-text-{{key}}">
 						{{ child.entity.field_newsletter_content_text|view }}
+=======
+			{% for key, item in paragraph.field_newsletter_section_select %}
+				{%  if key|first != '#' %}
+					{# Code to render selected article content (thumbnail) #}
+					{% if item.entity.field_newsletter_article_select.entity.field_ucb_article_thumbnail.entity.field_media_image.alt|render %}
+						<div id='feature-article-thumbnail-{{key}}'> {{ item.entity.field_newsletter_article_select.entity.field_ucb_article_thumbnail|view }} </div>
+
+						{# Code to render selected article content (!thumbnail) #}
+					{% elseif item.entity.field_newsletter_article_select.entity.field_ucb_article_content.entity.field_article_media_selection.entity.field_media.entity.field_media_image.alt|render %}
+						<div id='feature-article-content-{{key}}'>{{ item.entity.field_newsletter_article_select.entity.field_ucb_article_content.entity.field_article_media_selection.entity.field_media|view }}</div>
+
+						{# Code to render user made content #}
+					{% elseif item.entity.field_newsletter_content_image.entity.field_media_image.alt|render %}
+						<div id='feature-article-media-img-{{key}}'>{{ item.entity.field_newsletter_content_image|view }}</div>
+					{% endif %}
+
+					{# Code to render selected article title/url #}
+					{% if item.entity.field_newsletter_article_select.entity.title.value|render %}
+					<div id="feature-article-title-{{key}}">
+						<h3>
+							<a href="{{ path('entity.node.canonical', {'node': item.entity.field_newsletter_article_select.target_id}) }}">
+								{{ item.entity.field_newsletter_article_select.entity.title.value|render|striptags|trim }}
+							</a>
+						</h3>
 					</div>
+						{# Code to render user made content (title) #}
+					{% elseif item.entity.field_newsletter_content_title.value|render %}
+					<div id="feature-article-user-title-{{key}}">
+						<h3>
+							{{ item.entity.field_newsletter_content_title|view }}
+						</h3>
+>>>>>>> Stashed changes
+					</div>
+					{% endif %}
+
+
+					{# Code to render selected article content (categories) #}
+					{% if item.entity.field_newsletter_article_select.entity.field_ucb_article_categories is not empty %}
+						<div class="article-teaser-meta">
+							{{ item.entity.field_newsletter_article_select.entity.field_ucb_article_categories|view }}
+						</div>
+
+						{# Code to render user made content (categories) #}
+					{% elseif item.entity.field_news_content_categories is not empty %}
+						<div class="article-teaser-meta">
+							{{ item.entity.field_news_content_categories|view }}
+						</div>
+					{% endif %}
+
+
+					{# Code to render selected article content (summary) #}
+					{% if item.entity.field_newsletter_article_select.entity.field_ucb_article_summary.value|render %}
+						<div class="article-summary" id="feature-article-summary-{{key}}">
+							{{ item.entity.field_newsletter_article_select.entity.field_ucb_article_summary|view }}
+						</div>
+
+						{# Code to render selected article content (article text) #}
+					{% elseif item.entity.field_newsletter_article_select.entity.field_ucb_article_content.entity.field_article_text.value|render %}
+						<div class="article-summary" id="feature-article-summary-text-{{key}}">
+							{{ item.entity.field_newsletter_article_select.entity.field_ucb_article_content.entity.field_article_text|view }}
+						</div>
+
+						{# Code to render user made content (content text) #}
+					{% elseif item.entity.field_newsletter_content_text.value|render %}
+						<div class="article-summary" id="feature-article-summary-user-text-{{key}}">
+							{{ item.entity.field_newsletter_content_text|view }}
+						</div>
+					{% endif %}
 				{% endif %}
 			{% endfor %}
 		{% else %}
 			<div class="row row-content">
+<<<<<<< Updated upstream
 				{% for child in paragraph.field_newsletter_section_select|children %}
 					<div class="col-lg-5 col-8">
 
@@ -157,6 +226,79 @@
 							<img src="{{ child.entity.field_newsletter_content_image.entity.field_media_image.entity.fileuri|image_style('focal_image_square') }}" alt="{{ child.entity.field_newsletter_content_image.entity.field_media_image.alt|render }}"/>
 						{% endif %}
 					</div>
+=======
+				{% for key, item in paragraph.field_newsletter_section_select %}
+					{%  if key|first != '#' %}
+						<div class="col-lg-5 col-8">
+
+							{# Code to render selected article title/url #}
+							{% if item.entity.field_newsletter_article_select.entity.title.value|render %}
+								<h3>
+									<a href="{{ path('entity.node.canonical', {'node': item.entity.field_newsletter_article_select.target_id}) }}">
+										{{ item.entity.field_newsletter_article_select.entity.title.value|render|striptags|trim }}
+									</a>
+								</h3>
+
+								{# Code to render user made content (title) #}
+							{% elseif item.entity.field_newsletter_content_title.value|render %}
+								<h3>
+									{{ item.entity.field_newsletter_content_title|view }}
+								</h3>
+							{% endif %}
+
+
+							{# Code to render selected article content (categories) #}
+							{% if item.entity.field_newsletter_article_select.entity.field_ucb_article_categories is not empty %}
+								<div class="article-teaser-meta">
+									{{ item.entity.field_newsletter_article_select.entity.field_ucb_article_categories|view }}
+								</div>
+
+								{# Code to render user made content (categories) #}
+							{% elseif item.entity.field_news_content_categories is not empty %}
+								<div class="article-teaser-meta">
+									{{ item.entity.field_news_content_categories|view }}
+								</div>
+							{% endif %}
+
+
+							{# Code to render selected article content (summary) #}
+							{% if item.entity.field_newsletter_article_select.entity.field_ucb_article_summary.value|render %}
+								<div class="article-summary">
+									{{ item.entity.field_newsletter_article_select.entity.field_ucb_article_summary|view }}
+								</div>
+
+								{# Code to render selected article content (article text) #}
+							{% elseif item.entity.field_newsletter_article_select.entity.field_ucb_article_content.entity.field_article_text.value|render %}
+								<div class="article-summary">
+									{{ item.entity.field_newsletter_article_select.entity.field_ucb_article_content.entity.field_article_text|view }}
+								</div>
+
+								{# Code to render user made content (content text) #}
+							{% elseif item.entity.field_newsletter_content_text.value|render %}
+								<div class="article-summary">
+									{{ item.entity.field_newsletter_content_text|view }}
+								</div>
+							{% endif %}
+						</div>
+						<div
+							class="col-lg-1 col-4 align-self-center">
+							{# Code to render selected article content (thumbnail) #}
+							{% if item.entity.field_newsletter_article_select.entity.field_ucb_article_thumbnail.entity.field_media_image.alt|render %}
+								<img
+								src="{{ item.entity.field_newsletter_article_select.entity.field_ucb_article_thumbnail.entity.field_media_image.entity.fileuri|image_style('focal_image_square') }}" alt="{{ item.entity.field_newsletter_article_select.entity.field_ucb_article_thumbnail.entity.field_media_image.alt|render }}"/>
+
+								{# Code to render selected article content (!thumbnail) #}
+							{% elseif item.entity.field_newsletter_article_select.entity.field_ucb_article_content.entity.field_article_media_selection.entity.field_media.entity.field_media_image.alt|render %}
+								<img
+								src="{{ item.entity.field_newsletter_article_select.entity.field_ucb_article_content.entity.field_article_media_selection.entity.field_media.entity.field_media_image.entity.fileuri|image_style('focal_image_square') }}" alt="{{ item.entity.field_newsletter_article_select.entity.field_ucb_article_content.entity.field_article_media_selection.entity.field_media.entity.field_media_image.alt|render }}"/>
+
+								{# Code to render user made content #}
+							{% elseif item.entity.field_newsletter_content_image.entity.field_media_image.alt|render %}
+								<img src="{{ item.entity.field_newsletter_content_image.entity.field_media_image.entity.fileuri|image_style('focal_image_square') }}" alt="{{ item.entity.field_newsletter_content_image.entity.field_media_image.alt|render }}"/>
+							{% endif %}
+						</div>
+					{% endif %}
+>>>>>>> Stashed changes
 				{% endfor %}
 			</div>
 		{% endif %}


### PR DESCRIPTION
Updated the deprecated code by moving the `if` conditions into their respective `for` loop bodies.
Doing this instead of using the Twig Tweak `children` filter instead for code consistency.

This affects the following templates: 
**Block**
- Content Grid
- Content Row
- Expandable Content
- Site Info

**Paragraph**
- Newsletter Section

**Node**
- How-to Page

**Navigation**
- Breadcrumb

Closes #188 