### PR TITLE
Change: Adds 'White' background to card-styled Text Block

### DIFF
--- a/css/block/text-block.css
+++ b/css/block/text-block.css
@@ -72,6 +72,11 @@
   color: var(--ucb-black);
   border: 1px solid var(--ucb-black);
 }
+.text-block-white.text-block-card {
+  background: var(--ucb-white);
+  color: var(--ucb-black);
+  border: 1px solid var(--ucb-black);
+}
 
 .ucb-bootstrap-layout__background-color--gold .text-block-card {
   border: 1px solid var(--ucb-black);

--- a/templates/block/block--text-block.html.twig
+++ b/templates/block/block--text-block.html.twig
@@ -33,7 +33,7 @@
 {% elseif blockContent.field_text_block_background.value == '5' %}
 	{% set blockBackground = 'text-block-white' %}
 {% else %}
-	{% set blockBackground = 'text-block-white' %}
+	{% set blockBackground = 'text-block-none' %}
 {% endif %}
 
 {% if blockContent.field_text_block_style.value  == '1' %}

--- a/templates/block/block--text-block.html.twig
+++ b/templates/block/block--text-block.html.twig
@@ -30,6 +30,8 @@
 	{% set blockBackground = 'text-block-black' %}
 {% elseif blockContent.field_text_block_background.value == '4' %}
 	{% set blockBackground = 'text-block-gold' %}
+{% elseif blockContent.field_text_block_background.value == '5' %}
+	{% set blockBackground = 'text-block-white' %}
 {% else %}
 	{% set blockBackground = 'text-block-white' %}
 {% endif %}


### PR DESCRIPTION
Adds a White background option to card-style Text Block for the case where sections have a different colored background

Includes:

- `tiamat-theme` => `issue/tiamat-theme/413`
- `tiamat-custom-entities` => `issue/tiamat-theme/413`

Resolves #413 