### PR TITLE
Fix for center-align images placed via CKEditor

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -450,7 +450,10 @@
 	opacity: initial;
 }
 
-
+/* Image Styles */ 
 .imageMediaStyle{
   padding-bottom: 20px;
+}
+div.align-center {
+  width: fit-content;
 }


### PR DESCRIPTION
Images were left-aligned even when specified to be centered when placed from the media library via the CKEditor interface.  

Captions are not being honored either, however this seems to be an issue with CKEditor 5 and the Drupal Media Library.  Should be fixed in a future version of Drupal : (see : https://www.drupal.org/project/drupal/issues/3246385 ) 

Closes : #205 