### PR TITLE
Remove Extra Markup from inserted Images

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -831,8 +831,3 @@ table.table-vertical td, div.table-vertical table td {
   border-top: none;
   border-bottom: none;
 }
-
-figure:has(div:has(div:has(div:has(.wide_image_style)))){
-  margin-left: 0px !important;
-  margin-right: 0px !important;
-}

--- a/css/style.css
+++ b/css/style.css
@@ -496,6 +496,9 @@ div#drupal-off-canvas-wrapper {
 }
 
 /* Image Styles */ 
+.imageMediaStyle{
+  display: inline;
+}
 .imageMediaStyle img{
   padding-bottom: 20px;
 }
@@ -827,4 +830,9 @@ table.table-horizontal td, div.table-horizontal table td {
 table.table-vertical td, div.table-vertical table td {
   border-top: none;
   border-bottom: none;
+}
+
+figure:has(div:has(div:has(div:has(.wide_image_style)))){
+  margin-left: 0px !important;
+  margin-right: 0px !important;
 }

--- a/templates/content/media.html.twig
+++ b/templates/content/media.html.twig
@@ -1,0 +1,10 @@
+{# This condition prevents wrapping in an unnecessary <div> #}
+{% if attributes != "" %}
+<div{{ attributes }}>
+  {{ title_suffix.contextual_links }}
+  {{ content }}
+</div>
+{% else %}
+  {{ title_suffix.contextual_links }}
+  {{ content }}
+{% endif %}


### PR DESCRIPTION
Conditionally removes extra `<div>` elements added through Twig when there's no attributes to justify an additional `<div>` wrap of the rendered content. 

Changes default div styling of the imageMediaStyle class to not be `display:block`, both of which caused issues with wrapping an image in an anchor tag making the entire row clickable rather than just the image.

Resolves https://github.com/CuBoulder/tiamat-theme/issues/522