### PR TITLE
Re-factor of Drupal Regions to more closely match D7 Express

### DIFF
--- a/boulder_base.info.yml
+++ b/boulder_base.info.yml
@@ -14,16 +14,16 @@ regions:
   secondary_menu: "Secondary Menu"
   alerts: "Alerts"
   breadcrumb: "Breadcrumb Navigation"
+  post_wide_title: "Post Wide Title"
   above_content: "Above Content"
-  left_sidebar: "Left Sidebar"
-  content: "Main Content"
-  right_sidebar: "Right Sidebar"
-  below_content: "Below Content"
+  left_sidebar: "Sidebar First"
+  content: "Content"
+  right_sidebar: "Sidebar Second"
+  wide_post: "Wide Post"
+  below_content: "After Content"
+  second_below_content: "After Content 2"
   social: "Social Media Menu"
-  footer_cta: "Footer Call-To-Action"
-  footer_nav_one: "Footer Navigation One"
-  footer_nav_two: "Footer Navigation Two"
-  footer_nav_three: "Footer Navigation Three"
-  footer_nav_four: "Footer Navigation Four"
-  footer_menu: 'Footer Menu'
   footer: "Footer"
+  site_information: 'Site Information'
+  footer_menu: 'Footer Menu'
+

--- a/boulder_base.theme
+++ b/boulder_base.theme
@@ -185,7 +185,7 @@ function boulder_base_preprocess_region__header(array &$variables) {
 /***
  * Preprocess function to get the variables we'll need on the footer region template
  */
-function boulder_base_preprocess_region__footer(array &$variables) {
+function boulder_base_preprocess_region__site_information(array &$variables) {
   $variables['theme_path'] = base_path() . $variables['directory'];
   $variables['ucb_be_boulder'] = theme_get_setting('ucb_be_boulder');
 }

--- a/templates/layout/page.html.twig
+++ b/templates/layout/page.html.twig
@@ -149,6 +149,11 @@
   <main role="main">
     <a id="main-content" tabindex="-1"></a>{# link is in html.html.twig #}
     <div class="layout-content">
+     {% if page.post_wide_title|render %}
+        <div class="ucb-post-wide-title-region">
+          {{ page.post_wide_title }}
+        </div>
+      {% endif %}
       {% if page.above_content|render %}
         <div class="ucb-above-content-region">
           {{ page.above_content }}
@@ -196,47 +201,40 @@
         {{ page.content }}
       {% endif %}
 
+      {% if page.wide_post|render %}
+        <div class="ucb-below-content-region">
+          {{ page.wide_post }}
+        </div>
+      {% endif %}
       {% if page.below_content|render %}
         <div class="ucb-below-content-region">
           {{ page.below_content }}
+        </div>
+      {% endif %}
+      {% if page.second_below_content|render %}
+        <div class="ucb-below-content-region">
+          {{ page.second_below_content }}
         </div>
       {% endif %}
     </div>{# /.layout-content #}
   </main>
   </div>
 
-  {# FOOTER BLOCK #}
+{# FOOTER BLOCK #}
   {% block page_footer %}
   <footer class="ucb-homepage-footer background-black">
-    {% if page.footer_cta|render or page.footer_nav_one|render or ucb_footer_menu_default_links %}
+    {% if page.footer|render or ucb_footer_menu_default_links %}
       <div class="ucb-footer-top">
-        {% if page.footer_cta|render %}
+        {# {% if page.footer_cta|render %}
           <div class="ucb-footer-container footer-cta-block container">
             {{ page.footer_cta }}
           </div>
-        {% endif %}
+        {% endif %} #}
         {% if ucb_footer_menu_default_links %}
           {% include "@boulder_base/includes/ucb-footer-menus.html.twig" %}
-        {% elseif page.footer_nav_one|render %}
-          <div class="ucb-footer-nav-container container">
-            <div class="ucb-footer-nav-block">
-              {{ page.footer_nav_one }}
-            </div>
-            {% if page.footer_nav_two|render %}
-              <div class="ucb-footer-nav-block">
-                {{ page.footer_nav_two }}
-              </div>
-            {% endif %}
-            {% if page.footer_nav_three|render %}
-              <div class="ucb-footer-nav-block">
-                {{ page.footer_nav_three }}
-              </div>
-            {% endif %}
-            {% if page.footer_nav_four|render %}
-              <div class="ucb-footer-nav-block">
-                {{ page.footer_nav_four }}
-              </div>
-            {% endif %}
+        {% elseif page.footer|render %}
+          <div class="container ucb-footer-columns">
+            {{ page.footer }}
           </div>
         {% endif %}
       </div>
@@ -248,14 +246,15 @@
         {{ page.social }}
       </div>
     {% endif %}
-    {% if page.footer|render %}
+    {% if page.site_information|render %}
       <div class="container">
-        {{ page.footer }}
+        {{ page.site_information }}
       </div>
     {% endif %}
     </div>
   </footer>
   {% endblock %}
+
 
 
 </div>{# /.layout-container #}

--- a/templates/regions/region--footer.html.twig
+++ b/templates/regions/region--footer.html.twig
@@ -1,26 +1,20 @@
 {#
 /**
- * Theme layout to display a UCB Breadcrumb Region page.
+ * Theme layout to display a UCB Footer Region page.
  *
- * Created by jsparks on 6/18/19
+ * Created by jnichol4 on 8/17/23
  */
 #}
 
 
-{% if content|render and ucb_be_boulder|number_format == 1 %}
-  <div class="be-boulder-container">
-    <div class="col-lg-4 col-md-4 col-sm-6 col-xs-12">
-      {{ content }}
-    </div>
-    <div class="col-log-4 col-md-4 col-sm-6 col-xs-12 offset-lg-4 offset-md-4">
-      <div class="ucb-footer">
-        <p><a href="https://www.colorado.edu"><img alt="Be Boulder." class="ucb-footer-be-boulder" src="https://cdn.colorado.edu/static/brand-assets/live/images/be-boulder-white.svg" style="max-width:240px; height:auto;" /></a></p>
-        <p><a class="ucb-home-link" href="https://www.colorado.edu">University of Colorado Boulder</a></p>
-        <p>© Regents of the University of Colorado</p>
-        <p class="ucb-footer-links"><a href="http://www.colorado.edu/about/privacy-statement">Privacy</a> • <a href="http://www.colorado.edu/about/legal-trademarks">Legal &amp; Trademarks</a> • <a href="http://www.colorado.edu/map">Campus Map</a></p>
-      </div>
-    </div>
-  </div>
-{% else %}
-  {{ content }}
+{% if content|render %}
+	<div class="row row-cols-lg-4 row-cols-md-2 row-cols-1 footer-columns">
+		{% for item in elements %}
+			{% if item.content|render|striptags|trim is not empty %}
+				<div class="col flex-fill">
+					{{ item.content }}
+				</div>
+			{% endif %}
+		{% endfor %}
+	</div>
 {% endif %}

--- a/templates/regions/region--site-information.html.twig
+++ b/templates/regions/region--site-information.html.twig
@@ -1,0 +1,27 @@
+{#
+/**
+ * Theme layout to display a UCB Site Information Region page.
+ *
+ * Created by jsparks on 6/18/19
+ * Updated by jnichol4 on 8/17/23
+ */
+#}
+
+
+{% if content|render and ucb_be_boulder|number_format == 1 %}
+  <div class="be-boulder-container">
+    <div class="col-lg-4 col-md-4 col-sm-6 col-xs-12">
+      {{ content }}
+    </div>
+    <div class="col-log-4 col-md-4 col-sm-6 col-xs-12 offset-lg-4 offset-md-4">
+      <div class="ucb-info-footer">
+        <p><a href="https://www.colorado.edu"><img alt="Be Boulder." class="ucb-footer-be-boulder" src="https://cdn.colorado.edu/static/brand-assets/live/images/be-boulder-white.svg" style="max-width:240px; height:auto;" /></a></p>
+        <p><a class="ucb-home-link" href="https://www.colorado.edu">University of Colorado Boulder</a></p>
+        <p>© Regents of the University of Colorado</p>
+        <p class="ucb-info-footer-links"><a href="http://www.colorado.edu/about/privacy-statement">Privacy</a> • <a href="http://www.colorado.edu/about/legal-trademarks">Legal &amp; Trademarks</a> • <a href="http://www.colorado.edu/map">Campus Map</a></p>
+      </div>
+    </div>
+  </div>
+{% else %}
+  {{ content }}
+{% endif %}


### PR DESCRIPTION
Added new regions to to .info
Added new region rendering to page
Changed where the slogan is displayed in .theme
Added new `site-information.html.twig` for new region where slogan is displayed
Updated `footer.html.twig` to iterate through content so that it automatically adds columns (up to 4 per row)

I left our current machine names for items like `left_sidebar` the same but changed their display names to match the ones given by Kevin to `Sidebar First`

We also have logic written in the page.html.twig in case two sidebars are made through the block layout. Currently the settings only allow for one though.

I have left social media menu and footer menu as regions for the time being because I think those need to be separate for menuing purposes at the moment. 

Sister PR: https://github.com/CuBoulder/tiamat10-profile/pull/18