### PR TITLE
Page Title on user-set default Front Page set to screen-read only

### DIFF
--- a/boulder_base.theme
+++ b/boulder_base.theme
@@ -39,6 +39,20 @@ function boulder_base_page_attachments_alter(array &$page) {
   $page['#attached']['drupalSettings']['themePath'] = \Drupal::theme()->getActiveTheme()->getPath(); // Exposes a relative theme path in drupalSettings
 }
 
+/**
+ * Preprocess function to check if this page is set as front page, available to all nodes
+ */
+function boulder_base_preprocess(&$variables, $hook) {
+  try {
+    $variables['is_front'] = \Drupal::service('path.matcher')->isFrontPage();
+  }
+  catch (Exception $e) {
+    $variables['is_front'] = FALSE;
+  }
+  // Ensure the cache varies correctly (new in Drupal 8.3).
+  $variables['#cache']['contexts'][] = 'url.path.is_front';
+}
+
 /***
  * Preprocess function to get the variables we'll need on the html template
  */
@@ -192,16 +206,6 @@ function boulder_base_preprocess_node__ucb_article(array &$variables) {
 		$userCanEdit = $node->access('update', $user);
 		$variables['user_can_edit'] = $userCanEdit;
 	}
-}
-
-/*
-* Exposes front page variables to determine if title is shown on basic page
-*/
-function boulder_base_preprocess_node__basic_page(array &$variables) {
-    $front_uri = Drupal::config('system.site')->get('page.front');
-    $variables['current_path'] = \Drupal::service('path.current')->getPath();
-    $variables['front_uri'] = Drupal::config('system.site')->get('page.front');
-    $variables['front_alias'] = \Drupal::service('path_alias.manager')->getAliasByPath($front_uri);
 }
 
 /***

--- a/boulder_base.theme
+++ b/boulder_base.theme
@@ -194,6 +194,16 @@ function boulder_base_preprocess_node__ucb_article(array &$variables) {
 	}
 }
 
+/*
+* Exposes front page variables to determine if title is shown on basic page
+*/
+function boulder_base_preprocess_node__basic_page(array &$variables) {
+    $front_uri = Drupal::config('system.site')->get('page.front');
+    $variables['current_path'] = \Drupal::service('path.current')->getPath();
+    $variables['front_uri'] = Drupal::config('system.site')->get('page.front');
+    $variables['front_alias'] = \Drupal::service('path_alias.manager')->getAliasByPath($front_uri);
+}
+
 /***
  *  Custom theme settings worker function
  ***/

--- a/templates/content/node--basic-page.html.twig
+++ b/templates/content/node--basic-page.html.twig
@@ -76,7 +76,7 @@
 {# Used for hiding site title visibly using sr-only bootstrap class #}
 {% set site_url = path("<current>") %} 
 {% set srOnly = '' %}
-{% if site_url is same as '/homepage' %}
+{% if site_url is same as front_alias %}
 	{% set srOnly = 'sr-only' %}
 {% endif %}
 

--- a/templates/content/node--basic-page.html.twig
+++ b/templates/content/node--basic-page.html.twig
@@ -73,11 +73,10 @@
 {#Dummy variable to ensure that all content tags are set for caching purposes#}
 {% set content_render = content|render %}
 
-{# Used for hiding site title visibly using sr-only bootstrap class #}
-{% set site_url = path("<current>") %} 
-{% set srOnly = '' %}
-{% if site_url is same as front_alias %}
-	{% set srOnly = 'sr-only' %}
+{# Used for hiding site title visibly using sr-only bootstrap class, if front page #}
+{% set isFrontPage = '' %}
+{% if is_front %}
+	{% set isFrontPage = 'sr-only' %}
 {% endif %}
 
 {%
@@ -90,7 +89,7 @@
 <article{{attributes.addClass(classes)}}>
 	{% if label %}
 		<div class="container">
-			<h1{{title_attributes}} class="{{srOnly}}">
+			<h1{{title_attributes}} class="{{isFrontPage}}">
 				{{ label }}
 			</h1>
 		</div>

--- a/templates/content/node--form-page.html.twig
+++ b/templates/content/node--form-page.html.twig
@@ -9,9 +9,15 @@
 
 {% set sidebar_position = drupal_config('boulder_base.settings', 'ucb_sidebar_position') %}
 
+{# Used for hiding site title visibly using sr-only bootstrap class, if front page #}
+{% set isFrontPage = '' %}
+{% if is_front %}
+	{% set isFrontPage = 'sr-only' %}
+{% endif %}
+
 <article{{attributes.addClass(classes)}}>
 	<div class="container">
-		<h1{{title_attributes}}>
+		<h1{{title_attributes}} class="{{isFrontPage}}">
 			{{ label }}
 		</h1>
 	</div>

--- a/templates/content/node--how-to-page.html.twig
+++ b/templates/content/node--how-to-page.html.twig
@@ -16,10 +16,17 @@
   view_mode ? 'node--view-mode-' ~ view_mode|clean_class,
 ]
 %}
+
+{# Used for hiding site title visibly using sr-only bootstrap class, if front page #}
+{% set isFrontPage = '' %}
+{% if is_front %}
+	{% set isFrontPage = 'sr-only' %}
+{% endif %}
+
 {% set jsonLD2 =  ' "@context": "https://schema.org", "@type": "HowTo",' %}
 <article{{attributes.addClass(classes)}}>
 	<div class="container">
-		<h1{{title_attributes}}>
+		<h1{{title_attributes}} class="{{isFrontPage}}">
 			<span id="titleValue">{{ label }}</span>
 			{% set jsonLD2 = jsonLD2 ~ '"name": ' ~ label|render|striptags|json_encode ~ ','%}
 		</div>

--- a/templates/content/node--newsletter.html.twig
+++ b/templates/content/node--newsletter.html.twig
@@ -18,6 +18,12 @@ view_mode ? 'node--view-mode-' ~ view_mode|clean_class,
 ]
 %}
 
+{# Used for hiding site title visibly using sr-only bootstrap class, if front page #}
+{% set isFrontPage = '' %}
+{% if is_front %}
+	{% set isFrontPage = 'sr-only' %}
+{% endif %}
+
 {#Dummy variable to ensure that all content tags are set for caching purposes#}
 {% set content_render = content|render %}
 
@@ -32,7 +38,7 @@ view_mode ? 'node--view-mode-' ~ view_mode|clean_class,
 		data-loggedin="{{isLoggedIn}}"
 		>
 		{# Newsletter Title #}
-		<h1 class="ucb-newsletter-title" itemprop="name">{{ label }}</h1>
+		<h1 class="ucb-newsletter-title {{isFrontPage}}" itemprop="name">{{ label }}</h1>
 		{# Newsletter Intro #}
 		{% if content.field_newsletter_intro_image|render %}
 			<div id="newsletter-intro-img">{{ content.field_newsletter_intro_image }}</div>

--- a/templates/content/node--ucb-article-list.html.twig
+++ b/templates/content/node--ucb-article-list.html.twig
@@ -75,6 +75,12 @@
 
 {{ attach_library('boulder_base/ucb-article-list') }}
 
+{# Used for hiding site title visibly using sr-only bootstrap class, if front page #}
+{% set isFrontPage = '' %}
+{% if is_front %}
+	{% set isFrontPage = 'sr-only' %}
+{% endif %}
+
 {# NEW #}
 {# JSON API Endpoint information #}
 {% set articlesJSON = (url('<front>')|render|trim('/'))
@@ -260,7 +266,7 @@
 
 {# JSON API Filter logic #}
 <article {{ attributes.addClass('container') }}>
-  <h1 class="ucb-article-list-header">
+  <h1 class="ucb-article-list-header {{isFrontPage}}">
     {{ label }}
   </h1>
 

--- a/templates/content/node--ucb-article.html.twig
+++ b/templates/content/node--ucb-article.html.twig
@@ -11,6 +11,12 @@
 {{ attach_library('boulder_base/ucb-related-articles') }}
 {# Added class to article class 'pageStyleCSS' to control page style #}
 
+{# Used for hiding site title visibly using sr-only bootstrap class, if front page #}
+{% set isFrontPage = '' %}
+{% if is_front %}
+	{% set isFrontPage = 'sr-only' %}
+{% endif %}
+
 {% set excludeCats = related_articles_exclude_categories %}
 {% set excludeTags = drupal_config('ucb_site_configuration.settings', 'related_articles_exclude_tags') %}
 
@@ -152,7 +158,7 @@ pageStyleCSS
 				<div class="backgroundTitleDiv {{overlayClass}}">
 					{{ content.field_article_title_background }}
 					<div class="container">
-						<h1 class="centeredTitle article-header-{{textColor}}">{{label}}</h1>
+						<h1 class="centeredTitle article-header-{{textColor}} {{isFrontPage}}">{{label}}</h1>
 					</div>
 				</div>
 			{% endif %}
@@ -160,7 +166,7 @@ pageStyleCSS
 				{# If NO Title Background img, render the regular title #}
 				{% if not content.field_article_title_background|render %}
 				<header role="banner" class="ucb-article-banner">
-					<h1 class="ucb-article-heading">{{ label }}</h1>
+					<h1 class="ucb-article-heading {{isFrontPage}}">{{ label }}</h1>
 				</header>
 				{% endif %}
 				{% if social_share_button_position == "4" or social_share_button_position == "1"%}

--- a/templates/content/node--ucb-issue-archive.html.twig
+++ b/templates/content/node--ucb-issue-archive.html.twig
@@ -12,9 +12,15 @@
 	]
 %}
 
+{# Used for hiding site title visibly using sr-only bootstrap class, if front page #}
+{% set isFrontPage = '' %}
+{% if is_front %}
+	{% set isFrontPage = 'sr-only' %}
+{% endif %}
+
 <div id="ucb-issue-archive"{{attributes.addClass(classes)}}>
 	<div class="ucb-issue-archive-title">
-		<h1{{title_attributes}}>
+		<h1{{title_attributes}} class="{{isFrontPage}}">
 			{{ label }}
 		</h1>
 	</div>

--- a/templates/content/node--ucb-issue.html.twig
+++ b/templates/content/node--ucb-issue.html.twig
@@ -11,10 +11,16 @@
     ]
     %}
 
+{# Used for hiding site title visibly using sr-only bootstrap class, if front page #}
+{% set isFrontPage = '' %}
+{% if is_front %}
+	{% set isFrontPage = 'sr-only' %}
+{% endif %}
+
 <div class="container">
     <div class="row">
         <header role="banner" class="ucb-article-banner">
-			<h1 class="ucb-article-heading">{{ label }}</h1>
+			<h1 class="ucb-article-heading {{isFrontPage}}">{{ label }}</h1>
 		</header>
     </div>
 

--- a/templates/content/node--ucb-people-list-page.html.twig
+++ b/templates/content/node--ucb-people-list-page.html.twig
@@ -9,6 +9,13 @@
 #}
 {{ attach_library('boulder_base/ucb-page') }}
 {{ attach_library('boulder_base/ucb-people-list-page') }}
+
+{# Used for hiding site title visibly using sr-only bootstrap class, if front page #}
+{% set isFrontPage = '' %}
+{% if is_front %}
+	{% set isFrontPage = 'sr-only' %}
+{% endif %}
+
 {%
 	set classes = [
 		'node',
@@ -67,7 +74,7 @@
 %}
 <article id="ucb-people-list-page"{{attributes.addClass(classes)}}>
 	<div class="ucb-people-list-title">
-		<h1{{title_attributes}}>
+		<h1{{title_attributes}} class="{{isFrontPage}}">
 			{{ label }}
 		</h1>
 	</div>

--- a/templates/content/node--ucb-person.html.twig
+++ b/templates/content/node--ucb-person.html.twig
@@ -16,15 +16,10 @@
 	view_mode ? 'node--view-mode-' ~ view_mode|clean_class,
 ] %}
 
-{# Used for hiding site title visibly using sr-only bootstrap class, if front page #}
-{% set isFrontPage = '' %}
-{% if is_front %}
-	{% set isFrontPage = 'sr-only' %}
-{% endif %}
 
 <article{{attributes.addClass(classes)}} itemscope itemtype="https://schema.org/Person">
 	<div class="container ucb-person-header">
-		<h1 class="ucb-person-name {{isFrontPage}}">
+		<h1 class="ucb-person-name">
 			{{ content.field_ucb_person_first_name }}
 			{{ content.field_ucb_person_last_name }}
 		</h1>

--- a/templates/content/node--ucb-person.html.twig
+++ b/templates/content/node--ucb-person.html.twig
@@ -16,9 +16,15 @@
 	view_mode ? 'node--view-mode-' ~ view_mode|clean_class,
 ] %}
 
+{# Used for hiding site title visibly using sr-only bootstrap class, if front page #}
+{% set isFrontPage = '' %}
+{% if is_front %}
+	{% set isFrontPage = 'sr-only' %}
+{% endif %}
+
 <article{{attributes.addClass(classes)}} itemscope itemtype="https://schema.org/Person">
 	<div class="container ucb-person-header">
-		<h1 class="ucb-person-name">
+		<h1 class="ucb-person-name {{isFrontPage}}">
 			{{ content.field_ucb_person_first_name }}
 			{{ content.field_ucb_person_last_name }}
 		</h1>


### PR DESCRIPTION
Resolves #448 

Sets the title of pages chosen to be the site's default front page to 'sr-only' class. Will hide the title visually but still accessible to screen readers. Currently this works only if the page is set to explicitly the default '/homepage'. 