### PR TITLE
Resolved Article List bug caused by Articles that have no content

### DIFF
--- a/js/ucb-article-list.js
+++ b/js/ucb-article-list.js
@@ -56,7 +56,6 @@ function renderArticleList( JSONURL, ExcludeCategories = "", ExcludeTags = "") {
     fetch(JSONURL)
       .then((reponse) => reponse.json())
       .then((data) => {
-        console.log(data)
         // get the next URL and return that if there is one
         if(data.links.next) {
           let nextURL = data.links.next.href.split("/jsonapi/");

--- a/js/ucb-article-list.js
+++ b/js/ucb-article-list.js
@@ -56,6 +56,7 @@ function renderArticleList( JSONURL, ExcludeCategories = "", ExcludeTags = "") {
     fetch(JSONURL)
       .then((reponse) => reponse.json())
       .then((data) => {
+        console.log(data)
         // get the next URL and return that if there is one
         if(data.links.next) {
           let nextURL = data.links.next.href.split("/jsonapi/");
@@ -148,16 +149,15 @@ function renderArticleList( JSONURL, ExcludeCategories = "", ExcludeTags = "") {
           // if we didn't match any of the filtered tags or cats, then render the content
           if (doesIncludeCat.length == 0 && doesIncludeTag.length == 0) {
             // we need to render the Article Card view for this returned element
-
             // **ADD DATA**
             // this is my id of the article body paragraph type we need only if no thumbnail or summary provided
-            let bodyAndImageId = item.relationships.field_ucb_article_content.data[0].id;
-            let body = item.attributes.field_ucb_article_summary?item.attributes.field_ucb_article_summary : "";
+            let bodyAndImageId = item.relationships.field_ucb_article_content.data.length ? item.relationships.field_ucb_article_content.data[0].id : "";
+            let body = item.attributes.field_ucb_article_summary ? item.attributes.field_ucb_article_summary : "";
             body = body.trim();
             let imageSrc = "";
 
             // if no article summary, use a simplified article body
-            if (!body.length) {
+            if (!body.length && bodyAndImageId != "") {
               getArticleParagraph(bodyAndImageId)
                 .then((response) => response.json())
                 .then((data) => {


### PR DESCRIPTION
Previously if an Article set to display on an Article List page does NOT contain any content, Article List would stop mid-render and display "Error retrieving article list from the API endpoint. Please try again later."  This was a possibility for Articles using the external url feature.

This issue has been resolved on the Article List for any Articles that provide no content (such as External URL Articles) and Article List renders normally

Resolves #200 