### PR TITLE
Change: Article Taxonomy term display style

### DIFF
--- a/css/ucb-article.css
+++ b/css/ucb-article.css
@@ -32,13 +32,23 @@ i.far.fa-calendar {
   line-height: 1em;
 }
 
+.ucb-article-category-icon, .ucb-article-tag-icon{
+  background-color: #555555;
+  color: #e7e7e7;
+  height: 16px;
+  width: 16px;
+}
+.ucb-article-category-icon > svg, .ucb-article-tag-icon > svg{
+ padding: 2px;
+}
+
 .ucb-article-categories div,
 .ucb-article-tags div,
 .ucb-article-issue div {
   display: flex;
   flex-direction: row;
-  margin-right: 1em;
   line-height: 1.5em;
+  padding: 2px;
 }
 
 .ucb-article-categories a:link,
@@ -51,7 +61,6 @@ i.far.fa-calendar {
   color: #555;
   padding: 2px 6px;
   display: inline-block;
-  text-transform: uppercase;
   margin: 0 5px 5px 0;
 }
 

--- a/templates/content/node--ucb-article.html.twig
+++ b/templates/content/node--ucb-article.html.twig
@@ -202,7 +202,7 @@ pageStyleCSS
 			{% if content.field_ucb_article_categories|render %}
 				<div role="contentinfo" class="container ucb-article-categories" itemprop="about">
 					<span class="sr-only">Categories:</span>
-					<div>
+					<div class="ucb-article-category-icon">
 						<i class="fas fa-folder-open"></i>
 					</div>
 					{{ content.field_ucb_article_categories }}
@@ -210,7 +210,7 @@ pageStyleCSS
 			{% endif %}
 			{% if content.field_ucb_article_tags|render %}
 				<div role="contentinfo" class="container ucb-article-tags" itemprop="keywords">
-					<div>
+					<div class="ucb-article-tag-icon">
 						<span class="sr-only">Tags:</span>
 						<i class="fas fa-tags"></i>
 					</div>


### PR DESCRIPTION
Resolves #348  - Changes Article Taxonomy term display style. Terms are no longer be all uppercase and icon flush with first term. Color changes to icons. 

