### PR TITLE
Adds "Advanced" appearance settings and custom site logos; modifies contact info settings

### DIFF
--- a/boulderD9_base.theme
+++ b/boulderD9_base.theme
@@ -65,11 +65,18 @@ function boulderD9_base_preprocess_page(array &$variables) {
   $variables['ucb_footer_menu_default_links'] = theme_get_setting('ucb_footer_menu_default_links');
   $variables['theme_path'] = base_path() . $variables['directory'];
   $variables['ucb_campus_header_color'] = theme_get_setting('ucb_campus_header_color');
-  $variables['ucb_header_color'] = theme_get_setting('ucb_header_color');
+  $variables['ucb_header_color'] = $headerColor = theme_get_setting('ucb_header_color');
   $variables['ucb_be_boulder'] = theme_get_setting('ucb_be_boulder');
   $variables['ucb_social_share_position'] = theme_get_setting('ucb_social_share_position');
   $variables['ucb_rave_alerts'] = theme_get_setting('ucb_rave_alerts');
   $variables['ucb_date_format'] = theme_get_setting('ucb_date_format');
+  $useCustomLogo = theme_get_setting('ucb_use_custom_logo');
+  if ($useCustomLogo) {
+	$variables['ucb_custom_logo'] = [
+		'url' =>  file_create_url(theme_get_setting($headerColor == '1' || $headerColor == '2' ? 'ucb_custom_logo_light_path' : 'ucb_custom_logo_dark_path')),
+		'scale' => theme_get_setting('ucb_custom_logo_scale') ?? '2x'
+	];
+  } else $variables['ucb_custom_logo'] = null;
 
   // check to see if we're on the homepage or not
   try {

--- a/config/install/boulderD9_base.settings.yml
+++ b/config/install/boulderD9_base.settings.yml
@@ -22,3 +22,4 @@ ucb_footer_menu_default_links: 0
 ucb_social_share_position: '0'
 ucb_breadcrumb_nav: 1
 ucb_date_format:  '0'
+ucb_use_custom_logo: false

--- a/css/ucb-site-contact-info-footer.css
+++ b/css/ucb-site-contact-info-footer.css
@@ -14,13 +14,13 @@
     flex-wrap: wrap;
 }
 
-.ucb-site-contact-info-footer-address {
+.ucb-site-contact-info-footer-general {
     display: flex;
     flex-direction: column;
     margin-right: 2em;
 }
 
-.ucb-site-contact-info-footer-department-label, .ucb-site-contact-info-footer-addresses, .ucb-site-contact-info-footer-emails, .ucb-site-contact-info-footer-phones {
+.ucb-site-contact-info-footer-general, .ucb-site-contact-info-footer-emails, .ucb-site-contact-info-footer-phones {
     margin: 10px 0;
 }
 
@@ -38,4 +38,6 @@
     color: var(--ucb-gold);
 }
 
-
+.ucb-site-contact-info-footer-content * {
+	margin-bottom: 0;
+}

--- a/templates/block/block--site-info.html.twig
+++ b/templates/block/block--site-info.html.twig
@@ -29,26 +29,21 @@
 {% set data = content['#data'] %}
 {% set icons_visible = data.icons_visible %}
 {%
-  set classes = [
-    data.separate_departments == '1' ? '-ucb-separate-departments',
-    data.address_visible == '1' ? '-ucb-addresses-visible',
-    data.email_visible == '1' ? '-ucb-emails-visible',
-    data.phone_visible == '1' ? '-ucb-phones-visible'
-  ]
+  set classes = []
 %}
 <div{{ attributes.addClass(classes) }}>
-  <h5><a href="/"> {{ site_name }} </a> </h5>
+  <h5><a href="/"> {{ site_name }} </a></h5>
   {% block content %}
     <div class="ucb-site-contact-info-footer">
-      {% if data.address_visible == '1' %}
+      {% if data.general_visible == '1' %}
       <div class="ucb-site-contact-info-footer-left">
-        {% for address in data.address %}
-          {% if address.visible == '1' %}
-            <div class="ucb-site-contact-info-footer-address">
-              {% if address.label %}
-                <span class="ucb-site-contact-info-footer-label ucb-site-contact-info-footer-address-label">{{ address.label }}: </span>
+        {% for item in data.general %}
+          {% if item.visible == '1' %}
+            <div class="ucb-site-contact-info-footer-general">
+              {% if item.label %}
+                <span class="ucb-site-contact-info-footer-label ucb-site-contact-info-footer-general-label">{{ item.label }} </span>
               {% endif %}
-              <span class="ucb-site-contact-info-footer-content ucb-site-contact-info-footer-address-content">{{ address.value | nl2br }}</span>
+              <span class="ucb-site-contact-info-footer-content ucb-site-contact-info-footer-general-content">{% if item.value.format == 'wysiwyg' or item.value.format == 'full_html' %}{{ item.value.value | raw }}{% else %}{{ item.value.value | nl2br }}{% endif %}</span>
             </div>
           {% endif %}
         {% endfor %}
@@ -61,7 +56,7 @@
             {% if email.visible == '1' %}
               <div class="ucb-site-contact-info-footer-email">
               {% if email.label %}
-                <span class="ucb-site-contact-info-footer-label ucb-site-contact-info-footer-email-label">{% if icons_visible %}<i class="fas fa-envelope-open"></i> {% endif %}{{ email.label }}: </span>
+                <span class="ucb-site-contact-info-footer-label ucb-site-contact-info-footer-email-label">{% if icons_visible %}<i class="fas fa-envelope-open"></i> {% endif %}{{ email.label }}</span>
               {% endif %}
               <a class="ucb-site-contact-info-footer-content ucb-site-contact-info-footer-email-content" href="mailto:{{ email.value }}">{% if not email.label and icons_visible %}<i class="fas fa-envelope-open"></i> {% endif %}{{ email.value }}</a></div>
             {% endif %}
@@ -74,7 +69,7 @@
             {% if phone.visible == '1' %}
               <div class="ucb-site-contact-info-footer-phone">
               {% if phone.label %}
-                <span class="ucb-site-contact-info-footer-label ucb-site-contact-info-footer-phone-label">{% if icons_visible %}<i class="fas fa-phone-alt"></i> {% endif %}{{ phone.label }}: </span>
+                <span class="ucb-site-contact-info-footer-label ucb-site-contact-info-footer-phone-label">{% if icons_visible %}<i class="fas fa-phone-alt"></i> {% endif %}{{ phone.label }}</span>
               {% endif %}
               <a class="ucb-site-contact-info-footer-content ucb-site-contact-info-footer-phone-content" href="tel:{{ phone.value }}">{% if not phone.label and icons_visible %}<i class="fas fa-phone-alt"></i> {% endif %}{{ phone.value }}</a></div>
             {% endif %}

--- a/templates/layout/page.html.twig
+++ b/templates/layout/page.html.twig
@@ -83,7 +83,7 @@
     <header class="ucb {{ header_color }}{% if site_affiliation.id %} ucb-site-affiliation-{{ site_affiliation.id }}{% endif %}" role="banner">
       <div class="container ucb-menu-wrapper">
         <div class="ucb-site-name-wrapper">
-          <a href="{{ front_page }}">{{ site_name }}</a>
+          <a href="{{ front_page }}">{% if ucb_custom_logo %}<img role="img" class="ucb-custom-logo" srcset="{{ ucb_custom_logo.url }} {{ ucb_custom_logo.scale }}" alt="{{ site_name }}">{% else %}{{ site_name }}{% endif %}</a>
           {% if site_affiliation.id %}
             <div class="affiliation">
               {% if site_affiliation.url %}<a href="{{ site_affiliation.url }}">{{ site_affiliation.label }}</a>{% else %}{{ site_affiliation.label }}{% endif %}


### PR DESCRIPTION
This update:
- Adds an _Advanced_ view at the bottom of the _Appearance_ settings, collapsed by default and visible only to those with the _Edit advanced site settings_ permission.
- Moves all theme settings previously restricted to Drupal's default theme settings into the _Advanced_ view.
- Adds site-specific custom logos (resolves CuBoulder/tiamat-theme#264) and places the settings for custom logos into the _Advanced_ view:
  - Custom logo requires _white text on dark header_ and _dark text on white header_ variants.
  - An image can be uploaded or a path can be manually specified for each.
  - ~~A scale can be specified, which defaults to _2x_ (Retina) but also allows _1x_ (standard) or _3x_ (enhanced Retina)~~.
- Assigns the _Architect_ and _Developer_ user roles the _Edit advanced site settings_ permission.
- Replaces address fields with general field and WYSIWYG editor in site contact info; removes colons from site contact info footer (resolves CuBoulder/tiamat-theme#269)

Sister PR in: [ucb_site_configuration](https://github.com/CuBoulder/ucb_site_configuration/pull/19), [tiamat-profile](https://github.com/CuBoulder/tiamat-profile/pull/34)