### PR TITLE
Hero Unit Buttons fixed for Internal Links

### DIFF
--- a/templates/block/block--hero-unit.html.twig
+++ b/templates/block/block--hero-unit.html.twig
@@ -64,13 +64,11 @@
 {% endif %}
 
 <div{{attributes.addClass(classes)}}>
-	<div class="container">
 	{{ title_prefix }}
 	{% if label %}
 		<h2{{title_attributes}}>{{ label }}</h2>
 	{% endif %}
 	{{ title_suffix }}
-	</div>
 	{% block content %}
 		<div{{attributes.addClass(classes).setAttribute("style","#{bgValue}").addClass(size,overlayClass)}}>
 			{% if videoURL is defined %}

--- a/templates/block/block--hero-unit.html.twig
+++ b/templates/block/block--hero-unit.html.twig
@@ -64,11 +64,13 @@
 {% endif %}
 
 <div{{attributes.addClass(classes)}}>
+	<div class="container">
 	{{ title_prefix }}
 	{% if label %}
 		<h2{{title_attributes}}>{{ label }}</h2>
 	{% endif %}
 	{{ title_suffix }}
+	</div>
 	{% block content %}
 		<div{{attributes.addClass(classes).setAttribute("style","#{bgValue}").addClass(size,overlayClass)}}>
 			{% if videoURL is defined %}
@@ -96,9 +98,8 @@
 					<div class="col">
 						{{ content|without('field_links') }}
 						{# Render links here #}
-						{# <p> {{ dump(content['#block_content'].field_links.value) }} </p> #}
 							{% for item in content['#block_content'].field_links.value %}
-								<a href="{{ item.uri }}" class="button {{ linkColor }}"> {{ item.title }}
+								{{ link(item.title, item.uri, {'class': ['button', linkColor]} ) }}
 							</a>
 						{% endfor %}
 					</div>

--- a/templates/block/block--hero-unit.html.twig
+++ b/templates/block/block--hero-unit.html.twig
@@ -100,8 +100,7 @@
 						{# Render links here #}
 							{% for item in content['#block_content'].field_links.value %}
 								{{ link(item.title, item.uri, {'class': ['button', linkColor]} ) }}
-							</a>
-						{% endfor %}
+							{% endfor %}
 					</div>
 					{% if content['#block_content'].field_text_align.value == "text-lefthalf" %}
 						<div class="col-12 col-md-6"></div>


### PR DESCRIPTION
Hero Unit buttons correctly link when provided internal links either by direct internal url or selected by page title within the form. 

Resolves #407 