### PR TITLE
Adds Aggregator module and feed block

### DIFF
--- a/boulderD9_base.libraries.yml
+++ b/boulderD9_base.libraries.yml
@@ -170,6 +170,12 @@ ucb-text-block:
     theme:
       css/block/text-block.css: {}
 
+aggregator-feed-block:
+  version: 1.x
+  css:
+    theme:
+      css/block/aggregator-feed.css: {}
+
 ucb-form-page:
   version: 1.x
   js:

--- a/css/block/aggregator-feed.css
+++ b/css/block/aggregator-feed.css
@@ -1,0 +1,22 @@
+.block-aggregator-feed-block ul,
+.block-aggregator-feed-block ul li {
+	list-style: none;
+	list-style-image: none;
+	margin: 0;
+	padding: 0
+}
+.block-aggregator-feed-block ul li a {
+	display: block;
+	margin: 10px 0;
+}
+
+.block-aggregator-feed-block ul li {
+	border-bottom: 1px solid #e7e7e7;
+}
+
+.block-aggregator-feed-block a {
+	display: block;
+}
+.block-aggregator-feed-block ul li:last-child {
+	border-bottom: none;
+}

--- a/css/block/aggregator-feed.css
+++ b/css/block/aggregator-feed.css
@@ -5,6 +5,7 @@
 	margin: 0;
 	padding: 0
 }
+
 .block-aggregator-feed-block ul li a {
 	display: block;
 	margin: 10px 0;
@@ -17,6 +18,13 @@
 .block-aggregator-feed-block a {
 	display: block;
 }
-.block-aggregator-feed-block ul li:last-child {
-	border-bottom: none;
+
+.block-aggregator-feed-block a.rss-site-link {
+	display: block;
+	padding: 10px 0;
+	font-size: .85rem;
+}
+
+.block-aggregator-feed-block a.rss-site-link .rss-icon {
+	color: #ff6600;
 }

--- a/templates/block/block--aggregator-feed-block.html.twig
+++ b/templates/block/block--aggregator-feed-block.html.twig
@@ -42,5 +42,6 @@
   {{ title_suffix }}
   {% block content %}
     {{ content.list|render }}
+	<a href="{{ content.more_link['#url'].options.entity.url.value }}" class="rss-site-link"><span class="rss-icon"><i class="fa fa-rss-square"></i></span> {{ content.more_link['#url'].options.entity.title.value }}</a>
   {% endblock %}
 </div>

--- a/templates/block/block--aggregator-feed-block.html.twig
+++ b/templates/block/block--aggregator-feed-block.html.twig
@@ -1,0 +1,46 @@
+{#
+/**
+ * @file
+ * Theme override to display a block.
+ *
+ * Available variables:
+ * - plugin_id: The ID of the block implementation.
+ * - label: The configured label of the block if visible.
+ * - configuration: A list of the block's configuration values.
+ *   - label: The configured label for the block.
+ *   - label_display: The display settings for the label.
+ *   - provider: The module or other provider that provided this block plugin.
+ *   - Block plugin specific settings will also be stored here.
+ * - content: The content of this block.
+ * - attributes: array of HTML attributes populated by modules, intended to
+ *   be added to the main container tag of this template.
+ *   - id: A valid HTML ID and guaranteed unique.
+ * - title_attributes: Same as attributes, except applied to the main title
+ *   tag that appears in the template.
+ * - title_prefix: Additional output populated by modules, intended to be
+ *   displayed in front of the main title tag that appears in the template.
+ * - title_suffix: Additional output populated by modules, intended to be
+ *   displayed after the main title tag that appears in the template.
+ *
+ * @see template_preprocess_block()
+ */
+#}
+{{ attach_library('boulderD9_base/aggregator-feed-block') }}
+{%
+  set classes = [
+    'container',
+    'block',
+    'block-' ~ configuration.provider|clean_class,
+    'block-' ~ plugin_id|clean_class
+  ]
+%}
+<div{{ attributes.addClass(classes) }}>
+  {{ title_prefix }}
+  {% if label %}
+    <h2{{ title_attributes }}>{{ label }}</h2>
+  {% endif %}
+  {{ title_suffix }}
+  {% block content %}
+    {{ content.list|render }}
+  {% endblock %}
+</div>


### PR DESCRIPTION
This update installs and themes the Aggregator module and Aggregator feed block respectively. The block is available to be placed on a basic page via Layout Builder.

Sister PRs in: [tiamat-project-template](https://github.com/CuBoulder/tiamat-project-template/pull/18), [tiamat-profile](https://github.com/CuBoulder/tiamat-profile/pull/23)

Resolves #169