### PR TITLE
Adds sticky menu

### DIFF
--- a/boulderD9_base.libraries.yml
+++ b/boulderD9_base.libraries.yml
@@ -200,6 +200,14 @@ ucb-newsletter:
     theme:
       css/ucb-newsletter.css: {}
 
+ucb-sticky-menu:
+  version: 1.x
+  js:
+    js/ucb-sticky-menu.js: {}
+  css:
+    theme:
+      css/ucb-sticky-menu.css: {}
+
 livechat:
   version: 1.x
   js:

--- a/boulderD9_base.theme
+++ b/boulderD9_base.theme
@@ -69,14 +69,19 @@ function boulderD9_base_preprocess_page(array &$variables) {
   $variables['ucb_be_boulder'] = theme_get_setting('ucb_be_boulder');
   $variables['ucb_social_share_position'] = theme_get_setting('ucb_social_share_position');
   $variables['ucb_rave_alerts'] = theme_get_setting('ucb_rave_alerts');
+  $variables['ucb_sticky_menu'] = theme_get_setting('ucb_sticky_menu');
   $variables['ucb_date_format'] = theme_get_setting('ucb_date_format');
   $useCustomLogo = theme_get_setting('ucb_use_custom_logo');
   if ($useCustomLogo) {
+	$logoDarkURL = file_create_url(theme_get_setting('ucb_custom_logo_dark_path'));
+	$logoLightURL = file_create_url(theme_get_setting('ucb_custom_logo_light_path'));
 	$variables['ucb_custom_logo'] = [
-		'url' =>  file_create_url(theme_get_setting($headerColor == '1' || $headerColor == '2' ? 'ucb_custom_logo_light_path' : 'ucb_custom_logo_dark_path')),
+		'dark_url' => $logoDarkURL,
+		'light_url' => $logoLightURL,
+		'url' =>  $headerColor == '1' || $headerColor == '2' ? $logoLightURL : $logoDarkURL,
 		'scale' => theme_get_setting('ucb_custom_logo_scale') ?? '2x'
 	];
-  } else $variables['ucb_custom_logo'] = null;
+  }
 
   // check to see if we're on the homepage or not
   try {

--- a/config/install/boulderD9_base.settings.yml
+++ b/config/install/boulderD9_base.settings.yml
@@ -14,6 +14,7 @@ ucb_header_color: '3'
 ucb_sidebar_position: '0'
 ucb_be_boulder: '1'
 ucb_rave_alerts: 1
+ucb_sticky_menu: 0
 ucb_gtm_account: ''
 ucb_secondary_menu_default_links: 0
 ucb_secondary_menu_position: inline

--- a/css/ucb-sticky-menu.css
+++ b/css/ucb-sticky-menu.css
@@ -1,14 +1,68 @@
 .ucb-sticky-menu {
-	display: block;
 	position: fixed;
+	display: block;
+	width: 100%;
 	top: 0;
 	left: 0;
-	width: 100%;
+	border-bottom: 1px solid var(--ucb-gold);
+	z-index: 20;
+	padding: .5rem 0;
 }
 
-.ucb-sticky-menu .ucb-logo {
+@media only screen and (max-width: 960px) {
+	.ucb-sticky-menu {
+		display: none;
+	}
+}
+
+.ucb-sticky-menu[hidden] {
+	display: none;
+}
+
+.gin--horizontal-toolbar .ucb-sticky-menu {
+	top: var(--gin-toolbar-height, 53px);
+}
+
+.ucb-sticky-menu img {
+	display: block;
 	max-width: 200px;
 	height: auto;
-	display: block;
-	margin-bottom: 10px;
+}
+
+.ucb-sticky-menu .sticky-menu-branding {
+	margin: .5em 0;
+}
+
+.ucb-sticky-menu .sticky-menu-inner {
+	display: flex;
+	flex-direction: row;
+	align-items: center;
+	justify-content: space-between;
+}
+
+.ucb-sticky-menu .sticky-menu-site-name {
+	flex-shrink: 1;
+	font-family: 'Roboto Condensed', 'Helvetica Neue', Helvetica, Arial, sans-serif;
+	font-size: 1rem;
+	min-width: 200px;
+	margin-right: 1.5rem;
+}
+
+.ucb-sticky-menu .sticky-menu-menu {
+	font-size: .75rem;
+	font-weight: bold;
+}
+
+.sticky-menu-inner a:link, .sticky-menu-inner a:visited {
+	color: #FFFFFF;
+}
+
+.sticky-menu-inner li.main-menu-item a.nav-link {
+	color: #FFFFFF;
+	border-bottom: none;
+	padding: 0 .5rem;
+}
+
+.sticky-menu-inner li.main-menu-item a.nav-link:hover {
+	color: var(--ucb-gold);
 }

--- a/css/ucb-sticky-menu.css
+++ b/css/ucb-sticky-menu.css
@@ -1,0 +1,14 @@
+.ucb-sticky-menu {
+	display: block;
+	position: fixed;
+	top: 0;
+	left: 0;
+	width: 100%;
+}
+
+.ucb-sticky-menu .ucb-logo {
+	max-width: 200px;
+	height: auto;
+	display: block;
+	margin-bottom: 10px;
+}

--- a/js/ucb-sticky-menu.js
+++ b/js/ucb-sticky-menu.js
@@ -1,0 +1,21 @@
+(function(stickyMenuElement, headerElement) {
+	if (!stickyMenuElement || !headerElement) return;
+	let stickyMenuHidden = true;
+	document.addEventListener('scroll', function(e) {
+		const headerRect = headerElement.getBoundingClientRect();
+		if (headerRect.bottom <= 0) {
+			if (stickyMenuHidden) {
+				stickyMenuElement.removeAttribute('hidden');
+				stickyMenuHidden = false;
+			}
+		} else {
+			if (!stickyMenuHidden) {
+				stickyMenuElement.setAttribute('hidden', '');
+				stickyMenuHidden = true;
+			}
+		}
+	});
+})(
+	document.querySelector('.ucb-sticky-menu'),
+	document.querySelector('.page-header')
+);

--- a/templates/includes/ucb-sticky-menu.html.twig
+++ b/templates/includes/ucb-sticky-menu.html.twig
@@ -1,0 +1,8 @@
+{{ attach_library('boulderD9_base/ucb-sticky-menu') }}
+<div class="ucb-sticky-menu">
+	<div class="background-black">
+		<div class="container">
+			<a href="https://www.colorado.edu" class="ucb-home-link"><img class="ucb-logo" src="https://cdn.colorado.edu/static/brand-assets/live/images/cu-boulder-logo-text-white.svg" alt="University of Colorado Boulder"></a>
+		</div>
+	</div>
+</div>

--- a/templates/includes/ucb-sticky-menu.html.twig
+++ b/templates/includes/ucb-sticky-menu.html.twig
@@ -1,8 +1,16 @@
 {{ attach_library('boulderD9_base/ucb-sticky-menu') }}
-<div class="ucb-sticky-menu">
-	<div class="background-black">
-		<div class="container">
+<div hidden class="ucb-sticky-menu background-black">
+	<div class="container">
+		<div class="sticky-menu-branding">
 			<a href="https://www.colorado.edu" class="ucb-home-link"><img class="ucb-logo" src="https://cdn.colorado.edu/static/brand-assets/live/images/cu-boulder-logo-text-white.svg" alt="University of Colorado Boulder"></a>
+		</div>
+		<div class="sticky-menu-inner">
+			<div class="sticky-menu-site-name">
+			    <a href="{{ front_page }}">{% if ucb_custom_logo %}<img role="img" srcset="{{ ucb_custom_logo.dark_url }} {{ ucb_custom_logo.scale }}" alt="{{ site_name }}">{% else %}{{ site_name }}{% endif %}</a>
+			</div>
+			<div class="sticky-menu-menu">
+				{{ page.primary_menu }}
+			</div>
 		</div>
 	</div>
 </div>

--- a/templates/layout/page.html.twig
+++ b/templates/layout/page.html.twig
@@ -68,6 +68,8 @@
 		<rave-alert feed="https://www.getrave.com/rss/cuboulder/channel1" link="https://alerts.colorado.edu"></rave-alert>
 	{% endif %}
 
+	{% include '@boulderD9_base/includes/ucb-sticky-menu.html.twig' %}
+
     {{ page.header }}
     <div class="page-header">
     {% if user.hasPermission('access administration pages') %}

--- a/templates/layout/page.html.twig
+++ b/templates/layout/page.html.twig
@@ -68,7 +68,9 @@
 		<rave-alert feed="https://www.getrave.com/rss/cuboulder/channel1" link="https://alerts.colorado.edu"></rave-alert>
 	{% endif %}
 
-	{% include '@boulderD9_base/includes/ucb-sticky-menu.html.twig' %}
+	{% if ucb_sticky_menu %}
+		{% include '@boulderD9_base/includes/ucb-sticky-menu.html.twig' %}
+	{% endif %}
 
     {{ page.header }}
     <div class="page-header">


### PR DESCRIPTION
This update adds an optional "sticky menu" component to all pages on a site, enabled by visiting CU Boulder site settings → Appearance and toggling on _Show sticky menu_. The menu appears automatically when a user scrolls down passed the main website header, and only on large screen devices (at least 960 pixels wide).

Resolves CuBoulder/tiamat-theme#247

Sister PR in: [tiamat-theme](https://github.com/CuBoulder/ucb_site_configuration/pull/20)