### PR TITLE
Fixes a bug which caused improper display of special characters like ampersands on Person pages

### DIFF
--- a/boulderD9_base.info.yml
+++ b/boulderD9_base.info.yml
@@ -5,9 +5,6 @@ core_version_requirement: ^9 || ^10
 type: theme
 base theme: stable9
 
-dependencies:
-  - core/drupalSettings
-
 libraries: 
   - boulderD9_base/ucb-global
 

--- a/css/ucb-person.css
+++ b/css/ucb-person.css
@@ -92,6 +92,6 @@ ul.ucb-person-department li:not(:first-child):before {
 	clear: both;
 }
 
-.ucb-person-img>div>div .media-image-caption {
+.ucb-person-img .media-image-caption {
 	text-align: center;
 }

--- a/css/ucb-person.css
+++ b/css/ucb-person.css
@@ -65,10 +65,11 @@ ul.ucb-person-title li:not(:first-child):before,
 ul.ucb-person-department li:not(:first-child):before {
 	font-family: "Font Awesome 5 Free";
 	font-weight: 900;
-	font-size: 0.25em;
+	font-size: .25em;
 	content: "\f111";
 	vertical-align: middle;
-	padding: 0 0.25em;
+	padding-left: .25em;
+	padding-right: 1em;
 }
 
 .ucb-person-title li,

--- a/css/ucb-person.css
+++ b/css/ucb-person.css
@@ -7,7 +7,10 @@
 }
 
 .ucb-person-pronouns {
+	list-style: none;
 	font-size: 1.1em;
+	margin: 0;
+	padding: 0;
 }
 
 .ucb-person-section {

--- a/templates/content/node--ucb-person.html.twig
+++ b/templates/content/node--ucb-person.html.twig
@@ -38,11 +38,11 @@ view_mode ? 'node--view-mode-' ~ view_mode|clean_class,
 					<div class="ucb-person-img" itemprop="image">
 						{{ content.field_ucb_person_photo }}
 					</div>
-				{% endif %}{% set personTitle = content.field_ucb_person_title['#items'].value|trim %}{% set personDepartment = content.field_ucb_person_department|render %}
+				{% endif %}{% set personTitle = content.field_ucb_person_title|render %}{% set personDepartment = content.field_ucb_person_department|render %}
 				{% if personTitle or personDepartment %}
 					<div class="ucb-person-section ucb-person-job">
-						{% if personTitle %}<span class="d-block">{{ personTitle }}</span>{% endif %}
-						{% if personDepartment %}<span class="d-block">{{ personDepartment }}</span>{% endif %}
+						{% if personTitle %}<div>{{ personTitle }}</div>{% endif %}
+						{% if personDepartment %}<div>{{ personDepartment }}</div>{% endif %}
 					</div>
 				{% endif %}{% set personEmail = content.field_ucb_person_email['#items'].value|trim %}{% set personPhone = content.field_ucb_person_phone['#items'].value|trim %}
 				{% if personEmail or personPhone %}

--- a/templates/content/node--ucb-person.html.twig
+++ b/templates/content/node--ucb-person.html.twig
@@ -27,11 +27,7 @@
 	<div class="container ucb-person">
 		<div class="row ucb-person-personal">
 			<div class="col ucb-person-main">
-				{% if content.field_ucb_person_photo.0 %}
-					<div class="ucb-person-img" itemprop="image">
-						{{ content.field_ucb_person_photo }}
-					</div>
-				{% endif %}
+				{{ content.field_ucb_person_photo }}
 				{% if content.field_ucb_person_title.0 or content.field_ucb_person_department.0 %}
 					<div class="ucb-person-section ucb-person-job">
 						{{ content.field_ucb_person_title }}

--- a/templates/content/node--ucb-person.html.twig
+++ b/templates/content/node--ucb-person.html.twig
@@ -21,56 +21,54 @@ view_mode ? 'node--view-mode-' ~ view_mode|clean_class,
 {#Dummy variable to ensure that all content tags are set for caching purposes#}
 {% set content_render = content|render %}
 
-<article{{attributes.addClass(classes)}}>
-	<div class="container-fluid ucb-person-header">
-		<div class="container">
-			<h1 class="ucb-person-name">
-				<span itemprop="givenName">{{ content.field_ucb_person_first_name['#items'].value|trim }}</span>
-				<span itemprop="familyName">{{ content.field_ucb_person_last_name['#items'].value|trim }}</span>
-			</h1>
-			{% set pronouns = content.field_ucb_person_pronouns['#items'].value|trim %}{% if pronouns %}<div class="ucb-person-pronouns">(<span itemprop="pronouns">{{ pronouns }}</span>)</div>{% endif %}
-		</div>
+<article{{attributes.addClass(classes)}} itemscope itemtype="https://schema.org/Person">
+	<div class="container ucb-person-header">
+		<h1 class="ucb-person-name">
+			{{ content.field_ucb_person_first_name }}
+			{{ content.field_ucb_person_last_name }}
+		</h1>
+		{{ content.field_ucb_person_pronouns }}
 	</div>
-	<div class="container ucb-person" itemscope itemtype="https://schema.org/Person">
+	<div class="container ucb-person">
 		<div class="row ucb-person-personal">
 			<div class="col ucb-person-main">
-				{% if content.field_ucb_person_photo|render %}
+				{% if content.field_ucb_person_photo.0 %}
 					<div class="ucb-person-img" itemprop="image">
 						{{ content.field_ucb_person_photo }}
 					</div>
-				{% endif %}{% set personTitle = content.field_ucb_person_title|render %}{% set personDepartment = content.field_ucb_person_department|render %}
-				{% if personTitle or personDepartment %}
+				{% endif %}
+				{% if content.field_ucb_person_title.0 or content.field_ucb_person_department.0 %}
 					<div class="ucb-person-section ucb-person-job">
-						{% if personTitle %}<div>{{ personTitle }}</div>{% endif %}
-						{% if personDepartment %}<div>{{ personDepartment }}</div>{% endif %}
+						{{ content.field_ucb_person_title }}
+						{{ content.field_ucb_person_department }}
 					</div>
-				{% endif %}{% set personEmail = content.field_ucb_person_email['#items'].value|trim %}{% set personPhone = content.field_ucb_person_phone['#items'].value|trim %}
-				{% if personEmail or personPhone %}
+				{% endif %}
+				{% if content.field_ucb_person_email.0 or content.field_ucb_person_phone.0 %}
 					<div class="ucb-person-section ucb-person-contact">
-						{% if personEmail %}<div itemprop="email">{{ personEmail }}</div>{% endif %}
-						{% if personPhone %}<div itemprop="telephone">{{ personPhone }}</div>{% endif %}
+						{{ content.field_ucb_person_email }}
+						{{ content.field_ucb_person_phone }}
 					</div>
-				{% endif %}{% set personLinks = content.field_ucb_person_links|render %}
-				{% if personLinks %}
+				{% endif %}
+				{% if content.field_ucb_person_links.0 %}
 					<div class="ucb-person-section ucb-person-links">
-						{{ personLinks }}
+						{{ content.field_ucb_person_links }}
 					</div>
-				{% endif %}{% set personAddress = content.field_ucb_person_address|render %}
-				{% if personAddress %}
-					<div class="ucb-person-section ucb-person-address" itemprop="address">
+				{% endif %}
+				{% if content.field_ucb_person_address.0 %}
+					<div class="ucb-person-section" itemprop="address" aria-labelledby="headerAddress">
 						<span class="ucb-person-section-header" id="headerAddress">Address</span>
-						{{ personAddress }}
+						{{ content.field_ucb_person_address }}
 					</div>
-				{% endif %}{% set personOfficeHours = content.field_ucb_person_office_hours|render %}
-				{% if personOfficeHours %}
+				{% endif %}
+				{% if content.field_ucb_person_office_hours.0 %}
 					<div class="ucb-person-section ucb-person-office-hours" aria-labelledby="headerOfficeHours">
 						<span class="ucb-person-section-header" id="headerOfficeHours">Office Hours</span>
-						{{ personOfficeHours }}
+						{{ content.field_ucb_person_office_hours }}
 					</div>
-				{% endif %}{% set body = content.body|render %}
-				{% if body %}
+				{% endif %}
+				{% if content.body.0 %}
 					<div class="ucb-person-section ucb-person-body">
-						{{ body }}
+						{{ content.body }}
 					</div>
 				{% endif %}
 			</div>

--- a/templates/content/node--ucb-person.html.twig
+++ b/templates/content/node--ucb-person.html.twig
@@ -9,17 +9,12 @@
 {{ attach_library('boulderD9_base/ucb-page') }}
 {{ attach_library('boulderD9_base/ucb-person') }}
 
-{%
-set classes = [
-'node',
-'node--type-' ~ node.bundle|clean_class,
-not node.isPublished() ? 'node--unpublished',
-view_mode ? 'node--view-mode-' ~ view_mode|clean_class,
-]
-%}
-
-{#Dummy variable to ensure that all content tags are set for caching purposes#}
-{% set content_render = content|render %}
+{% set classes = [
+	'node',
+	'node--type-' ~ node.bundle|clean_class,
+	not node.isPublished() ? 'node--unpublished',
+	view_mode ? 'node--view-mode-' ~ view_mode|clean_class,
+] %}
 
 <article{{attributes.addClass(classes)}} itemscope itemtype="https://schema.org/Person">
 	<div class="container ucb-person-header">

--- a/templates/content/node--ucb-person.html.twig
+++ b/templates/content/node--ucb-person.html.twig
@@ -50,7 +50,7 @@
 					</div>
 				{% endif %}
 				{% if content.field_ucb_person_address.0 %}
-					<div class="ucb-person-section" itemprop="address" aria-labelledby="headerAddress">
+					<div class="ucb-person-section" aria-labelledby="headerAddress">
 						<span class="ucb-person-section-header" id="headerAddress">Address</span>
 						{{ content.field_ucb_person_address }}
 					</div>

--- a/templates/content/node--ucb-person.html.twig
+++ b/templates/content/node--ucb-person.html.twig
@@ -38,53 +38,39 @@ view_mode ? 'node--view-mode-' ~ view_mode|clean_class,
 					<div class="ucb-person-img" itemprop="image">
 						{{ content.field_ucb_person_photo }}
 					</div>
-				{% endif %}
-				{% if content.field_ucb_person_title|render or content.field_ucb_person_department|render %}
+				{% endif %}{% set personTitle = content.field_ucb_person_title['#items'].value|trim %}{% set personDepartment = content.field_ucb_person_department|render %}
+				{% if personTitle or personDepartment %}
 					<div class="ucb-person-section ucb-person-job">
-						{% if content.field_ucb_person_title|render %}
-							<span class="d-block">
-								{{ content.field_ucb_person_title}}
-							</span>
-						{% endif %}
-						{% if content.field_ucb_person_department|render %}
-							<span class="d-block">{{ content.field_ucb_person_department}}</span>
-						{% endif %}
+						{% if personTitle %}<span class="d-block">{{ personTitle }}</span>{% endif %}
+						{% if personDepartment %}<span class="d-block">{{ personDepartment }}</span>{% endif %}
 					</div>
-				{% endif %}
-				{% if content.field_ucb_person_email|render or content.field_ucb_person_phone|render %}
+				{% endif %}{% set personEmail = content.field_ucb_person_email['#items'].value|trim %}{% set personPhone = content.field_ucb_person_phone['#items'].value|trim %}
+				{% if personEmail or personPhone %}
 					<div class="ucb-person-section ucb-person-contact">
-						{% if content.field_ucb_person_email|render %}
-							<div itemprop="email">
-								{{ content.field_ucb_person_email }}
-							</div>
-						{% endif %}
-						{% if content.field_ucb_person_phone|render %}
-							<div itemprop="telephone">
-								{{ content.field_ucb_person_phone }}
-							</div>
-						{% endif %}
+						{% if personEmail %}<div itemprop="email">{{ personEmail }}</div>{% endif %}
+						{% if personPhone %}<div itemprop="telephone">{{ personPhone }}</div>{% endif %}
 					</div>
-				{% endif %}
-				{% if content.field_ucb_person_links|render %}
+				{% endif %}{% set personLinks = content.field_ucb_person_links|render %}
+				{% if personLinks %}
 					<div class="ucb-person-section ucb-person-links">
-						{{ content.field_ucb_person_links }}
+						{{ personLinks }}
 					</div>
-				{% endif %}
-				{% if content.field_ucb_person_address|render %}
+				{% endif %}{% set personAddress = content.field_ucb_person_address|render %}
+				{% if personAddress %}
 					<div class="ucb-person-section ucb-person-address" itemprop="address">
 						<span class="ucb-person-section-header" id="headerAddress">Address</span>
-						{{ content.field_ucb_person_address }}
+						{{ personAddress }}
 					</div>
-				{% endif %}
-				{% if content.field_ucb_person_office_hours|render %}
+				{% endif %}{% set personOfficeHours = content.field_ucb_person_office_hours|render %}
+				{% if personOfficeHours %}
 					<div class="ucb-person-section ucb-person-office-hours" aria-labelledby="headerOfficeHours">
 						<span class="ucb-person-section-header" id="headerOfficeHours">Office Hours</span>
-						{{ content.field_ucb_person_office_hours }}
+						{{ personOfficeHours }}
 					</div>
-				{% endif %}
-				{% if content.body|render %}
+				{% endif %}{% set body = content.body|render %}
+				{% if body %}
 					<div class="ucb-person-section ucb-person-body">
-						{{ content.body }}
+						{{ body }}
 					</div>
 				{% endif %}
 			</div>

--- a/templates/field/field--field-ucb-person-address.html.twig
+++ b/templates/field/field--field-ucb-person-address.html.twig
@@ -4,7 +4,7 @@
  */
 #}
 {% if items.0 %}
-<div itemprop="address">
+<div class="ucb-person-address" itemprop="address">
 	{{ items.0.content }}
 </div>
 {% endif %}

--- a/templates/field/field--field-ucb-person-address.html.twig
+++ b/templates/field/field--field-ucb-person-address.html.twig
@@ -1,0 +1,10 @@
+{#
+/**
+ * @file Contains the template to display the Person node's Address field.
+ */
+#}
+{% if items.0 %}
+<div itemprop="address">
+	{{ items.0.content }}
+</div>
+{% endif %}

--- a/templates/field/field--field-ucb-person-department.html.twig
+++ b/templates/field/field--field-ucb-person-department.html.twig
@@ -1,8 +1,3 @@
-
 <ul class="ucb-person-department">
-    {% for item in items %}
-        <li itemprop="department">
-            {{ item.content|render|striptags|trim }}
-        </li>
-    {% endfor %}
+	{% for item in items %}<li itemprop="department">{{ item.content|render|striptags|trim|raw }}</li> {% endfor %}
 </ul>

--- a/templates/field/field--field-ucb-person-department.html.twig
+++ b/templates/field/field--field-ucb-person-department.html.twig
@@ -1,3 +1,14 @@
-<ul class="ucb-person-department">
-	{% for item in items %}<li itemprop="department">{{ item.content|render|striptags|trim|raw }}</li> {% endfor %}
-</ul>
+{#
+/**
+ * @file Contains the template to display the Person node's Department field.
+ */
+#}
+{% if items %}
+<div>
+	<ul class="ucb-person-department">
+		{% for item in items %}
+		<li itemprop="department">{{ item.content['#title'] }}</li>
+		{% endfor %}
+	</ul>
+</div>
+{% endif %}

--- a/templates/field/field--field-ucb-person-email.html.twig
+++ b/templates/field/field--field-ucb-person-email.html.twig
@@ -1,15 +1,16 @@
 {#
 /**
-* Theme layout to display a UCB Person Email Field.
-*/
+ * @file Contains the template to display the Person node's Email field.
+ */
 #}
-
-<ul class="ucb-person-email-address">
-    {% for item in items %}
-    <li>
-        <i class="fa fal fa-envelope"></i>&nbsp;<a href="mailto:{{ item.content|render|striptags|trim }}">{{
-            item.attributes
-            }}{{ item.content }}</a>
-    </li>
-    {% endfor %}
-</ul>
+{% if items %}
+<div>
+	<ul class="ucb-person-email-address">
+		{% for item in items %}
+		<li>
+			<i class="fa fal fa-envelope"></i>&nbsp;<a itemprop="email" href="mailto:{{ item.content['#context'].value|trim|url_encode }}">{{ item.content|render|trim }}</a>
+		</li>
+		{% endfor %}
+	</ul>
+</div>
+{% endif %}

--- a/templates/field/field--field-ucb-person-email.html.twig
+++ b/templates/field/field--field-ucb-person-email.html.twig
@@ -6,9 +6,9 @@
 {% if items %}
 <div>
 	<ul class="ucb-person-email-address">
-		{% for item in items %}
+		{% for item in items %}{% set value = item.content['#context'].value|trim %}
 		<li>
-			<i class="fa fal fa-envelope"></i>&nbsp;<a itemprop="email" href="mailto:{{ item.content['#context'].value|trim|url_encode }}">{{ item.content|render|trim }}</a>
+			<i class="fa fal fa-envelope"></i>&nbsp;<a itemprop="email" href="mailto:{{ value|url_encode }}">{{ value }}</a>
 		</li>
 		{% endfor %}
 	</ul>

--- a/templates/field/field--field-ucb-person-first-name.html.twig
+++ b/templates/field/field--field-ucb-person-first-name.html.twig
@@ -3,4 +3,4 @@
  * @file Contains the template to display the Person node's First name field.
  */
 #}
-{% if items.0 %}<span itemprop="givenName">{{ items.0.content|render|trim }}</span>{% endif %}
+{% if items.0 %}<span itemprop="givenName">{{ items.0.content['#context'].value|trim }}</span>{% endif %}

--- a/templates/field/field--field-ucb-person-first-name.html.twig
+++ b/templates/field/field--field-ucb-person-first-name.html.twig
@@ -1,0 +1,6 @@
+{#
+/**
+ * @file Contains the template to display the Person node's First name field.
+ */
+#}
+{% if items.0 %}<span itemprop="givenName">{{ items.0.content|render|trim }}</span>{% endif %}

--- a/templates/field/field--field-ucb-person-last-name.html.twig
+++ b/templates/field/field--field-ucb-person-last-name.html.twig
@@ -3,4 +3,4 @@
  * @file Contains the template to display the Person node's Last name field.
  */
 #}
-{% if items.0 %}<span itemprop="familyName">{{ items.0.content|render|trim }}</span>{% endif %}
+{% if items.0 %}<span itemprop="familyName">{{ items.0.content['#context'].value|trim }}</span>{% endif %}

--- a/templates/field/field--field-ucb-person-last-name.html.twig
+++ b/templates/field/field--field-ucb-person-last-name.html.twig
@@ -1,0 +1,6 @@
+{#
+/**
+ * @file Contains the template to display the Person node's Last name field.
+ */
+#}
+{% if items.0 %}<span itemprop="familyName">{{ items.0.content|render|trim }}</span>{% endif %}

--- a/templates/field/field--field-ucb-person-links.html.twig
+++ b/templates/field/field--field-ucb-person-links.html.twig
@@ -1,10 +1,10 @@
 {#
 /**
-* Theme layout to display a UCB Person Link Field.
-*/
+ * @file Contains the template to display the Person node's Links field.
+ */
 #}
-
 {% if items %}
+<div>
 	<ul class="ucb-person-links">
 		{% for item in items %}
 			{%
@@ -17,9 +17,8 @@
 				]
 			%}
 			<li{{item.attributes.addClass(classes)}}>
-
 				{% set linkTitle = item.content['#title'] %}
-				{% set linkUrl = item.content['#url']|render|striptags|trim %}
+				{% set linkUrl = item.content['#url'].uri|trim %}
 				{% set linkUrlUpper = linkUrl|upper %}
 
 				{% if 'FACEBOOK' in linkUrlUpper %}
@@ -132,4 +131,5 @@
 			</li>
 		{% endfor %}
 	</ul>
+</div>
 {% endif %}

--- a/templates/field/field--field-ucb-person-links.html.twig
+++ b/templates/field/field--field-ucb-person-links.html.twig
@@ -18,7 +18,7 @@
 			%}
 			<li{{item.attributes.addClass(classes)}}>
 				{% set linkTitle = item.content['#title'] %}
-				{% set linkUrl = item.content['#url'].uri|trim %}
+				{% set linkUrl = item.content['#url'].uri %}
 				{% set linkUrlUpper = linkUrl|upper %}
 
 				{% if 'FACEBOOK' in linkUrlUpper %}

--- a/templates/field/field--field-ucb-person-phone.html.twig
+++ b/templates/field/field--field-ucb-person-phone.html.twig
@@ -1,13 +1,16 @@
 {#
 /**
-* Theme layout to display a UCB Person Phone Field.
-*/
+ * @file Contains the template to display the Person node's Phone field.
+ */
 #}
-
-<ul class="ucb-person-phone-numbers">
-    {% for item in items %}
-    <li>
-        <i class="fa fal fa-phone"></i>{{ item.attributes }} {{ item.content }}
-    </li>
-    {% endfor %}
-</ul>
+{% if items %}
+<div>
+	<ul class="ucb-person-phone-numbers">
+		{% for item in items %}
+		<li>
+			<i class="fa fal fa-phone"></i>&nbsp;<span itemprop="phone">{{ item.content }}</span>
+		</li>
+		{% endfor %}
+	</ul>
+</div>
+{% endif %}

--- a/templates/field/field--field-ucb-person-photo.html.twig
+++ b/templates/field/field--field-ucb-person-photo.html.twig
@@ -1,0 +1,10 @@
+{#
+/**
+ * @file Contains the template to display the Person node's Photo field.
+ */
+#}
+{% if items.0 %}
+<div class="ucb-person-img" itemprop="image">
+	{{ items.0.content }}
+</div>
+{% endif %}

--- a/templates/field/field--field-ucb-person-pronouns.html.twig
+++ b/templates/field/field--field-ucb-person-pronouns.html.twig
@@ -1,0 +1,14 @@
+{#
+/**
+ * @file Contains the template to display the Person node's Pronouns field.
+ */
+#}
+{% if items %}
+<div>
+	<ul class="ucb-person-pronouns">
+		{% for item in items %}
+		<li>(<span>{{ item.content|render|trim }}</span>)</li>
+		{% endfor %}
+	</ul>
+</div>
+{% endif %}

--- a/templates/field/field--field-ucb-person-pronouns.html.twig
+++ b/templates/field/field--field-ucb-person-pronouns.html.twig
@@ -7,7 +7,7 @@
 <div>
 	<ul class="ucb-person-pronouns">
 		{% for item in items %}
-		<li>(<span>{{ item.content|render|trim }}</span>)</li>
+		<li>(<span>{{ item.content['#context'].value|trim }}</span>)</li>
 		{% endfor %}
 	</ul>
 </div>

--- a/templates/field/field--field-ucb-person-title.html.twig
+++ b/templates/field/field--field-ucb-person-title.html.twig
@@ -1,3 +1,14 @@
-<ul class="ucb-person-title">
-	{% for item in items %}<li itemprop="jobTitle">{{ item.content }}</li> {% endfor %}
-</ul>
+{#
+/**
+ * @file Contains the template to display the Person node's Title field.
+ */
+#}
+{% if items %}
+<div>
+	<ul class="ucb-person-title">
+		{% for item in items %}
+		<li itemprop="jobTitle">{{ item.content|render|trim }}</li>
+		{% endfor %}
+	</ul>
+</div>
+{% endif %}

--- a/templates/field/field--field-ucb-person-title.html.twig
+++ b/templates/field/field--field-ucb-person-title.html.twig
@@ -7,7 +7,7 @@
 <div>
 	<ul class="ucb-person-title">
 		{% for item in items %}
-		<li itemprop="jobTitle">{{ item.content|render|trim }}</li>
+		<li itemprop="jobTitle">{{ item.content['#context'].value|trim }}</li>
 		{% endfor %}
 	</ul>
 </div>

--- a/templates/field/field--field-ucb-person-title.html.twig
+++ b/templates/field/field--field-ucb-person-title.html.twig
@@ -1,3 +1,3 @@
 <ul class="ucb-person-title">
-	{% for item in items %}<li itemprop="jobTitle">{{ item.content|render|striptags|trim|raw }}</li> {% endfor %}
+	{% for item in items %}<li itemprop="jobTitle">{{ item.content }}</li> {% endfor %}
 </ul>

--- a/templates/field/field--field-ucb-person-title.html.twig
+++ b/templates/field/field--field-ucb-person-title.html.twig
@@ -1,7 +1,3 @@
 <ul class="ucb-person-title">
-	{% for item in items %}
-		<li itemprop="jobTitle">
-			{{ item.content|render|striptags|trim }}
-		</li>
-	{% endfor %}
+	{% for item in items %}<li itemprop="jobTitle">{{ item.content|render|striptags|trim|raw }}</li> {% endfor %}
 </ul>


### PR DESCRIPTION
- Some special characters such as `&` in _Job Title_ and _Department_ fields displayed as `&amp;` on Person pages. These characters now display properly. Resolves CuBoulder/tiamat-theme#275
- An error resulted from the added `core/drupalSettings` dependency. This dependency is removed.
- Person page schema changes: `itemprop` attributes have been move into field templates; `itemscope` moved to the higher-level `<article>` tag.
- Additional cleanup of the Person page template