### PR TITLE
Adds Link field to Events Block

### DIFF
--- a/css/block/events-calendar.css
+++ b/css/block/events-calendar.css
@@ -277,6 +277,29 @@ table.localist_minicalendar_minicalendar caption {
   line-height: 1;
 }
 
+.ucb-calendar-block-link-container{
+  text-align: center;
+}
+
+.ucb-calendar-button{
+  display: inline-block;
+  padding: 5px 10px;
+  font-weight: bold;
+  font-family: "Roboto","Helvetica Neue",Helvetica,Arial,sans-serif;
+  margin-bottom: 5px;
+  background-clip: padding-box;
+  color: #0277BD !important;
+  border: 1px solid #0277BD;
+  border-radius: 0px;
+  background-color: transparent;
+}
+
+.ucb-calendar-button:hover{
+  transition: background-color 0.25s ease, border-color 0.25s ease, color 0.25s ease;
+  background-color: #0277BD;
+  color: white !important;
+}
+
 @media screen and (min-width: 600px) {
   .template-5 .le-date-wrapper .le-date-month {
     font-size: 250%;

--- a/templates/block/block--events-calendar.html.twig
+++ b/templates/block/block--events-calendar.html.twig
@@ -27,6 +27,12 @@
 			<h2{{title_attributes}}>{{ label }}</h2>
 		{% endif %}
 		{{ title_suffix }}
-		{{ content }}
+		{{ content|without('field_additional_events_link') }}
+		{# Events Link #}
+		<div class="ucb-calendar-block-link-container">
+		{% for item in content['#block_content'].field_additional_events_link.value %}
+			{{ link(item.title, item.uri, {'class': ['ucb-calendar-button']} ) }}
+		{% endfor %}
+		</div>
 	</div>
 {% endblock %}


### PR DESCRIPTION
Resolves #381 - Adds a Link field to the Events Calendar Block to allow for links to additional events. 

Includes:
[tiamat-theme](https://github.com/CuBoulder/tiamat-theme) => [issue/tiamat-theme/381 ](https://github.com/CuBoulder/tiamat-theme/pull/411)
[tiamat-custom-entities](https://github.com/CuBoulder/tiamat-custom-entities) => [issue/tiamat-theme/381](https://github.com/CuBoulder/tiamat-custom-entities/pull/65)