### PR TITLE
Fixes Content List and Text block stale cache issues

### DIFF
--- a/templates/block/block--content-list.html.twig
+++ b/templates/block/block--content-list.html.twig
@@ -8,17 +8,18 @@
 {{ attach_library('boulderD9_base/ucb-content-list') }}
 
 {% set blockContent = content['#block_content'] %}
+{% set _rendered = blockContent|view|render %}{# Easiest way to ensure the cache is updated when the block or a referenced node is. Resolves #377, 378. #}
 {% set sort = blockContent.field_content_list_sort.value %}
 {% set display = blockContent.field_content_list_display.value %}
-{% set content = blockContent.field_content_list_content %}
+{% set items = blockContent.field_content_list_content %}
 
 {# sorting #}
 {% if sort == 'created_asc' %}
-	{% set content = content|sort((a, b) => a.entity.created.value <=> b.entity.created.value) %}
+	{% set items = items|sort((a, b) => a.entity.created.value <=> b.entity.created.value) %}
 {% elseif sort == 'created_desc' %}
-	{% set content = content|sort((a, b) => b.entity.created.value <=> a.entity.created.value) %}
+	{% set items = items|sort((a, b) => b.entity.created.value <=> a.entity.created.value) %}
 {% elseif sort == 'alphabetical' %}
-	{% set content = content|sort((a, b) => a.entity.title.0.value|trim <=> b.entity.title.0.value|trim) %}
+	{% set items = items|sort((a, b) => a.entity.title.0.value|trim <=> b.entity.title.0.value|trim) %}
 {% endif %}
 
 {%
@@ -41,7 +42,7 @@
 	{% if label %}<h2{{ title_attributes }}>{{ label }}</h2>{% endif %}
 	{{ title_suffix }}
 	<div class="ucb-content-list-container">
-		{% if display == 'full' %}{% for key, item in content %}<div class="row ucb-content-list-row">
+		{% if display == 'full' %}{% for item in items %}<div class="row ucb-content-list-row">
 			{% set image = item.entity.field_ucb_article_thumbnail.entity.field_media_image ?? item.entity.field_ucb_person_photo.entity.field_media_image ?? item.entity.field_how_to_initial_image.entity.field_media_image %}
 			<div class="ucb-content-list-text-container{{ image ? ' col-9' : ' container' }}">
 				<h4 class="ucb-content-list-title"><a href="{{ item.entity.path.alias }}">{{ item.entity.title.0.value }}</a></h4>
@@ -50,7 +51,7 @@
 						{% for title in item.entity.field_ucb_person_title %}<span class="ucb-content-list-person-title">{{ title.value }}</span>{% endfor %}
 					</div>
 					<div class="ucb-content-list-person-departments">
-						{% for department in item.entity.field_ucb_person_department %}<span class="ucb-content-list-person-department">{{ department.entity.label|render|striptags|trim }}</span>{% endfor %}
+						{% for department in item.entity.field_ucb_person_department %}<span class="ucb-content-list-person-department">{{ department.entity.name.value }}</span>{% endfor %}
 					</div>
 					<div class="ucb-content-list-person-contact">
 						{% set email = item.entity.field_ucb_person_email.0.value %}{% if email %}<span class="ucb-content-list-person-contact-item ucb-content-list-person-email"><a href="mailto:{{ email }}">{{ email }}</a></span>{% endif %}
@@ -68,7 +69,7 @@
 				{% set imageURI = image.entity.fileuri|image_style('focal_image_square') %}{% set imageAlt = image.alt|render %}
 				<a href="{{ item.entity.path.alias }}"><img class="ucb-content-list-image" src="{{ imageURI }}" alt="{{ imageAlt }}"></a>
 			{% endif %}</div>
-		</div>{% endfor %}{% elseif display == 'condensed' or display == 'teaser' %}{% for key, item in content %}<div class="row ucb-content-list-row">
+		</div>{% endfor %}{% elseif display == 'condensed' or display == 'teaser' %}{% for item in items %}<div class="row ucb-content-list-row">
 			{% set image = item.entity.field_ucb_article_thumbnail.entity.field_media_image ?? item.entity.field_ucb_person_photo.entity.field_media_image ?? item.entity.field_how_to_initial_image.entity.field_media_image %}
 			<div class="ucb-content-list-image-container{{ image ? (display == 'condensed' ? ' col-2' : ' col-lg-3 col-2') : '' }}">{% if image %}
 				{% set imageURI = image.entity.fileuri|image_style('focal_image_square') %}{% set imageAlt = image.alt|render %}
@@ -81,7 +82,7 @@
 						{% for title in item.entity.field_ucb_person_title %}<span class="ucb-content-list-person-title">{{ title.value }}</span>{% endfor %}
 					</div>
 					<div class="ucb-content-list-person-departments">
-						{% for department in item.entity.field_ucb_person_department %}<span class="ucb-content-list-person-department">{{ department.entity.label|render|striptags|trim }}</span>{% endfor %}
+						{% for department in item.entity.field_ucb_person_department %}<span class="ucb-content-list-person-department">{{ department.entity.name.value }}</span>{% endfor %}
 					</div>
 					<div class="ucb-content-list-person-contact">
 						{% set email = item.entity.field_ucb_person_email.0.value %}{% if email %}<span class="ucb-content-list-person-contact-item ucb-content-list-person-email"><a href="mailto:{{ email }}">{{ email }}</a></span>{% endif %}
@@ -96,10 +97,10 @@
 					    <a class="ucb-content-list-read-more" href="{{ item.entity.path.alias }}">Read more &raquo;</a></p>
 			</div>
 		</div>{% endfor %}{% elseif display == 'title' %}
-		<ul class="ucb-content-list-list">{% for key, item in content %}
+		<ul class="ucb-content-list-list">{% for item in items %}
 			<li class="ucb-content-list-row ucb-content-list-title"><a href="{{ item.entity.path.alias }}">{{ item.entity.title.0.value }}</a></li>
 		{% endfor %}</ul>
-		{% elseif display == 'sidebar' %}{% for key, item in content %}<div class="row ucb-content-list-row">
+		{% elseif display == 'sidebar' %}{% for item in items %}<div class="row ucb-content-list-row">
 			{% set image = item.entity.field_ucb_article_thumbnail.entity.field_media_image ?? item.entity.field_ucb_person_photo.entity.field_media_image ?? item.entity.field_how_to_initial_image.entity.field_media_image %}
 			<div class="ucb-content-list-text-container{{ image ? ' col-lg-9 col-10' : ' container' }}">
 				<span class="ucb-content-list-title"><a href="{{ item.entity.path.alias }}">{{ item.entity.title.0.value }}</a></span>

--- a/templates/block/block--text-block.html.twig
+++ b/templates/block/block--text-block.html.twig
@@ -10,31 +10,31 @@
 {{ attach_library('boulderD9_base/ucb-text-block') }}
 
 
-{%
-  set classes = [
+{% set classes = [
 	'container',
 	'block',
-    'block-' ~ configuration.provider|clean_class,
-    'block-' ~ plugin_id|clean_class,
-    bundle ? 'block--type-' ~ bundle|clean_class,
-    view_mode ? 'block--view-mode-' ~ view_mode|clean_class,
-    ''
-  ]
-%}
+	'block-' ~ configuration.provider|clean_class,
+	'block-' ~ plugin_id|clean_class,
+	bundle ? 'block--type-' ~ bundle|clean_class,
+	view_mode ? 'block--view-mode-' ~ view_mode|clean_class,
+	''
+] %}
 
-{% if content['#block_content'].field_text_block_background.value == '1' %}
+{% set blockContent = content['#block_content'] %}
+{% set _rendered = blockContent|view|render %}{# Easiest way to ensure the cache is updated when the block or a referenced node is. Resolves #387. #}
+{% if blockContent.field_text_block_background.value == '1' %}
 	{% set blockBackground = 'text-block-light-gray' %}
-{% elseif content['#block_content'].field_text_block_background.value == '2' %}
+{% elseif blockContent.field_text_block_background.value == '2' %}
 	{% set blockBackground = 'text-block-dark-gray' %}
-{% elseif content['#block_content'].field_text_block_background.value == '3' %}
+{% elseif blockContent.field_text_block_background.value == '3' %}
 	{% set blockBackground = 'text-block-black' %}
-{% elseif content['#block_content'].field_text_block_background.value == '4' %}
+{% elseif blockContent.field_text_block_background.value == '4' %}
 	{% set blockBackground = 'text-block-gold' %}
 {% else %}
 	{% set blockBackground = 'text-block-white' %}
 {% endif %}
 
-{% if content['#block_content'].field_text_block_style.value  == '1' %}
+{% if blockContent.field_text_block_style.value  == '1' %}
 	{% set blockStyle = 'text-block-card' %}
 {% else %}
 	{% set blockStyle = 'text-block-default' %}


### PR DESCRIPTION
A Content List block may have failed to update properly after updating a referenced node. A Content List or Text block placed using Block Layout may have also failed to reflect changes made to the block's fields. This update includes a fix to prevent stale cache issues.

Resolves CuBoulder/tiamat-theme#377

Resolves CuBoulder/tiamat-theme#378

Resolves CuBoulder/tiamat-theme#387