### PR TITLE
Spacing around images in content

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -449,3 +449,8 @@
 	background-color: initial;
 	opacity: initial;
 }
+
+
+.imageMediaStyle{
+  padding-bottom: 20px;
+}

--- a/css/ucb-page.css
+++ b/css/ucb-page.css
@@ -1,7 +1,3 @@
 /*
   Placeholder for styles for the basic page
  */
-
- .imageMediaStyle{
-  padding-bottom: 20px;
-}

--- a/css/ucb-page.css
+++ b/css/ucb-page.css
@@ -1,3 +1,7 @@
 /*
   Placeholder for styles for the basic page
  */
+
+ .imageMediaStyle{
+  padding-bottom: 20px;
+}

--- a/templates/field/field--media--field-media-image--image.html.twig
+++ b/templates/field/field--media--field-media-image--image.html.twig
@@ -12,7 +12,7 @@
 #}
 
 {% for item in items %}
-<div>
+<div class = "imageMediaStyle">
   {{ item.content }}
 </div>
 {% endfor %}


### PR DESCRIPTION
Added some padding around images that have been placed with CKEditor in Text Blocks.  

Closes #153, works on both articles and basic pages