### PR TITLE
Adds search frontend and settings

### DIFF
--- a/boulder_base.libraries.yml
+++ b/boulder_base.libraries.yml
@@ -328,6 +328,28 @@ ucb-article-feature-block:
     theme:
       css/block/ucb-article-feature-block.css: {}
 
+ucb-brand-bar:
+  version: 1.x
+  css:
+    theme:
+      css/ucb-brand-bar.css: {}
+
+ucb-search-box:
+  version: 1.x
+  js:
+    js/ucb-search-box.js: {}
+  css:
+    theme:
+      css/ucb-search-box.css: {}
+
+ucb-search-modal:
+  version: 1.x
+  js:
+    js/ucb-search-modal.js: {}
+  css:
+    theme:
+      css/ucb-search-modal.css: {}
+
 ucb-menu-style-highlight:
   version: 1.x
   css:

--- a/css/style.css
+++ b/css/style.css
@@ -1,504 +1,531 @@
 /**** GLOBAL STYLES ******/
 :root {
-    --ucb-gold: #cfb87b;
-    --ucb-link: #0277bd;
-    --ucb-link-visited: #e51c23;
-    --ucb-white: #fff;
-    --ucb-black: #222;
-    --ucb-darker: #333;
-    --ucb-light-contrast: #e7e7e7;
-    --ucb-off-white: #f2f2f2;
-    --ucb-dark-gray: #424242;
-    --ucb-light-gray: #eee;
-    --ucb-light-blue: #e1f5fe;
-  }
-  
-  body {
-    min-height: 100%;
-    display: flex;
-    flex-direction: column;
-    font: 16px/24px Roboto, "Helvetica Neue", Helvetica, Arial, sans-serif;
-    -webkit-font-smoothing: antialiased;
-    -moz-osx-font-smoothing: grayscale;
-    text-rendering: optimizelegibility;
-  }
-  
-  .ucb-page-content {
-  }
+  --ucb-gold: #cfb87b;
+  --ucb-link: #0277bd;
+  --ucb-link-visited: #e51c23;
+  --ucb-white: #fff;
+  --ucb-black: #222;
+  --ucb-darker: #333;
+  --ucb-light-contrast: #e7e7e7;
+  --ucb-off-white: #f2f2f2;
+  --ucb-dark-gray: #424242;
+  --ucb-light-gray: #eee;
+  --ucb-light-blue: #e1f5fe;
+}
 
-  .ucb-breadcrumb-region {
-    padding: 10px 0;
-  }
+body {
+  min-height: 100%;
+  display: flex;
+  flex-direction: column;
+  font: 16px/24px Roboto, "Helvetica Neue", Helvetica, Arial, sans-serif;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  text-rendering: optimizelegibility;
+}
 
-  main {
-    padding: 0 0 10px 0;
-  }
-  
-  h1,
-  h2,
-  h3,
-  h4,
-  h5 {
-    font-family: Roboto, "Helvetica Neue", Helvetica, Arial, sans-serif;
-  }
-  
-  a:link,
-  a:visited {
-    color: var(--ucb-link);
-  }
-  
-  a:hover {
-    color: var(--ucb-link-visited);
-    text-decoration: none;
-  }
-  
-  button {
-    border: none;
-  }
-  
-  input[type="submit"] {
-    border: none;
-  }
-  
-  .ucb-homepage-footer a {
-    color: var(--ucb-gold);
-  }
-  
-  .toolbar-menu a,
-  .toolbar-menu a:visited {
-    color: #565656;
-  }
-  
-  .ucb-local-tasks li > a {
-    color: var(--ucb-light-contrast);
-  }
-  
-  .ucb-homepage-footer a:hover {
-    color: var(--ucb-white);
-  }
-  
-  .ucb-page-container {
-    min-height: 100vh;
-    display: flex;
-    flex-direction: column;
-  }
-  
-  .page-header.local-tasks-present {
-    margin-top: 32px;
-  }
-  
-  .list-style-none {
-    list-style: none;
-    padding-left: 0;
-  }
-  
-  /********* Fonts *************/
-  .ucb-roboto-bold {
-    font-family:
-      Roboto,
-      "Helvetica Neue",
-      Helvetica,
-      Arial,
-      sans-serif;
-    font-weight: bold;
-  }
-  
-  .ucb-roboto-condensed-bold {
-    font-family:
-      "Roboto Condensed",
-      "Helvetica Neue",
-      Helvetica,
-      Arial,
-      sans-serif;
-    font-weight: bold;
-  }
-  
-  .ucb-roboto {
-    font-family: Roboto, "Helvetica Neue", Helvetica, Arial, sans-serif;
-  }
-  
-  .font-white {
-    color: var(--ucb-white);
-  }
-  
-  .font-gold {
-    color: var(--ucb-gold);
-  }
-  
-  .font-black {
-    color: var(--ucb-black);
-  }
-  
-  /******** Header Region **********/
-  .ucb-brand-bar {
-    padding: 1rem 0;
-  }
-  
-  .ucb-admin-alert {
-    margin-bottom: 0;
-    padding: 0.25em;
-  }
+.ucb-breadcrumb-region {
+  padding: 10px 0;
+}
+
+main {
+  padding: 0 0 10px 0;
+}
+
+h1,
+h2,
+h3,
+h4,
+h5 {
+  font-family: Roboto, "Helvetica Neue", Helvetica, Arial, sans-serif;
+}
+
+a:link,
+a:visited {
+  color: var(--ucb-link);
+}
+
+a:hover {
+  color: var(--ucb-link-visited);
+  text-decoration: none;
+}
+
+button {
+  border: none;
+}
+
+input[type="submit"] {
+  border: none;
+}
+
+.ucb-homepage-footer a {
+  color: var(--ucb-gold);
+}
+
+.toolbar-menu a,
+.toolbar-menu a:visited {
+  color: #565656;
+}
+
+.ucb-local-tasks li>a {
+  color: var(--ucb-light-contrast);
+}
+
+.ucb-homepage-footer a:hover {
+  color: var(--ucb-white);
+}
+
+.ucb-page-container {
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+}
+
+.page-header.local-tasks-present {
+  margin-top: 32px;
+}
+
+.list-style-none {
+  list-style: none;
+  padding-left: 0;
+}
+
+/********* Fonts *************/
+.ucb-roboto-bold {
+  font-family:
+    Roboto,
+    "Helvetica Neue",
+    Helvetica,
+    Arial,
+    sans-serif;
+  font-weight: bold;
+}
+
+.ucb-roboto-condensed-bold {
+  font-family:
+    "Roboto Condensed",
+    "Helvetica Neue",
+    Helvetica,
+    Arial,
+    sans-serif;
+  font-weight: bold;
+}
+
+.ucb-roboto {
+  font-family: Roboto, "Helvetica Neue", Helvetica, Arial, sans-serif;
+}
+
+.font-white {
+  color: var(--ucb-white);
+}
+
+.font-gold {
+  color: var(--ucb-gold);
+}
+
+.font-black {
+  color: var(--ucb-black);
+}
+
+/******** Header Region **********/
+.ucb-brand-bar {
+  padding: 1rem 0;
+}
+
+.ucb-admin-alert {
+  margin-bottom: 0;
+  padding: 0.25em;
+}
 
 .ucb-alert {
-	text-align: center;
-	border-radius: 0;
-	width: 100%;
-	margin: 0;
+  text-align: center;
+  border-radius: 0;
+  width: 100%;
+  margin: 0;
 }
 
-.alert-danger{
+.alert-danger {
   --bs-alert-color: white !important;
-    --bs-alert-bg: #E41B23 !important;
-    --bs-alert-border-color: #E41B23;
-    font-weight: 600;
+  --bs-alert-bg: #E41B23 !important;
+  --bs-alert-border-color: #E41B23;
+  font-weight: 600;
 }
 
-.ucb-alert-link:link, .ucb-alert-link:visited {
-	background-color: white;
+.ucb-alert-link:link,
+.ucb-alert-link:visited {
+  background-color: white;
   padding: 2px 5px;
-  color:#222 ;
+  color: #222;
   font-size: 85%;
   display: inline-flex;
   align-items: center;
   margin-left: 5px;
 }
-  
-.ucb-alert-link > svg{
+
+.ucb-alert-link>svg {
   margin-left: 2px;
 }
-  header#ucb-header-block {
-    background: black;
-    padding: 1em 0;
-  }
-  
-  .ucb-header-container {
-    display: flex;
-    flex-direction: row;
-    align-items: center;
-    padding: 20px 0;
-  }
-  
-  .ucb-header-container .homepage-logo {
-    flex-grow: 1;
-  }
-  
-  .ucb-header-container > * {
-    flex-grow: 0;
-    flex-shrink: 0;
-  }
+
+header#ucb-header-block {
+  background: black;
+  padding: 1em 0;
+}
+
+.ucb-header-container {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  padding: 20px 0;
+}
+
+.ucb-header-container .homepage-logo {
+  flex-grow: 1;
+}
+
+.ucb-header-container>* {
+  flex-grow: 0;
+  flex-shrink: 0;
+}
 
 .ucb-site-affiliation-sport_club .ucb-menu-wrapper .ucb-site-name-wrapper {
-	background-image: url(../images/cu-buffs-logo.png);
-	background-repeat: no-repeat;
-	background-position: left center;
-	background-size: 45px 33px;
-	padding-left: 55px;
-	min-height: 33px;
+  background-image: url(../images/cu-buffs-logo.png);
+  background-repeat: no-repeat;
+  background-position: left center;
+  background-size: 45px 33px;
+  padding-left: 55px;
+  min-height: 33px;
 }
-  
-  img, article img {
-    max-width: 100%;
-    height: auto;
-  }
+
+img,
+article img {
+  max-width: 100%;
+  height: auto;
+}
 
 /** Image size in layout builder editor as article does not exist **/
-  .layout-builder img {
-    width: 100%;
-    height: auto;
+.layout-builder img {
+  width: 100%;
+  height: auto;
 }
-  
-  .homepage-logo img {
-    max-width: 320px;
-    min-width: 180px;
-    width: 320px;
-    height: 30px;
-  }
-  
-  .homepage-slogan img {
-    min-width: 180px;
-    max-width: 240px;
-    margin-right: 0;
-  }
-  
-  /*********** Navigations **************/
-  section.ucb-main-nav-section {
-    box-shadow: 0 2px 5px rgba(0 0 0 /10%);
-    background: white;
-  }
-  
-  .ucb-main-nav-continer {
-    display: flex;
-    flex-grow: 0;
-    flex-shrink: 0;
-    padding: 0;
-    height: inherit;
-    align-items: center;
-  }
-  
+
+.homepage-logo img {
+  max-width: 320px;
+  min-width: 180px;
+  width: 320px;
+  height: 30px;
+}
+
+.homepage-slogan img {
+  min-width: 180px;
+  max-width: 240px;
+  margin-right: 0;
+}
+
+/*********** Navigations **************/
+section.ucb-main-nav-section {
+  box-shadow: 0 2px 5px rgba(0 0 0 /10%);
+  background: white;
+}
+
+.ucb-main-nav-continer {
+  display: flex;
+  flex-grow: 0;
+  flex-shrink: 0;
+  padding: 0;
+  height: inherit;
+  align-items: center;
+}
+
 @media only screen and (max-width: 600px) {
   .ucb-main-nav-continer {
     flex-direction: column;
   }
 }
 
-  /*********** Main Menu **************/
-  ul.ucb-main-menu.nav {
-    flex-grow: 1;
-  }
-  
-  .ucb-menu a.nav-link {
-    font-size: 0.85em;
-    vertical-align: baseline;
-    font-family: Roboto, "Helvetica Neue", Helvetica, Arial, sans-serif;
-    font-weight: 600;
-    line-height: 1rem;
-    margin: 0.5rem;
-    color: var(--ucb-darker);
-    padding: 0.5rem;
-  }
-  
-  li.main-menu-item a.nav-link {
-    color: var(--ucb-darker);
-    border-bottom: 2px solid #fff;
-    font-weight: 600;
-    line-height: 2rem;
-    padding: .25rem 1rem;
-    margin: 2px 0 0 0;
-  }
-  
-  .ucb-footer-top .ucb-menu a.nav-link {
-    color: white;
-    font-size: 1.25em;
-    padding: 0.5rem;
-    border-radius: 0.2rem;
-  }
-  
-  .mobile-menu-toggle {
-    display: none;
-  }
-  
-  /********** Secondary Menu **********/
-  
-  .ucb-menu a.nav-link:hover {
-    color: var(--ucb-black);
-    background: var(--ucb-light-contrast);
-    border-radius: 3px;
-  }
-  
-  .ucb-footer-nav-block .ucb-menu.nav {
-    flex-direction: column;
-    flex-grow: 1;
-    padding-right: 2em;
-  }
-  
-  .ucb-footer-nav-block .ucb-menu a.nav-link {
-    color: #cfb87b;
-    background: transparent;
-    text-align: left;
-    font-size: 14px;
-    border-bottom: 1px solid #555;
-    border-radius: 0;
-    padding: 0.5rem 0;
-    margin: 0.5rem 0;
-  }
-  
-  li.main-menu-item a.nav-link:hover, li.main-menu-item a.nav-link.is-active, li.main-menu-item.active a.nav-link:first-of-type {
-    border-bottom: 2px solid black;
-    color: black;
-  }
-  
-  /****** Local Tasks ********/
-  .ucb-local-tasks {
-    position: fixed;
-    top: 0;
-    width: 100%;
-    background-color: var(--ucb-link);
-    z-index: 99;
-    height: 32px;
-    padding: 0;
-    margin: 0;
-  }
-  
-  .ucb-local-tasks ul {
-    display: flex;
-    list-style-type: none;
-    align-items: center;
-    justify-content: flex-start;
-    padding: 0;
-    margin: 0;
-  }
-  
-  .ucb-local-tasks ul li {
-    width: 100px;
-    padding: 0.25em;
-    text-align: center;
-    background-color: inherit;
-    color: inherit;
-  }
-  
-  .ucb-local-tasks ul li:hover {
-    background-color: rgba(255 255 255 / 15%);
-    transition: background-color 200ms;
-  }
-  
-  .ucb-local-tasks li > a:hover {
-    color: #fff;
-  }
-  
-  /********* Footer ***********/
-  .ucb-homepage-footer {
-    display: block;
-    flex: 1;
-  }
-  
-  .ucb-footer-top {
-    padding: 20px 0;
-  }
-  
-  .ucb-footer-top .ucb-menu li.menu-item {
-    flex-grow: 1;
-    text-align: center;
-  }
-  
-  .ucb-footer-top .ucb-menu a.nav-link:hover {
-    box-shadow: 0 2px 5px rgba(0 0 0 /30%);
-  }
-  
-  .ucb-footer-nav-block {
-    display: flex;
-    flex-direction: row;
-    flex-grow: 1;
-    max-width: 100%;
-    flex-basis: 0;
-    -ms-flex-positive: 1;
-    -mx-flex-preferred-size: 0;
-  }
-  
-  .ucb-footer-nav-container {
-    display: flex;
-    flex: 1 0 auto;
-    margin: 2em auto;
-  }
-  
-  .ucb-footer-nav-container .ucb-menu-title {
-    color: white;
-    font-size: 1.4rem;
-    font-family:
-      "Roboto Condensed",
-      Roboto,
-      "Helvetica Neue",
-      Helvetica,
-      Arial,
-      sans-serif;
-    font-weight: bold;
-  }
-  
-  .ucb-system-menu-block {
-    display: block;
-    width: 100%;
-  }
-  
-  .ucb-footer-nav-block .ucb-menu a.nav-link:hover {
-    color: white;
-    background: transparent;
-    box-shadow: none;
-  }
-  
-  .ucb-footer-bottom {
-    color: white;
-    padding: 40px 0;
-    text-align: left;
-    font-size: 0.9rem;
-  }
-  
-  .menu.social-media {
-    flex-direction: row;
-    justify-content: center;
-    margin-bottom: 1em;
-    font-size: 1.25rem;
-    line-height: 1.25;
-  }
-  
-  li.social-media-item.menu-item {
-    padding-right: 0.5rem;
-  }
-  
-  .be-boulder-container {
-    display: flex;
-    align-items: top;
-    justify-content: space-between;
-    padding-bottom: 2em;
-    flex-wrap: wrap;
-  }
-
-  .ucb-footer-be-boulder {
-    padding-bottom: 2em;
+/*********** Main Menu **************/
+ul.ucb-main-menu.nav {
+  flex-grow: 1;
 }
-  
-  /**** Styles for media types inserted with the media text editor embed button ****/
-  
-  /**** O-EMBED Videos Media *******/
-  .field_media_oembed_video {
-    position: relative;
-    overflow: hidden;
-    width: 100%;
-    padding-top: 56.25%; /* 16:9 Aspect Ratio (divide 9 by 16 = 0.5625) */
-  }
-  
-  .field_media_oembed_video iframe {
-    position: absolute;
-    top: 0;
-    left: 0;
-    bottom: 0;
-    right: 0;
-    width: 100%;
-    height: 100%;
-  }
-  
-  /**** Responsive Images ******/
-  
-  article .align-right img,
-  article .align-right .media-image-caption p {
-    padding-left: 1em;
-  }
-  
-  article .align-left img,
-  article .align-left .media-image-caption p {
-    padding-right: 1em;
-  }
+
+.ucb-menu a.nav-link {
+  font-size: 0.85em;
+  vertical-align: baseline;
+  font-family: Roboto, "Helvetica Neue", Helvetica, Arial, sans-serif;
+  font-weight: 600;
+  line-height: 1rem;
+  margin: 0.5rem;
+  color: var(--ucb-darker);
+  padding: 0.5rem;
+}
+
+li.main-menu-item a.nav-link {
+  color: var(--ucb-darker);
+  border-bottom: 2px solid #fff;
+  font-weight: 600;
+  line-height: 2rem;
+  padding: .25rem 1rem;
+  margin: 2px 0 0 0;
+}
+
+.ucb-footer-top .ucb-menu a.nav-link {
+  color: white;
+  font-size: 1.25em;
+  padding: 0.5rem;
+  border-radius: 0.2rem;
+}
+
+.mobile-menu-toggle {
+  display: none;
+}
+
+/********** Secondary Menu **********/
+
+.ucb-menu a.nav-link:hover {
+  color: var(--ucb-black);
+  background: var(--ucb-light-contrast);
+  border-radius: 3px;
+}
+
+.ucb-footer-nav-block .ucb-menu.nav {
+  flex-direction: column;
+  flex-grow: 1;
+  padding-right: 2em;
+}
+
+.ucb-footer-nav-block .ucb-menu a.nav-link {
+  color: #cfb87b;
+  background: transparent;
+  text-align: left;
+  font-size: 14px;
+  border-bottom: 1px solid #555;
+  border-radius: 0;
+  padding: 0.5rem 0;
+  margin: 0.5rem 0;
+}
+
+li.main-menu-item a.nav-link:hover,
+li.main-menu-item a.nav-link.is-active,
+li.main-menu-item.active a.nav-link:first-of-type {
+  border-bottom: 2px solid black;
+  color: black;
+}
+
+/****** Local Tasks ********/
+.ucb-local-tasks {
+  position: fixed;
+  top: 0;
+  width: 100%;
+  background-color: var(--ucb-link);
+  z-index: 99;
+  height: 32px;
+  padding: 0;
+  margin: 0;
+}
+
+.ucb-local-tasks ul {
+  display: flex;
+  list-style-type: none;
+  align-items: center;
+  justify-content: flex-start;
+  padding: 0;
+  margin: 0;
+}
+
+.ucb-local-tasks ul li {
+  width: 100px;
+  padding: 0.25em;
+  text-align: center;
+  background-color: inherit;
+  color: inherit;
+}
+
+.ucb-local-tasks ul li:hover {
+  background-color: rgba(255 255 255 / 15%);
+  transition: background-color 200ms;
+}
+
+.ucb-local-tasks li>a:hover {
+  color: #fff;
+}
+
+/********* Footer ***********/
+
+.ucb-footer p {
+  margin: 0;
+  padding: 0;
+}
+
+.ucb-footer a.ucb-home-link {
+  font-weight: bold;
+}
+
+.ucb-footer img.ucb-footer-be-boulder {
+  max-width: 240px;
+  width: 100%;
+  height: auto;
+  display: inline-block;
+}
+
+.ucb-footer .ucb-footer-links {
+  font-size: 85%;
+}
+
+.ucb-homepage-footer {
+  display: block;
+  flex: 1;
+}
+
+.ucb-footer-top {
+  padding: 20px 0;
+}
+
+.ucb-footer-top .ucb-menu li.menu-item {
+  flex-grow: 1;
+  text-align: center;
+}
+
+.ucb-footer-top .ucb-menu a.nav-link:hover {
+  box-shadow: 0 2px 5px rgba(0 0 0 /30%);
+}
+
+.ucb-footer-nav-block {
+  display: flex;
+  flex-direction: row;
+  flex-grow: 1;
+  max-width: 100%;
+  flex-basis: 0;
+  -ms-flex-positive: 1;
+  -mx-flex-preferred-size: 0;
+}
+
+.ucb-footer-nav-container {
+  display: flex;
+  flex: 1 0 auto;
+  margin: 2em auto;
+}
+
+.ucb-footer-nav-container .ucb-menu-title {
+  color: white;
+  font-size: 1.4rem;
+  font-family:
+    "Roboto Condensed",
+    Roboto,
+    "Helvetica Neue",
+    Helvetica,
+    Arial,
+    sans-serif;
+  font-weight: bold;
+}
+
+.ucb-system-menu-block {
+  display: block;
+  width: 100%;
+}
+
+.ucb-footer-nav-block .ucb-menu a.nav-link:hover {
+  color: white;
+  background: transparent;
+  box-shadow: none;
+}
+
+.ucb-footer-bottom {
+  color: white;
+  padding: 40px 0;
+  text-align: left;
+  font-size: 0.9rem;
+}
+
+.menu.social-media {
+  flex-direction: row;
+  justify-content: center;
+  margin-bottom: 1em;
+  font-size: 1.25rem;
+  line-height: 1.25;
+}
+
+li.social-media-item.menu-item {
+  padding-right: 0.5rem;
+}
+
+.be-boulder-container {
+  display: flex;
+  align-items: top;
+  justify-content: space-between;
+  padding-bottom: 2em;
+  flex-wrap: wrap;
+}
+
+.ucb-footer-be-boulder {
+  padding-bottom: 2em;
+}
+
+/**** Styles for media types inserted with the media text editor embed button ****/
+
+/**** O-EMBED Videos Media *******/
+.field_media_oembed_video {
+  position: relative;
+  overflow: hidden;
+  width: 100%;
+  padding-top: 56.25%;
+  /* 16:9 Aspect Ratio (divide 9 by 16 = 0.5625) */
+}
+
+.field_media_oembed_video iframe {
+  position: absolute;
+  top: 0;
+  left: 0;
+  bottom: 0;
+  right: 0;
+  width: 100%;
+  height: 100%;
+}
+
+/**** Responsive Images ******/
+
+article .align-right img,
+article .align-right .media-image-caption p {
+  padding-left: 1em;
+}
+
+article .align-left img,
+article .align-left .media-image-caption p {
+  padding-right: 1em;
+}
 
 /* Resets Bootstrap's `placeholder` class styles */
 .placeholder {
-	display: initial;
-	vertical-align: initial;
-	min-height: initial;
-	cursor: auto;
-	background-color: initial;
-	opacity: initial;
+  display: initial;
+  vertical-align: initial;
+  min-height: initial;
+  cursor: auto;
+  background-color: initial;
+  opacity: initial;
 }
 
 /* Layout Builder Pre-Block Add Styles */
 div#drupal-off-canvas-wrapper {
-    background: white;
+  background: white;
 }
 
-#drupal-off-canvas .inline-block-create-button, #drupal-off-canvas .inline-block-list__item {
-    background: white;
-    border: none;
+#drupal-off-canvas .inline-block-create-button,
+#drupal-off-canvas .inline-block-list__item {
+  background: white;
+  border: none;
 }
 
-#drupal-off-canvas .inline-block-create-button:hover, #drupal-off-canvas .inline-block-list__item:hover {
-    background: #00000026;
+#drupal-off-canvas .inline-block-create-button:hover,
+#drupal-off-canvas .inline-block-list__item:hover {
+  background: #00000026;
 }
 
 #drupal-off-canvas-wrapper .inline-block-create-button::before {
-    display: none;
+  display: none;
 }
 
-/* Image Styles */ 
-.imageMediaStyle img{
+/* Image Styles */
+.imageMediaStyle img {
   padding-bottom: 20px;
 }
+
 div.align-center {
   width: fit-content;
 }
@@ -525,12 +552,12 @@ div.align-center {
     /* 25% of container (285px) */
     width: 285px;
   }
-  
+
   .medium_750px_50_display_size_ img {
     /* 50% of container (570px) */
     width: 570px;
   }
-  
+
   .small_square_image_style img {
     /* 25% of container (285px) */
     width: 285px;
@@ -541,17 +568,17 @@ div.align-center {
   .square_thumbnail_image_style img {
     width: 75px;
   }
-  
+
   .small_500px_25_display_size_ img {
     /* 25% of container (240px) */
     width: 240px;
   }
-  
+
   .medium_750px_50_display_size_ img {
     /* 50% of container (480px) */
     width: 480px;
   }
-  
+
   .small_square_image_style img {
     /* 25% of container (240px) */
     width: 240px;
@@ -564,12 +591,12 @@ div.align-center {
     /* 25% of container (180px) */
     width: 180px;
   }
-  
+
   .medium_750px_50_display_size_ img {
     /* 50% of container (360px) */
     width: 360px;
   }
-  
+
   .small_square_image_style img {
     /* 25% of container (180px) */
     width: 180px;
@@ -586,12 +613,12 @@ div.align-center {
     /* 25% of container (135px) */
     width: 135px;
   }
-  
+
   .medium_750px_50_display_size_ img {
     /* 50% of container (270px) */
     width: 270px;
   }
-  
+
   .small_square_image_style img {
     /* 25% of container (135px) */
     width: 135px;
@@ -603,20 +630,20 @@ div.align-center {
 /* TAXONOMY VIEWS */
 
 .item-list.container ul li {
-	border-bottom: 2px solid rgba(128, 128, 128, 0.333);
-	margin-bottom: 20px;
+  border-bottom: 2px solid rgba(128, 128, 128, 0.333);
+  margin-bottom: 20px;
   list-style: none;
   display: flex;
 }
 
 .item-list.container ul {
-	padding-left: 0;
+  padding-left: 0;
 }
 
 .views-field-field-ucb-article-thumbnail {
-	width: calc(100px + var(--bs-gutter-x));
-	height: auto;
-	margin-bottom: 20px;
+  width: calc(100px + var(--bs-gutter-x));
+  height: auto;
+  margin-bottom: 20px;
   padding-top: 5px;
 }
 
@@ -627,14 +654,16 @@ div.align-center {
 }
 
 .ucb-taxonomy-readmore {
-font-weight: 600;
-font-size: 75%;
+  font-weight: 600;
+  font-size: 75%;
 }
+
 .ucb-taxonomy-date {
   font-size: 85%;
   line-height: 85%;
   margin-bottom: 10px;
 }
+
 .ucb-taxonomy-title {
   font-size: 120%;
   font-weight: normal;
@@ -642,16 +671,19 @@ font-size: 75%;
   line-height: 1.3;
   margin: 0 0 10px 0;
 }
+
 .ucb-taxonomy-thumbnail {
-	width: calc(100px + var(--bs-gutter-x));
-	height: auto;
-	margin-bottom: 20px;
-	min-width: calc(100px + var(--bs-gutter-x));
+  width: calc(100px + var(--bs-gutter-x));
+  height: auto;
+  margin-bottom: 20px;
+  min-width: calc(100px + var(--bs-gutter-x));
 }
+
 .item-list .views-field .field-content {
   display: flex;
 
 }
+
 .taxonomy-view-title {
   font-weight: normal;
   font-size: 220%;

--- a/css/style.css
+++ b/css/style.css
@@ -492,7 +492,8 @@ article .align-left .media-image-caption p {
 }
 
 /* Adjusts list elements when a left-floated image (.align-left) is a preceeding sibling, aligns list indicators with other elements  */
-.align-left + ol, .align-left + ul {
+.align-left+ol,
+.align-left+ul {
   right: -1em;
   position: relative;
 }
@@ -527,11 +528,12 @@ div#drupal-off-canvas-wrapper {
   display: none;
 }
 
-/* Image Styles */ 
-.imageMediaStyle{
+/* Image Styles */
+.imageMediaStyle {
   display: inline;
 }
-.imageMediaStyle img{
+
+.imageMediaStyle img {
   padding-bottom: 20px;
 }
 
@@ -698,7 +700,8 @@ div.align-center {
   font-size: 220%;
 }
 
-small, .small-text {
+small,
+.small-text {
   font-size: 80%;
   font-family: Arial, Helvetica, sans-serif !important;
 }
@@ -736,7 +739,7 @@ p.supersize strong {
   font-family: "Roboto Condensed", "Helvetica Neue", Helvetica, Arial, sans-serif;
 }
 
-ul.list-style-underline > li {
+ul.list-style-underline>li {
   list-style: none;
 }
 
@@ -753,7 +756,7 @@ ul.list-style-nobullet {
   padding-left: 0;
 }
 
-ul.list-style-nobullet > li {
+ul.list-style-nobullet>li {
   list-style: none;
   list-style-image: none;
 }
@@ -766,28 +769,44 @@ ul.list-style-border {
   border-top: 1px solid rgba(128, 128, 128, 0.333);
 }
 
-ul.list-style-border > li {
+ul.list-style-border>li {
   list-style: none;
   border: 1px solid rgba(128, 128, 128, 0.333);
   border-top: none;
   padding: 10px;
   margin-bottom: 0;
 }
+
 /* UNORDERED LIST STYLES */
 
-ul.list-style-icon-1, ul.list-style-icon-2, ul.list-style-icon-3, ul.list-style-icon-4, ul.list-style-icon-5, ul.list-style-icon-6 {
+ul.list-style-icon-1,
+ul.list-style-icon-2,
+ul.list-style-icon-3,
+ul.list-style-icon-4,
+ul.list-style-icon-5,
+ul.list-style-icon-6 {
   list-style: none;
   list-style-image: none;
   overflow: hidden;
 }
 
-ul.list-style-icon-1 > li, ul.list-style-icon-2 > li, ul.list-style-icon-3 > li, ul.list-style-icon-4 > li, ul.list-style-icon-5 > li, ul.list-style-icon-6 > li {
+ul.list-style-icon-1>li,
+ul.list-style-icon-2>li,
+ul.list-style-icon-3>li,
+ul.list-style-icon-4>li,
+ul.list-style-icon-5>li,
+ul.list-style-icon-6>li {
   list-style: none !important;
   list-style-image: none !important;
   position: relative;
 }
 
-ul.list-style-icon-1 li:before, ul.list-style-icon-2 li:before, ul.list-style-icon-3 li:before, ul.list-style-icon-4 li:before, ul.list-style-icon-5 li:before, ul.list-style-icon-6 li:before {
+ul.list-style-icon-1 li:before,
+ul.list-style-icon-2 li:before,
+ul.list-style-icon-3 li:before,
+ul.list-style-icon-4 li:before,
+ul.list-style-icon-5 li:before,
+ul.list-style-icon-6 li:before {
   font-family: "Font Awesome 5 Free", "FontAwesome";
   position: absolute;
   top: 0;
@@ -795,50 +814,60 @@ ul.list-style-icon-1 li:before, ul.list-style-icon-2 li:before, ul.list-style-ic
   color: #cfb87c;
 }
 
-ul.list-style-icon-1 > li:before, ul.list-style-icon-check > li:before {
+ul.list-style-icon-1>li:before,
+ul.list-style-icon-check>li:before {
   content: '\f00c';
   font-weight: 900;
 }
 
-ul.list-style-icon-2 > li:before, ul.list-style-icon-checkbox > li:before {
+ul.list-style-icon-2>li:before,
+ul.list-style-icon-checkbox>li:before {
   content: '\f14a';
   font-weight: 900;
 }
 
-ul.list-style-icon-3 > li:before, ul.list-style-icon-angle-double > li:before {
+ul.list-style-icon-3>li:before,
+ul.list-style-icon-angle-double>li:before {
   content: '\f101';
   font-weight: 900;
 }
 
-ul.list-style-icon-4 > li:before, ul.list-style-icon-circle-arrow > li:before {
+ul.list-style-icon-4>li:before,
+ul.list-style-icon-circle-arrow>li:before {
   content: '\f0a9';
   font-weight: 900;
 }
 
-ul.list-style-icon-5 > li:before, ul.list-style-icon-star > li:before {
+ul.list-style-icon-5>li:before,
+ul.list-style-icon-star>li:before {
   content: '\f005';
   font-weight: 900;
 }
 
-ul.list-style-icon-6 > li:before, ul.list-style-icon-finger > li:before {
+ul.list-style-icon-6>li:before,
+ul.list-style-icon-finger>li:before {
   content: '\f0a4';
   font-weight: 900;
 }
 
 /* ORDERED LIST STYLES */
-ol.list-style-alpha-upper, ol.list-style-alpha-upper > li {
+ol.list-style-alpha-upper,
+ol.list-style-alpha-upper>li {
   list-style: upper-alpha;
 }
 
-ol.list-style-alpha-lower, ol.list-style-alpha-lower > li {
+ol.list-style-alpha-lower,
+ol.list-style-alpha-lower>li {
   list-style: lower-alpha;
 }
 
-ol.list-style-roman-upper, ol.list-style-roman-upper > li {
+ol.list-style-roman-upper,
+ol.list-style-roman-upper>li {
   list-style: upper-roman;
 }
 
-ol.list-style-roman-lower, ol.list-style-roman-lower > li {
+ol.list-style-roman-lower,
+ol.list-style-roman-lower>li {
   list-style: lower-roman;
 }
 
@@ -847,24 +876,33 @@ table.table-zebra tr:nth-child(odd) td {
   background: #f3f3f3;
 }
 
-table.table-condensed td, table.table-condensed th, div.table-condensed table td, div.table-condensed table th {
+table.table-condensed td,
+table.table-condensed th,
+div.table-condensed table td,
+div.table-condensed table th {
   padding: 4px;
 }
 
-table.table-small, div.table-small table {
-    font-size: 80%;
+table.table-small,
+div.table-small table {
+  font-size: 80%;
 }
 
-table.table-small td, table.table-small th, div.table-small table td, div.table-small table th {
-    padding: 4px;
+table.table-small td,
+table.table-small th,
+div.table-small table td,
+div.table-small table th {
+  padding: 4px;
 }
 
-table.table-horizontal td, div.table-horizontal table td {
+table.table-horizontal td,
+div.table-horizontal table td {
   border-left: none;
   border-right: none;
 }
 
-table.table-vertical td, div.table-vertical table td {
+table.table-vertical td,
+div.table-vertical table td {
   border-top: none;
   border-bottom: none;
 }

--- a/css/ucb-brand-bar.css
+++ b/css/ucb-brand-bar.css
@@ -1,50 +1,36 @@
-/* CU Boulder Brand Bar */
 .ucb-brand-bar {
-  display:flex;
+  display: flex;
   flex-direction: row;
   justify-content: space-between;
-  align-items:center;
-}
-.ucb-brand-bar.ucb-brand-bar-white {
-  background-color:#fff; 
-}
-.ucb-brand-bar.ucb-brand-bar-black {
-  background-color:#000; 
-}
-.ucb-brand-bar img.ucb-logo {
-  width:100%;
-  max-width: 200px;
-  min-width:160px;
-  height:auto;
-  margin-right:20px;
-  display:block;
-}
-@media screen and (min-width:768px) {
-  .ucb-brand-bar img.ucb-logo {
-    max-width:240px;
-  }
-}
-.ucb-brand-bar img.ucb-search {
-  width:18px;
-  height:18px;
-  margin-left:20px;
-  display:block;
+  align-items: center;
 }
 
-/* CU Boulder Footer */
-.ucb-footer p {
-  margin:0;
-  padding:0;
+.ucb-brand-bar.ucb-brand-bar-white {
+  background-color: #fff;
 }
-.ucb-footer a.ucb-home-link {
-  font-weight:bold; 
+
+.ucb-brand-bar.ucb-brand-bar-black {
+  background-color: #000;
 }
-.ucb-footer img.ucb-footer-be-boulder {
-  max-width:240px;
-  width:100%;
-  height:auto;
-  display:inline-block;
+
+.ucb-brand-bar img.ucb-logo {
+  width: 100%;
+  max-width: 200px;
+  min-width: 160px;
+  height: auto;
+  margin-right: 20px;
+  display: block;
 }
-.ucb-footer .ucb-footer-links {
- font-size:85%; 
+
+@media screen and (min-width: 768px) {
+  .ucb-brand-bar img.ucb-logo {
+    max-width: 240px;
+  }
+}
+
+.ucb-brand-bar img.ucb-search {
+  width: 18px;
+  height: 18px;
+  margin-left: 20px;
+  display: block;
 }

--- a/css/ucb-brand-bar.css
+++ b/css/ucb-brand-bar.css
@@ -1,0 +1,50 @@
+/* CU Boulder Brand Bar */
+.ucb-brand-bar {
+  display:flex;
+  flex-direction: row;
+  justify-content: space-between;
+  align-items:center;
+}
+.ucb-brand-bar.ucb-brand-bar-white {
+  background-color:#fff; 
+}
+.ucb-brand-bar.ucb-brand-bar-black {
+  background-color:#000; 
+}
+.ucb-brand-bar img.ucb-logo {
+  width:100%;
+  max-width: 200px;
+  min-width:160px;
+  height:auto;
+  margin-right:20px;
+  display:block;
+}
+@media screen and (min-width:768px) {
+  .ucb-brand-bar img.ucb-logo {
+    max-width:240px;
+  }
+}
+.ucb-brand-bar img.ucb-search {
+  width:18px;
+  height:18px;
+  margin-left:20px;
+  display:block;
+}
+
+/* CU Boulder Footer */
+.ucb-footer p {
+  margin:0;
+  padding:0;
+}
+.ucb-footer a.ucb-home-link {
+  font-weight:bold; 
+}
+.ucb-footer img.ucb-footer-be-boulder {
+  max-width:240px;
+  width:100%;
+  height:auto;
+  display:inline-block;
+}
+.ucb-footer .ucb-footer-links {
+ font-size:85%; 
+}

--- a/css/ucb-search-box.css
+++ b/css/ucb-search-box.css
@@ -1,7 +1,6 @@
 .ucb-search-box .ucb-search-box-links {
   padding: 20px 0;
-  border-top: 3px solid rgba(128, 128, 128, 0.333);
-  font-size: 85%;
+  font-size: .85em;
   font-weight: bold;
 }
 
@@ -9,12 +8,12 @@
   font-size: 1em;
 }
 
-.ucb-search-box .ucb-search-box-links ul li.list-inline-item:not(:last-child) {
+.ucb-search-box .ucb-search-box-links ul li:not(:last-child) {
   margin-right: .25rem;
 }
 
 
-.ucb-search-box .ucb-search-box-links ul li.list-inline-item:not(:first-child):before {
+.ucb-search-box .ucb-search-box-links ul li:not(:first-child):before {
   display: inline-block;
   content: '\2022';
   margin-right: .25rem;
@@ -23,13 +22,14 @@
 .ucb-search-box .ucb-search-box-options {
   display: flex;
   flex-direction: row;
-  gap: 1em;
-  padding: 10px 0;
+  gap: 1.25rem;
+  border-bottom: 3px solid rgba(128, 128, 128, 0.333);
+  padding: 10px 5px;
 }
 
 .ucb-search-box .ucb-search-box-options label,
 .ucb-search-box .ucb-search-input-submit input {
-  font-size: 1em;
+  font-size: .9em;
   font-weight: bold;
 }
 
@@ -56,6 +56,13 @@
   background-color: #fff;
   color: #000;
   border: none;
+  outline-offset: 0px;
+  transition: outline-offset .1s ease-in-out;
+}
+
+.ucb-search-box .ucb-search-input-text input:focus {
+  outline: #0277BD solid 2px;
+  outline-offset: 3px;
 }
 
 .ucb-search-box .ucb-search-input-submit input {

--- a/css/ucb-search-box.css
+++ b/css/ucb-search-box.css
@@ -1,5 +1,5 @@
 .ucb-search-box .ucb-search-box-links {
-  padding: 20px 0;
+  padding: 10px 0;
   font-size: .85em;
   font-weight: bold;
 }
@@ -25,6 +25,10 @@
   gap: 1.25rem;
   border-bottom: 3px solid rgba(128, 128, 128, 0.333);
   padding: 10px 5px;
+}
+
+.ucb-search-box .ucb-search-box-options label {
+  vertical-align: middle;
 }
 
 .ucb-search-box .ucb-search-box-options label,
@@ -55,7 +59,11 @@
   padding: 0 8px;
   background-color: #fff;
   color: #000;
+  -webkit-border-radius: 0;
+  -moz-border-radius: 0;
+  border-radius: 0;
   border: none;
+  -webkit-appearance: none;
   outline-offset: 0px;
   transition: outline-offset .1s ease-in-out;
 }
@@ -66,6 +74,7 @@
 }
 
 .ucb-search-box .ucb-search-input-submit input {
+  display: block;
   line-height: 40px;
   height: 40px;
   background: var(--ucb-gold);
@@ -78,6 +87,12 @@
   -moz-border-radius: 0;
   border-radius: 0;
   border: none;
-  display: block;
+  -webkit-appearance: none;
   margin: 0;
+  transition: background-color 0.5s ease;
+}
+
+.ucb-search-box .ucb-search-input-submit input:hover,
+.ucb-search-box .ucb-search-input-submit input:focus {
+    background-color: #a6a6a6;
 }

--- a/css/ucb-search-box.css
+++ b/css/ucb-search-box.css
@@ -1,0 +1,76 @@
+.ucb-search-box .ucb-search-box-links {
+  padding: 20px 0;
+  border-top: 3px solid rgba(128, 128, 128, 0.333);
+  font-size: 85%;
+  font-weight: bold;
+}
+
+.ucb-search-box .ucb-search-box-links h3 {
+  font-size: 1em;
+}
+
+.ucb-search-box .ucb-search-box-links ul li.list-inline-item:not(:last-child) {
+  margin-right: .25rem;
+}
+
+
+.ucb-search-box .ucb-search-box-links ul li.list-inline-item:not(:first-child):before {
+  display: inline-block;
+  content: '\2022';
+  margin-right: .25rem;
+}
+
+.ucb-search-box .ucb-search-box-options {
+  display: flex;
+  flex-direction: row;
+  gap: 1em;
+  padding: 10px 0;
+}
+
+.ucb-search-box .ucb-search-box-options label,
+.ucb-search-box .ucb-search-input-submit input {
+  font-size: 1em;
+  font-weight: bold;
+}
+
+.ucb-search-box .ucb-search-box-inputs {
+  display: flex;
+  flex-direction: row;
+  border: 5px solid rgba(255, 255, 255, 0.333);
+}
+
+.ucb-search-box .ucb-search-input-text {
+  flex: 1;
+}
+
+.ucb-search-box .ucb-search-input-submit {
+  flex: 0;
+}
+
+.ucb-search-box .ucb-search-input-text input {
+  width: 100%;
+  font-size: 1em;
+  line-height: 40px;
+  height: 40px;
+  padding: 0 8px;
+  background-color: #fff;
+  color: #000;
+  border: none;
+}
+
+.ucb-search-box .ucb-search-input-submit input {
+  line-height: 40px;
+  height: 40px;
+  background: var(--ucb-gold);
+  color: #000;
+  padding: 0 8px;
+  -webkit-box-shadow: none;
+  -moz-box-shadow: none;
+  box-shadow: none;
+  -webkit-border-radius: 0;
+  -moz-border-radius: 0;
+  border-radius: 0;
+  border: none;
+  display: block;
+  margin: 0;
+}

--- a/css/ucb-search-modal.css
+++ b/css/ucb-search-modal.css
@@ -8,6 +8,7 @@
   z-index: 300;
   background: rgba(0, 0, 0, 0.85);
   color: #fff;
+  transition: opacity .2s ease-in-out;
 }
 
 .ucb-search-modal[hidden] {
@@ -22,21 +23,20 @@
 
 .ucb-search-modal .ucb-search-modal-content {
   position: relative;
+  box-sizing: border-box;
   width: 100%;
-  max-width: 680px;
+  max-width: 720px;
   margin: 0 auto;
-  padding: 20px 0;
+  padding: 20px;
 }
 
+.ucb-search-modal .ucb-search-modal-header,
 .ucb-search-modal .ucb-search-modal-close {
-  position: absolute;
-  top: 0;
-  right: 0;
-  z-index: 11;
-  font-size: 24px;
+  font-size: 1.6em;
   background: none;
   border: none;
   color: #fff;
+  margin: 0 0 10px 0;
 }
 
 .ucb-search-modal a:link,

--- a/css/ucb-search-modal.css
+++ b/css/ucb-search-modal.css
@@ -1,0 +1,50 @@
+.ucb-search-modal {
+  display: block;
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  z-index: 300;
+  background: rgba(0, 0, 0, 0.85);
+  color: #fff;
+}
+
+.ucb-search-modal[hidden] {
+  display: none;
+}
+
+.ucb-search-modal .ucb-search-modal-inner {
+  display: flex;
+  align-items: center;
+  height: 100%;
+}
+
+.ucb-search-modal .ucb-search-modal-content {
+  position: relative;
+  width: 100%;
+  max-width: 680px;
+  margin: 0 auto;
+  padding: 20px 0;
+}
+
+.ucb-search-modal .ucb-search-modal-close {
+  position: absolute;
+  top: 0;
+  right: 0;
+  z-index: 11;
+  font-size: 24px;
+  background: none;
+  border: none;
+  color: #fff;
+}
+
+.ucb-search-modal a:link,
+.ucb-search-modal a:visited {
+  color: var(--ucb-gold);
+}
+
+.ucb-search-modal a:link:hover,
+.ucb-search-modal a:visited:hover {
+  color: #fff;
+}

--- a/css/ucb-search-modal.css
+++ b/css/ucb-search-modal.css
@@ -1,11 +1,10 @@
 .ucb-search-modal {
-  display: block;
   position: fixed;
   top: 0;
   left: 0;
   right: 0;
   bottom: 0;
-  z-index: 300;
+  z-index: 999;
   background: rgba(0, 0, 0, 0.85);
   color: #fff;
   transition: opacity .2s ease-in-out;
@@ -15,18 +14,20 @@
   display: none;
 }
 
-.ucb-search-modal .ucb-search-modal-inner {
-  display: flex;
-  align-items: center;
+.ucb-search-modal .ucb-search-modal-backdrop {
+  position: absolute;
+  width: 100%;
   height: 100%;
 }
 
 .ucb-search-modal .ucb-search-modal-content {
   position: relative;
-  box-sizing: border-box;
   width: 100%;
+  height: 100%;
   max-width: 720px;
-  margin: 0 auto;
+  box-sizing: border-box;
+  overflow-y: auto;
+  margin: 25vh auto 0 auto;
   padding: 20px;
 }
 
@@ -47,4 +48,16 @@
 .ucb-search-modal a:link:hover,
 .ucb-search-modal a:visited:hover {
   color: #fff;
+}
+
+@media screen and (max-height: 768px) {
+  .ucb-search-modal .ucb-search-modal-content {
+    margin-top: 10vh;
+  }
+}
+
+@media screen and (max-height: 512px) {
+  .ucb-search-modal .ucb-search-modal-content {
+    margin-top: 0;
+  }
 }

--- a/js/ucb-search-box.js
+++ b/js/ucb-search-box.js
@@ -1,20 +1,28 @@
 (function (document) {
+
   function selectSearchOption(radio) {
     const searchForm = radio.parentElement.parentElement.parentElement;
     searchForm.querySelector('.ucb-search-input-text input').setAttribute('placeholder', radio.dataset['placeholder']);
     searchForm.setAttribute('action', radio.dataset['action']);
   }
-  const searchBoxOptions = document.getElementsByClassName('ucb-search-box-options');
-  for (let i = 0; i < searchBoxOptions.length; i++) {
-    const radios = searchBoxOptions[i].getElementsByTagName('input');
+
+  const searchBoxes = document.getElementsByClassName('ucb-search-box');
+  for (let i = 0; i < searchBoxes.length; i++) {
+    const searchBoxOptions = searchBoxes[i].querySelector('.ucb-search-box-options');
+    const radios = searchBoxOptions.getElementsByTagName('input');
+    searchBoxes[i].querySelector('form').onsubmit = function (event) {
+      for (let j = 0; j < radios.length; j++)
+        radios[j].removeAttribute('name');
+    };
     for (let j = 0; j < radios.length; j++) {
       if (radios[j].checked)
         selectSearchOption(radios[j]);
-      radios[j].parentElement.addEventListener('change', function (event) {
+      radios[j].addEventListener('change', function (event) {
         const radio = event.target;
         if (radio.checked)
           selectSearchOption(radio);
       });
     }
   }
+
 })(document);

--- a/js/ucb-search-box.js
+++ b/js/ucb-search-box.js
@@ -1,0 +1,20 @@
+(function (document) {
+  function selectSearchOption(radio) {
+    const searchForm = radio.parentElement.parentElement.parentElement;
+    searchForm.querySelector('.ucb-search-input-text input').setAttribute('placeholder', radio.dataset['placeholder']);
+    searchForm.setAttribute('action', radio.dataset['action']);
+  }
+  const searchBoxOptions = document.getElementsByClassName('ucb-search-box-options');
+  for (let i = 0; i < searchBoxOptions.length; i++) {
+    const radios = searchBoxOptions[i].getElementsByTagName('input');
+    for (let j = 0; j < radios.length; j++) {
+      if (radios[j].checked)
+        selectSearchOption(radios[j]);
+      radios[j].parentElement.addEventListener('change', function (event) {
+        const radio = event.target;
+        if (radio.checked)
+          selectSearchOption(radio);
+      });
+    }
+  }
+})(document);

--- a/js/ucb-search-box.js
+++ b/js/ucb-search-box.js
@@ -2,7 +2,9 @@
 
   function selectSearchOption(radio) {
     const searchForm = radio.parentElement.parentElement.parentElement;
-    searchForm.querySelector('.ucb-search-input-text input').setAttribute('placeholder', radio.dataset['placeholder']);
+    const input = searchForm.querySelector('.ucb-search-input-text input');
+    input.setAttribute('placeholder', radio.dataset['placeholder']);
+    input.setAttribute('name', radio.dataset['parameter']);
     searchForm.setAttribute('action', radio.dataset['action']);
   }
 

--- a/js/ucb-search-modal.js
+++ b/js/ucb-search-modal.js
@@ -1,13 +1,19 @@
-(function (document) {
+(function (window, document) {
   document.querySelector('.ucb-search-link').addEventListener('click', function (event) {
     event.preventDefault();
     const searchModal = document.querySelector('.ucb-search-modal');
     searchModal.removeAttribute('hidden');
+    searchModal.querySelector('.ucb-search-input-text input').focus();
+    window.setTimeout(function () {
+      searchModal.className = searchModal.className.replace('opacity-0', 'opacity-100');
+    }, 0);
   });
 
   document.querySelector('.ucb-search-modal .ucb-search-modal-close').addEventListener('click', function (event) {
     event.preventDefault();
     const searchModal = document.querySelector('.ucb-search-modal');
     searchModal.setAttribute('hidden', '');
+    searchModal.className = searchModal.className.replace('opacity-100', 'opacity-0');
+    document.querySelector('.ucb-search-link').focus();
   });
-})(document);
+})(window, document);

--- a/js/ucb-search-modal.js
+++ b/js/ucb-search-modal.js
@@ -1,19 +1,40 @@
 (function (window, document) {
-  document.querySelector('.ucb-search-link').addEventListener('click', function (event) {
-    event.preventDefault();
+  let keyListener;
+
+  function showModal() {
     const searchModal = document.querySelector('.ucb-search-modal');
     searchModal.removeAttribute('hidden');
     searchModal.querySelector('.ucb-search-input-text input').focus();
     window.setTimeout(function () {
       searchModal.className = searchModal.className.replace('opacity-0', 'opacity-100');
     }, 0);
-  });
+    keyListener = document.addEventListener('keyup', function (event) {
+      if(event.key == 'Escape' || event.key == 'Esc' || event.keyCode == 27)
+        hideModal();
+    });
+  }
 
-  document.querySelector('.ucb-search-modal .ucb-search-modal-close').addEventListener('click', function (event) {
-    event.preventDefault();
+  function hideModal() {
     const searchModal = document.querySelector('.ucb-search-modal');
     searchModal.setAttribute('hidden', '');
     searchModal.className = searchModal.className.replace('opacity-100', 'opacity-0');
     document.querySelector('.ucb-search-link').focus();
+    document.removeEventListener('keypress', keyListener);
+  }
+
+  document.querySelector('.ucb-search-link').addEventListener('click', function (event) {
+    event.preventDefault();
+    showModal();
   });
+
+  document.querySelector('.ucb-search-modal .ucb-search-modal-close').addEventListener('click', function (event) {
+    event.preventDefault();
+    hideModal();
+  });
+
+  document.querySelector('.ucb-search-modal .ucb-search-modal-backdrop').addEventListener('click', function (event) {
+    event.preventDefault();
+    hideModal();
+  });
+
 })(window, document);

--- a/js/ucb-search-modal.js
+++ b/js/ucb-search-modal.js
@@ -1,0 +1,13 @@
+(function (document) {
+  document.querySelector('.ucb-search-link').addEventListener('click', function (event) {
+    event.preventDefault();
+    const searchModal = document.querySelector('.ucb-search-modal');
+    searchModal.removeAttribute('hidden');
+  });
+
+  document.querySelector('.ucb-search-modal .ucb-search-modal-close').addEventListener('click', function (event) {
+    event.preventDefault();
+    const searchModal = document.querySelector('.ucb-search-modal');
+    searchModal.setAttribute('hidden', '');
+  });
+})(document);

--- a/templates/includes/ucb-search-box.html.twig
+++ b/templates/includes/ucb-search-box.html.twig
@@ -4,17 +4,17 @@
     <div class="ucb-search-box-inputs">
       <div class="ucb-search-input-text">
         <label for="ucb-search-text-field" class="sr-only">Enter the terms you wish to search for.</label>
-        <input id="ucb-search-text-field" placeholder="{{ site_search.0.placeholder }}" type="search" name="cse" value="" size="15" maxlength="1024">
+        <input id="ucb-search-text-field" placeholder="{{ site_search.0.placeholder }}" type="search" name="{{ site_search.0.parameter ?? 'keys' }}" value="" size="15" maxlength="1024">
       </div>
       <div class="ucb-search-input-submit">
-        <input type="submit" name="op" value="Search">
+        <input type="submit" value="Search">
       </div>
     </div>
     {% if site_search|length > 1 %}
       <div class="ucb-search-box-options">
         {% for index, search in site_search %}
           <div>
-            <input {{ index == 0 ? 'checked ' }}id="search-{{ search.name }}" class="me-1" name="search-box-option" type="radio" value="{{ search.name }}" data-placeholder="{{ search.placeholder }}" data-action="{{ search.url }}"> <label for="search-{{ search.name }}">{{ search.label }}</label>
+            <input {{ index == 0 ? 'checked ' }}id="search-{{ search.name }}" class="me-1" name="search-box-option" type="radio" value="{{ search.name }}" data-placeholder="{{ search.placeholder }}" data-parameter="{{ search.parameter ?? 'keys' }}" data-action="{{ search.url }}"> <label for="search-{{ search.name }}">{{ search.label }}</label>
           </div>
         {% endfor %}
       </div>

--- a/templates/includes/ucb-search-box.html.twig
+++ b/templates/includes/ucb-search-box.html.twig
@@ -1,0 +1,27 @@
+{{ attach_library('boulder_base/ucb-search-box') }}
+<div class="ucb-search-box" role="search">
+  <form action="{{ site_search.0.url }}" method="get">
+    <div class="ucb-search-box-inputs">
+    <div class="ucb-search-input-text">
+      <label class="element-invisible">Enter the terms you wish to search for.</label>
+      <input placeholder="{{ site_search.0.placeholder }}" type="search" name="cse" value="" size="15" maxlength="1024">
+    </div>
+    <div class="ucb-search-input-submit">
+      <input type="submit" name="op" value="Search">
+    </div>
+    </div>
+    {% if site_search|length > 1 %}
+      <div class="ucb-search-box-options">
+        {% for index, search in site_search %}
+          <div>
+            <input type="radio"{{ index == 0 ? ' checked="checked"' }}value="{{ search.label }}" data-placeholder="{{ search.placeholder }}" data-action="{{ search.url }}" id="search-{{ search.name }}"> <label for="search-{{ search.name }}">{{ search.label }}</label>
+          </div>
+        {% endfor %}
+      </div>
+    {% endif %}
+    <div class="ucb-search-box-links">
+    <h3 class="d-inline">Other ways to search:</h3>
+    <ul class="d-inline list-inline"><li class="list-inline-item"><a href="https://calendar.colorado.edu">Events Calendar</a></li><li class="list-inline-item"><a href="https://www.colorado.edu/map">Campus Map</a></li></ul>
+    </div>
+  </form>
+</div>

--- a/templates/includes/ucb-search-box.html.twig
+++ b/templates/includes/ucb-search-box.html.twig
@@ -3,8 +3,8 @@
   <form action="{{ site_search.0.url }}" method="get">
     <div class="ucb-search-box-inputs">
       <div class="ucb-search-input-text">
-        <label class="element-invisible">Enter the terms you wish to search for.</label>
-        <input placeholder="{{ site_search.0.placeholder }}" type="search" name="cse" value="" size="15" maxlength="1024">
+        <label for="ucb-search-text-field" class="sr-only">Enter the terms you wish to search for.</label>
+        <input id="ucb-search-text-field" placeholder="{{ site_search.0.placeholder }}" type="search" name="cse" value="" size="15" maxlength="1024">
       </div>
       <div class="ucb-search-input-submit">
         <input type="submit" name="op" value="Search">
@@ -14,7 +14,7 @@
       <div class="ucb-search-box-options">
         {% for index, search in site_search %}
           <div>
-            <input name="search-box-option" type="radio"{{ index == 0 ? ' checked="checked"' }}value="{{ search.label }}" data-placeholder="{{ search.placeholder }}" data-action="{{ search.url }}" class="me-1" id="search-{{ search.name }}"> <label class="align-middle" for="search-{{ search.name }}">{{ search.label }}</label>
+            <input {{ index == 0 ? 'checked ' }}id="search-{{ search.name }}" class="me-1" name="search-box-option" type="radio" value="{{ search.name }}" data-placeholder="{{ search.placeholder }}" data-action="{{ search.url }}"> <label for="search-{{ search.name }}">{{ search.label }}</label>
           </div>
         {% endfor %}
       </div>

--- a/templates/includes/ucb-search-box.html.twig
+++ b/templates/includes/ucb-search-box.html.twig
@@ -2,26 +2,26 @@
 <div class="ucb-search-box" role="search">
   <form action="{{ site_search.0.url }}" method="get">
     <div class="ucb-search-box-inputs">
-    <div class="ucb-search-input-text">
-      <label class="element-invisible">Enter the terms you wish to search for.</label>
-      <input placeholder="{{ site_search.0.placeholder }}" type="search" name="cse" value="" size="15" maxlength="1024">
-    </div>
-    <div class="ucb-search-input-submit">
-      <input type="submit" name="op" value="Search">
-    </div>
+      <div class="ucb-search-input-text">
+        <label class="element-invisible">Enter the terms you wish to search for.</label>
+        <input placeholder="{{ site_search.0.placeholder }}" type="search" name="cse" value="" size="15" maxlength="1024">
+      </div>
+      <div class="ucb-search-input-submit">
+        <input type="submit" name="op" value="Search">
+      </div>
     </div>
     {% if site_search|length > 1 %}
       <div class="ucb-search-box-options">
         {% for index, search in site_search %}
           <div>
-            <input type="radio"{{ index == 0 ? ' checked="checked"' }}value="{{ search.label }}" data-placeholder="{{ search.placeholder }}" data-action="{{ search.url }}" id="search-{{ search.name }}"> <label for="search-{{ search.name }}">{{ search.label }}</label>
+            <input name="search-box-option" type="radio"{{ index == 0 ? ' checked="checked"' }}value="{{ search.label }}" data-placeholder="{{ search.placeholder }}" data-action="{{ search.url }}" class="me-1" id="search-{{ search.name }}"> <label class="align-middle" for="search-{{ search.name }}">{{ search.label }}</label>
           </div>
         {% endfor %}
       </div>
     {% endif %}
     <div class="ucb-search-box-links">
-    <h3 class="d-inline">Other ways to search:</h3>
-    <ul class="d-inline list-inline"><li class="list-inline-item"><a href="https://calendar.colorado.edu">Events Calendar</a></li><li class="list-inline-item"><a href="https://www.colorado.edu/map">Campus Map</a></li></ul>
+      <h3 class="d-inline">Other ways to search:</h3>
+      <ul class="d-inline list-inline"><li class="list-inline-item"><a href="https://calendar.colorado.edu">Events Calendar</a></li><li class="list-inline-item"><a href="https://www.colorado.edu/map">Campus Map</a></li></ul>
     </div>
   </form>
 </div>

--- a/templates/includes/ucb-search-modal.html.twig
+++ b/templates/includes/ucb-search-modal.html.twig
@@ -1,9 +1,9 @@
 {{ attach_library('boulder_base/ucb-search-modal') }}
-<div hidden tabindex="-1" class="ucb-search-modal">
+<div hidden tabindex="-1" class="ucb-search-modal opacity-0">
   <div class="ucb-search-modal-inner">
     <div class="ucb-search-modal-content">
-      <div>
-        <h2>Search</h2>
+      <div class="d-flex justify-content-between">
+        <h2 class="ucb-search-modal-header"><i class="fa-solid fa-magnifying-glass me-1" aria-hidden="true"></i>Search</h2>
         <button class="ucb-search-modal-close" aria-label="Close search"><i class="fa-solid fa-times" aria-hidden="true"></i></button>
       </div>
       {% include '@boulder_base/includes/ucb-search-box.html.twig' %}

--- a/templates/includes/ucb-search-modal.html.twig
+++ b/templates/includes/ucb-search-modal.html.twig
@@ -1,12 +1,11 @@
 {{ attach_library('boulder_base/ucb-search-modal') }}
 <div hidden tabindex="-1" class="ucb-search-modal opacity-0">
-  <div class="ucb-search-modal-inner">
-    <div class="ucb-search-modal-content">
-      <div class="d-flex justify-content-between">
-        <h2 class="ucb-search-modal-header"><i class="fa-solid fa-magnifying-glass me-1" aria-hidden="true"></i>Search</h2>
-        <button class="ucb-search-modal-close" aria-label="Close search"><i class="fa-solid fa-times" aria-hidden="true"></i></button>
-      </div>
-      {% include '@boulder_base/includes/ucb-search-box.html.twig' %}
+  <div class="ucb-search-modal-backdrop"></div>
+  <div class="ucb-search-modal-content">
+    <div class="d-flex justify-content-between">
+      <h2 class="ucb-search-modal-header"><i class="fa-solid fa-magnifying-glass me-1" aria-hidden="true"></i>Search</h2>
+      <button class="ucb-search-modal-close" aria-label="Close search"><i class="fa-solid fa-times" aria-hidden="true"></i></button>
     </div>
+    {% include '@boulder_base/includes/ucb-search-box.html.twig' %}
   </div>
 </div>

--- a/templates/includes/ucb-search-modal.html.twig
+++ b/templates/includes/ucb-search-modal.html.twig
@@ -1,0 +1,12 @@
+{{ attach_library('boulder_base/ucb-search-modal') }}
+<div hidden tabindex="-1" class="ucb-search-modal">
+  <div class="ucb-search-modal-inner">
+    <div class="ucb-search-modal-content">
+      <div>
+        <h2>Search</h2>
+        <button class="ucb-search-modal-close" aria-label="Close search"><i class="fa-solid fa-times" aria-hidden="true"></i></button>
+      </div>
+      {% include '@boulder_base/includes/ucb-search-box.html.twig' %}
+    </div>
+  </div>
+</div>

--- a/templates/layout/page.html.twig
+++ b/templates/layout/page.html.twig
@@ -77,9 +77,11 @@
 
     {% set header_color = 'black' %}
     {% set campus_header_color = 'black' %}
+    {% set campus_header_text_color = 'white' %}
 
     {% if ucb_campus_header_color == 1  %}
       {% set campus_header_color = 'white' %}
+      {% set campus_header_text_color = 'black' %}
     {% endif %}
 
     {% if ucb_header_color == 1  %}
@@ -106,10 +108,22 @@
       </div>
     {% endif %}
     <div class="background-{{ campus_header_color }} brand-bar brand-bar-{{ campus_header_color }} padding-vertical-small">
-      <div class="container">
-        <script type="text/javascript" src="https://cdn.colorado.edu/static/brand-assets/live/js/brand-bar.js" id="ucb-brand-bar-embed" data-color="{{ campus_header_color }}"></script>
+      <div class="container">{{ attach_library('boulder_base/ucb-brand-bar') }}
+        <div class="ucb-brand-bar ucb-brand-bar-{{ campus_header_color }}">
+          <a href="https://www.colorado.edu" class="ucb-home-link">
+            <img class="ucb-logo" src="https://cdn.colorado.edu/static/brand-assets/live/images/cu-boulder-logo-text-{{ campus_header_text_color }}.svg" alt="University of Colorado Boulder">
+          </a>
+          {% if site_search.0 %}
+            <a class="ucb-search-link" href="{{ site_search.0.url }}">
+              <img class="ucb-search" alt="Search Colorado.edu" src="https://cdn.colorado.edu/static/brand-assets/live/images/search-{{ campus_header_text_color }}.svg">
+            </a>
+          {% endif %}
+        </div>
       </div>
     </div>
+    {% if site_search.0 %}
+      {% include '@boulder_base/includes/ucb-search-modal.html.twig' %}
+    {% endif %}
     <header class="ucb {{ header_color }}{% if site_affiliation.id %} ucb-site-affiliation-{{ site_affiliation.id }}{% endif %}" role="banner">
       <div class="container ucb-menu-wrapper">
         <div class="ucb-site-name-wrapper">
@@ -259,27 +273,27 @@
 
 </div>{# /.layout-container #}
 
-  {# Services -- see ucb_site_config #}
-  {# LiveChat #}
-  {% if service_livechat_includes|length > 0%}
-  {{ attach_library('boulder_base/livechat') }}
-  {% for service in service_livechat_includes %}
-  <livechat-service license-id="{{service.service_settings.license_id}}"></livechat-service>
-  {% endfor %}
-  {% endif %}
+{# Services -- see ucb_site_config #}
+{# LiveChat #}
+{% if service_livechat_includes|length > 0%}
+{{ attach_library('boulder_base/livechat') }}
+{% for service in service_livechat_includes %}
+<livechat-service license-id="{{service.service_settings.license_id}}"></livechat-service>
+{% endfor %}
+{% endif %}
 
-  {# statuspage #}
-  {% if service_statuspage_includes|length > 0%}
-  {{ attach_library('boulder_base/statuspage') }}
-  {% for service in service_statuspage_includes %}
-  <statuspage-service page-id="{{service.service_settings.page_id}}"></statuspage-service>
-  {% endfor %}
-  {% endif %} 
- 
-  {# mainstay #}
-  {% if service_mainstay_includes|length > 0%}
-  {{ attach_library('boulder_base/mainstay') }}
-  {% for service in service_mainstay_includes %}
-  <mainstay-service bot-token="{{service.service_settings.bot_token}}" college-id="{{service.service_settings.college_id}}"></mainstay-service>
-  {% endfor %}
-  {% endif %} 
+{# statuspage #}
+{% if service_statuspage_includes|length > 0%}
+{{ attach_library('boulder_base/statuspage') }}
+{% for service in service_statuspage_includes %}
+<statuspage-service page-id="{{service.service_settings.page_id}}"></statuspage-service>
+{% endfor %}
+{% endif %} 
+
+{# mainstay #}
+{% if service_mainstay_includes|length > 0%}
+{{ attach_library('boulder_base/mainstay') }}
+{% for service in service_mainstay_includes %}
+<mainstay-service bot-token="{{service.service_settings.bot_token}}" college-id="{{service.service_settings.college_id}}"></mainstay-service>
+{% endfor %}
+{% endif %} 

--- a/templates/layout/page.html.twig
+++ b/templates/layout/page.html.twig
@@ -115,7 +115,7 @@
           </a>
           {% if site_search.0 %}
             <a class="ucb-search-link" href="{{ site_search.0.url }}">
-              <img class="ucb-search" alt="Search Colorado.edu" src="https://cdn.colorado.edu/static/brand-assets/live/images/search-{{ campus_header_text_color }}.svg">
+              <img class="ucb-search" alt="Search" src="https://cdn.colorado.edu/static/brand-assets/live/images/search-{{ campus_header_text_color }}.svg">
             </a>
           {% endif %}
         </div>


### PR DESCRIPTION
This update:
- Adds a search modal which appears when clicking on the search icon in the top bar.
- Adds a new "Pages and search" tab to CU Boulder site settings (`/admin/config/cu-boulder/pages`). This tab contains settings accessible to Architect, Developer, and Site Manager:
  - The home page setting (moved from "General").
  - Options to enable site search, all of Colorado.edu search (default), both, or neither.
  - Configuration for the site search label, placeholder, and URL.
- Renames "Appearance" to "Appearance and layout" and alters the descriptions of menu items.
- Adds the [Google Programmable Search Engine](https://www.drupal.org/project/google_cse) module, which allows creating custom search pages to use with site search.

Resolves CuBoulder/tiamat-theme#266

Sister PR in: [ucb_site_configuration](https://github.com/CuBoulder/ucb_site_configuration/pull/29), [tiamat10-profile](https://github.com/CuBoulder/tiamat10-profile/pull/43), [tiamat10-project-template](https://github.com/CuBoulder/tiamat10-project-template/pull/17)