### PR TITLE
Fixes List Indicator Alignment with Left Align Images

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -467,6 +467,17 @@
     padding-right: 1em;
   }
 
+/* Adjusts list elements when a left-floated image (.align-left) is a preceeding sibling, aligns list indicators with other elements  */
+.align-left + ol {
+  right: -1em;
+  position: relative;
+}
+
+.align-left + ul {
+  right: -1em;
+  position: relative;
+}
+
 /* Resets Bootstrap's `placeholder` class styles */
 .placeholder {
 	display: initial;

--- a/css/style.css
+++ b/css/style.css
@@ -468,12 +468,7 @@
   }
 
 /* Adjusts list elements when a left-floated image (.align-left) is a preceeding sibling, aligns list indicators with other elements  */
-.align-left + ol {
-  right: -1em;
-  position: relative;
-}
-
-.align-left + ul {
+.align-left + ol, .align-left + ul {
   right: -1em;
   position: relative;
 }


### PR DESCRIPTION
This change aligns the list indicators on a list element with other text elements next to a left-aligned image. 

Previously, the float css for aligning an element left would cause visual issues with list indicators specifically, the bullet-point or numbering becoming hard to see or lost within the image. There is now condtionally applied left-spacing to rendered Ordered and Unordered list elements, when directly next to a Left Align (.align-left) image. 

Resolves #523 