### PR TITLE
Major changes to Site Configuration bring new permissions and third-party services settings

### DIFF
--- a/boulderD9_base.libraries.yml
+++ b/boulderD9_base.libraries.yml
@@ -193,3 +193,18 @@ ucb-newsletter:
   css:
     theme:
       css/ucb-newsletter.css: {}
+
+livechat:
+  version: 1.x
+  js:
+    js/livechat.js: {}
+
+statuspage:
+  version: 1.x
+  js:
+    js/statuspage.js: {}
+    
+mainstay:
+  version: 1.x
+  js:
+    js/mainstay.js: {}

--- a/js/livechat.js
+++ b/js/livechat.js
@@ -1,0 +1,15 @@
+class LiveChat extends HTMLElement{
+    constructor() {
+		super();
+        const id = this.getAttribute('id')
+		this.build(id)
+	}
+
+    build(id){
+        const script = document.createElement('script')
+        script.innerText = `var __lc = {}; __lc.license = ${id};(function() {var lc = document.createElement('script'); lc.type = 'text/javascript'; lc.async = true;lc.src = ('https:' == document.location.protocol ? 'https://' : 'http://') + 'cdn.livechatinc.com/tracking.js';var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(lc, s);})();`
+        this.appendChild(script)
+    }
+}
+
+customElements.define('livechat-service', LiveChat);

--- a/js/livechat.js
+++ b/js/livechat.js
@@ -1,15 +1,18 @@
 class LiveChat extends HTMLElement{
-    constructor() {
+	constructor() {
 		super();
-        const id = this.getAttribute('id')
-		this.build(id)
+		const id = this.getAttribute('license-id');
+		this.build(id);
 	}
 
-    build(id){
-        const script = document.createElement('script')
-        script.innerText = `var __lc = {}; __lc.license = ${id};(function() {var lc = document.createElement('script'); lc.type = 'text/javascript'; lc.async = true;lc.src = ('https:' == document.location.protocol ? 'https://' : 'http://') + 'cdn.livechatinc.com/tracking.js';var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(lc, s);})();`
-        this.appendChild(script)
-    }
+	build(id){
+		window.__lc = {'license': id};
+		const script = document.createElement('script');
+		script.type = 'text/javascript';
+		script.async = true;
+		script.src = 'https://cdn.livechatinc.com/tracking.js';
+		this.appendChild(script);
+	}
 }
 
 customElements.define('livechat-service', LiveChat);

--- a/js/mainstay.js
+++ b/js/mainstay.js
@@ -2,16 +2,12 @@ class MainStay extends HTMLElement{
     constructor() {
 		super();
         const id = this.getAttribute('id')
-        const precollege = this.getAttribute('college')
-
-        // Sanitize
-        const college = precollege.replace(/[\W_]+/g, '');
+        const college = this.getAttribute('college')
 		this.build(id, college)
 	}
 
     build(id, college){
-        let tokenScript = document.createElement('script')
-        tokenScript.innerText= `window.admitHubBot = {botToken: "${id}", collegeId: "${college}" };`
+        window.admitHubBot = {botToken: id, collegeId: college};
  
         let chatScript = document.createElement('script')
         chatScript.src="https://webbot.mainstay.com/static/js/webchat.js"
@@ -20,7 +16,6 @@ class MainStay extends HTMLElement{
         stylesheet.type ="text/css"
         stylesheet.href="https://webbot.mainstay.com/static/css/webchat.css"
  
-        this.appendChild(tokenScript)
         this.appendChild(chatScript)
         this.appendChild(stylesheet)
     }

--- a/js/mainstay.js
+++ b/js/mainstay.js
@@ -1,0 +1,25 @@
+class MainStay extends HTMLElement{
+    constructor() {
+		super();
+        const id = this.getAttribute('id')
+		this.build(id)
+	}
+
+    build(id){
+        let tokenScript = document.createElement('script')
+        tokenScript.innerText= `window.admitHubBot = {botToken: "${id}" };`
+ 
+        let chatScript = document.createElement('script')
+        chatScript.src="https://webbot.admithub.com/static/js/webchat.js"
+        let stylesheet = document.createElement('link')
+        stylesheet.rel = "stylesheet"
+        stylesheet.type ="text/css"
+        stylesheet.href="https://webbot.admithub.com/static/css/webchat.css"
+ 
+        this.appendChild(tokenScript)
+        this.appendChild(chatScript)
+        this.appendChild(stylesheet)
+    }
+}
+
+customElements.define('mainstay-service', MainStay);

--- a/js/mainstay.js
+++ b/js/mainstay.js
@@ -1,24 +1,25 @@
 class MainStay extends HTMLElement{
-    constructor() {
+	constructor() {
 		super();
-        const id = this.getAttribute('id')
-        const college = this.getAttribute('college')
-		this.build(id, college)
+		const id = this.getAttribute('bot-token');
+		const college = this.getAttribute('college-id');
+		this.build(id, college);
 	}
 
-    build(id, college){
-        window.admitHubBot = {botToken: id, collegeId: college};
- 
-        let chatScript = document.createElement('script')
-        chatScript.src="https://webbot.mainstay.com/static/js/webchat.js"
-        let stylesheet = document.createElement('link')
-        stylesheet.rel = "stylesheet"
-        stylesheet.type ="text/css"
-        stylesheet.href="https://webbot.mainstay.com/static/css/webchat.css"
- 
-        this.appendChild(chatScript)
-        this.appendChild(stylesheet)
-    }
+	build(id, college){
+		window.admitHubBot = {'botToken': id, 'collegeId': college};
+
+		let chatScript = document.createElement('script');
+		chatScript.type = 'text/javascript';
+		chatScript.src = 'https://webbot.mainstay.com/static/js/webchat.js';
+		let stylesheet = document.createElement('link');
+		stylesheet.rel = 'stylesheet';
+		stylesheet.type = 'text/css';
+		stylesheet.href = 'https://webbot.mainstay.com/static/css/webchat.css';
+
+		this.appendChild(chatScript);
+		this.appendChild(stylesheet);
+	}
 }
 
 customElements.define('mainstay-service', MainStay);

--- a/js/mainstay.js
+++ b/js/mainstay.js
@@ -2,19 +2,23 @@ class MainStay extends HTMLElement{
     constructor() {
 		super();
         const id = this.getAttribute('id')
-		this.build(id)
+        const precollege = this.getAttribute('college')
+
+        // Sanitize
+        const college = precollege.replace(/[\W_]+/g, '');
+		this.build(id, college)
 	}
 
-    build(id){
+    build(id, college){
         let tokenScript = document.createElement('script')
-        tokenScript.innerText= `window.admitHubBot = {botToken: "${id}" };`
+        tokenScript.innerText= `window.admitHubBot = {botToken: "${id}", collegeId: "${college}" };`
  
         let chatScript = document.createElement('script')
-        chatScript.src="https://webbot.admithub.com/static/js/webchat.js"
+        chatScript.src="https://webbot.mainstay.com/static/js/webchat.js"
         let stylesheet = document.createElement('link')
         stylesheet.rel = "stylesheet"
         stylesheet.type ="text/css"
-        stylesheet.href="https://webbot.admithub.com/static/css/webchat.css"
+        stylesheet.href="https://webbot.mainstay.com/static/css/webchat.css"
  
         this.appendChild(tokenScript)
         this.appendChild(chatScript)

--- a/js/statuspage.js
+++ b/js/statuspage.js
@@ -1,0 +1,15 @@
+class StatusPage extends HTMLElement{
+    constructor() {
+		super();
+        const id = this.getAttribute('id')
+		this.build(id)
+	}
+
+    build(id){
+        const script = document.createElement('script')
+        script.src = `https://${id}.statuspage.io/embed/script.js`
+        this.appendChild(script)
+    }
+}
+
+customElements.define('statuspage-service', StatusPage);

--- a/js/statuspage.js
+++ b/js/statuspage.js
@@ -1,15 +1,16 @@
 class StatusPage extends HTMLElement{
-    constructor() {
+	constructor() {
 		super();
-        const id = this.getAttribute('id')
-		this.build(id)
+		const id = this.getAttribute('page-id');
+		this.build(id);
 	}
 
-    build(id){
-        const script = document.createElement('script')
-        script.src = `https://${id}.statuspage.io/embed/script.js`
-        this.appendChild(script)
-    }
+	build(id){
+		const script = document.createElement('script');
+		script.type = 'text/javascript';
+		script.src = `https://${id}.statuspage.io/embed/script.js`;
+		this.appendChild(script);
+	}
 }
 
 customElements.define('statuspage-service', StatusPage);

--- a/templates/block/block--includes-block.html.twig
+++ b/templates/block/block--includes-block.html.twig
@@ -1,0 +1,44 @@
+{#
+/**
+ * @file
+ * Theme override to display a JS Includes/Third Party Service Block.
+ *
+ * Available variables:
+ * - plugin_id: The ID of the block implementation.
+ * - label: The configured label of the block if visible.
+ * - configuration: A list of the block's configuration values.
+ *   - label: The configured label for the block.
+ *   - label_display: The display settings for the label.
+ *   - provider: The module or other provider that provided this block plugin.
+ *   - Block plugin specific settings will also be stored here.
+ * - content: The content of this block.
+ * - attributes: array of HTML attributes populated by modules, intended to
+ *   be added to the main container tag of this template.
+ *   - id: A valid HTML ID and guaranteed unique.
+ * - title_attributes: Same as attributes, except applied to the main title
+ *   tag that appears in the template.
+ * - title_prefix: Additional output populated by modules, intended to be
+ *   displayed in front of the main title tag that appears in the template.
+ * - title_suffix: Additional output populated by modules, intended to be
+ *   displayed after the main title tag that appears in the template.
+ *
+ * @see template_preprocess_block()
+ */
+#}
+{%
+    set classes = [
+      'block',
+      'block-' ~ configuration.provider|clean_class,
+      'block-' ~ plugin_id|clean_class,
+    ]
+  %}
+  <div{{ attributes.addClass(classes) }}>
+    {{ title_prefix }}
+    {# {% if label %}
+      <h2{{ title_attributes }}>{{ label }}</h2>
+    {% endif %} #}
+    {{ title_suffix }}
+    {% block content %}
+      {{ content }}
+    {% endblock %}
+  </div>

--- a/templates/layout/page.html.twig
+++ b/templates/layout/page.html.twig
@@ -43,6 +43,7 @@
  * @see html.html.twig
  */
 #}
+
 <div class="layout-container ucb-page-container">
   {# HEADER CONTENT #}
   {% block page_header %}
@@ -215,4 +216,30 @@
   </footer>
   {% endblock %}
 
+
 </div>{# /.layout-container #}
+
+  {# Services -- see ucb_site_config #}
+  {# LiveChat #}
+  {% if service_livechat_includes|length > 0%}
+  {{ attach_library('boulderD9_base/livechat') }}
+  {% for service in service_livechat_includes %}
+  <livechat-service id="{{service.service_settings.license_id}}"></livechat-service>
+  {% endfor %}
+  {% endif %}
+
+  {# statuspage #}
+  {% if service_statuspage_includes|length > 0%}
+  {{ attach_library('boulderD9_base/statuspage') }}
+  {% for service in service_statuspage_includes %}
+  <statuspage-service id="{{service.service_settings.page_id}}"></statuspage-service>
+  {% endfor %}
+  {% endif %} 
+ 
+  {# mainstay #}
+  {% if service_mainstay_includes|length > 0%}
+  {{ attach_library('boulderD9_base/mainstay') }}
+  {% for service in service_mainstay_includes %}
+  <mainstay-service id="{{service.service_settings.license_id}}" college="{{service.service_settings.college_id}}"></mainstay-service>
+  {% endfor %}
+  {% endif %} 

--- a/templates/layout/page.html.twig
+++ b/templates/layout/page.html.twig
@@ -240,6 +240,6 @@
   {% if service_mainstay_includes|length > 0%}
   {{ attach_library('boulderD9_base/mainstay') }}
   {% for service in service_mainstay_includes %}
-  <mainstay-service bot-token="{{service.service_settings.license_id}}" college-id="{{service.service_settings.college_id}}"></mainstay-service>
+  <mainstay-service bot-token="{{service.service_settings.bot_token}}" college-id="{{service.service_settings.college_id}}"></mainstay-service>
   {% endfor %}
   {% endif %} 

--- a/templates/layout/page.html.twig
+++ b/templates/layout/page.html.twig
@@ -224,7 +224,7 @@
   {% if service_livechat_includes|length > 0%}
   {{ attach_library('boulderD9_base/livechat') }}
   {% for service in service_livechat_includes %}
-  <livechat-service id="{{service.service_settings.license_id}}"></livechat-service>
+  <livechat-service license-id="{{service.service_settings.license_id}}"></livechat-service>
   {% endfor %}
   {% endif %}
 
@@ -232,7 +232,7 @@
   {% if service_statuspage_includes|length > 0%}
   {{ attach_library('boulderD9_base/statuspage') }}
   {% for service in service_statuspage_includes %}
-  <statuspage-service id="{{service.service_settings.page_id}}"></statuspage-service>
+  <statuspage-service page-id="{{service.service_settings.page_id}}"></statuspage-service>
   {% endfor %}
   {% endif %} 
  
@@ -240,6 +240,6 @@
   {% if service_mainstay_includes|length > 0%}
   {{ attach_library('boulderD9_base/mainstay') }}
   {% for service in service_mainstay_includes %}
-  <mainstay-service id="{{service.service_settings.license_id}}" college="{{service.service_settings.college_id}}"></mainstay-service>
+  <mainstay-service bot-token="{{service.service_settings.license_id}}" college-id="{{service.service_settings.college_id}}"></mainstay-service>
   {% endfor %}
   {% endif %} 


### PR DESCRIPTION
### Overview

This is a major update to CU Boulder Site Configuration. Changes include:
- A new CU Boulder site settings administration menu (`/admin/config/cu-boulder`) with three separate pages: Appearance, Contact info, and Third-party services
- Three new permissions for accessing and editing the settings on these pages
- Version bump to indicate D10 compatibility

Authors:
- @TeddyBearX (custom entity, permissions, and menu structure)
- @patrickbrown-io (frontend and third-party service compatibility)

Sister PR in: [ucb_site_configuration](https://github.com/CuBoulder/ucb_site_configuration/pull/6)

### Third-party services (formerly JavaScript Includes)

Third-party services is a new entity-based way to manage client-side services on a site. The services supported are:
- Mainstay (AKA Admithub)
- LiveChat
- StatusPage

These services can be configured and added to pages as desired, with options for specific pages or all pages on the site. Additionally, they can be configured to appear as options when creating or editing content, enabling them to be added or removed by content authors.

Resolves CuBoulder/tiamat-theme#165