### PR TITLE
Hidden Terms: Categories and Tags recieve form option to toggle display for admin-only taxonomies

### DIFF
--- a/js/ucb-related-articles.js
+++ b/js/ucb-related-articles.js
@@ -42,6 +42,7 @@
 
 			// console.log("TAG DATA", data)
 			let returnedArticles = data.data
+			console.log(data.data)
 			let existingIds = [];
 			// create an array of existing ids
 			array.map(article=>{
@@ -268,10 +269,14 @@
 
 		// Fetch
 		async function getArticles(URL){
+			getPrivateCategories()
+			getPrivateTags()
+			console.log('-------')
 			fetch(URL)
 				.then(response=>response.json())
 				.then(data=> {
-					// console.log(data)
+					console.log(data)
+
 			// Below objects are needed to match images with their corresponding articles. 
 			// There are two endpoints => data.data (article) and data.included (incl. media), both needed to associate a media library image with its respective article
 			let urlObj = {};
@@ -461,3 +466,17 @@
 		relatedArticlesBlock.style.display = "none";
 	}
 })(document.querySelector(".ucb-related-articles-block"));
+
+async function getPrivateCategories(){
+	// /jsonapi/taxonomy_term/category?filter[field_ucb_category_display]=false
+	fetch('/jsonapi/taxonomy_term/category?filter[field_ucb_category_display]=false')
+	.then(response => response.json())
+	.then(data=>{console.log('private cats', data)})
+}
+
+async function getPrivateTags(){
+		fetch('/jsonapi/taxonomy_term/tags?filter[field_ucb_tag_display]=false')
+		.then(response => response.json())
+		.then(data=>{console.log('private tags', data)})
+
+}

--- a/js/ucb-related-articles.js
+++ b/js/ucb-related-articles.js
@@ -26,6 +26,7 @@
 	function checkMatches(data, ids){
 		let count = 0;
 		let numberArr = ids.map(Number)
+		// TO DO -- add in private taxonomy, dont include on counts
 		data.forEach((article)=>{
 			if(numberArr.includes(article.meta.drupal_internal__target_id)){
 				count++
@@ -269,9 +270,12 @@
 
 		// Fetch
 		async function getArticles(URL){
-			getPrivateCategories()
-			getPrivateTags()
+			const privateTags = getPrivateTags()
+			const privateCats = getPrivateCategories()
 			console.log('-------')
+			console.log('my private tags', privateTags)
+			console.log('my private cats', privateCats)
+			console.log('===========')
 			fetch(URL)
 				.then(response=>response.json())
 				.then(data=> {
@@ -467,16 +471,29 @@
 	}
 })(document.querySelector(".ucb-related-articles-block"));
 
-async function getPrivateCategories(){
-	// /jsonapi/taxonomy_term/category?filter[field_ucb_category_display]=false
-	fetch('/jsonapi/taxonomy_term/category?filter[field_ucb_category_display]=false')
-	.then(response => response.json())
-	.then(data=>{console.log('private cats', data)})
+
+// These functions get the privated Categories and tags to not include them on the match count for their respective taxonomies
+function getPrivateCategories(){
+	let privateCats = []
+		fetch('/jsonapi/taxonomy_term/category?filter[field_ucb_category_display]=false')
+		.then(response => response.json())
+		.then(data=>{ 
+			data.data.forEach(cat=>{
+				privateCats.push(cat.attributes.drupal_internal__tid)
+			})
+		})
+	return privateCats
 }
 
-async function getPrivateTags(){
+function getPrivateTags(){
+	let privateTags = []
 		fetch('/jsonapi/taxonomy_term/tags?filter[field_ucb_tag_display]=false')
 		.then(response => response.json())
-		.then(data=>{console.log('private tags', data)})
+		.then(data=>{ 
+			data.data.forEach(tag=>{
+				privateTags.push(tag.attributes.drupal_internal__tid)
+			})
+		})
+	return privateTags
 
 }

--- a/templates/field/field--field-ucb-article-categories.html.twig
+++ b/templates/field/field--field-ucb-article-categories.html.twig
@@ -6,5 +6,8 @@
 #}
 
 {% for item in items %}
-    {{ item.content|render }}
+{# Only shows Taxonomy terms with display = true #}
+    {% if item.content['#options'].entity.field_ucb_category_display.value == 1 %}
+        {{ item.content|render }}
+    {% endif %}
 {% endfor %}

--- a/templates/field/field--field-ucb-article-tags.html.twig
+++ b/templates/field/field--field-ucb-article-tags.html.twig
@@ -1,3 +1,6 @@
 {% for item in items %}
-    {{ item.content|render }}
+    {# Only shows Taxonomy terms with display = true #}
+    {% if item.content['#options'].entity.field_ucb_tag_display.value == 1 %}
+        {{ item.content|render }}
+    {% endif %}
 {% endfor %}


### PR DESCRIPTION
Category and Tag taxonomies receive the form option for them to be hidden from public view, but the terms are still available for administration.

- Articles tagged with a private term can still be used to group those articles within Article Lists.
- Private terms are NOT used in the Related Articles block - private taxonomies do not affect an Articles 'related-ness' scores
- Private terms will not display in the Category/Tag link section on Articles

Resolves #217 

Change Includes:
- `tiamat-theme` => `issue/217`
- `tiamat-custom-entities` => `issue/217`
