### PR TITLE
People List Filter Labels as a Global Setting

### DIFF
--- a/config/install/boulder_base.settings.yml
+++ b/config/install/boulder_base.settings.yml
@@ -24,3 +24,8 @@ ucb_social_share_position: '0'
 ucb_breadcrumb_nav: 1
 ucb_date_format:  '0'
 ucb_use_custom_logo: false
+ucb_filter_1_label: 'Filter 1'
+ucb_filter_2_label: 'Filter 2'
+ucb_filter_3_label: 'Filter 3'
+
+

--- a/templates/content/node--ucb-people-list-page.html.twig
+++ b/templates/content/node--ucb-people-list-page.html.twig
@@ -16,6 +16,11 @@
 	{% set isFrontPage = 'sr-only' %}
 {% endif %}
 
+{# Global Labels for Filters 1-3, set in site config#}
+{% set ucb_filter_1_label = drupal_config('boulder_base.settings', 'ucb_filter_1_label') %}
+{% set ucb_filter_2_label = drupal_config('boulder_base.settings', 'ucb_filter_2_label') %}
+{% set ucb_filter_3_label = drupal_config('boulder_base.settings', 'ucb_filter_3_label') %}
+
 {%
 	set classes = [
 		'node',
@@ -51,19 +56,19 @@
 			'filter_1': {
 				'includes': content.field_ucb_people_filter_1|render|striptags|trim|split(' '),
 				'userAccessible': content.field_ucb_people_filter_1_s|render|striptags|trim == 'On',
-				'label': content.field_ucb_people_filter_1_label|render|striptags|trim,
+				'label': ucb_filter_1_label|render|striptags|trim,
 				'restrict': true
 			},
 			'filter_2': {
 				'includes': content.field_ucb_people_filter_2|render|striptags|trim|split(' '),
 				'userAccessible': content.field_ucb_people_filter_2_s|render|striptags|trim == 'On',
-				'label': content.field_ucb_people_filter_2_label|render|striptags|trim,
+				'label': ucb_filter_2_label|render|striptags|trim,
 				'restrict': true
 			},
 			'filter_3': {
 				'includes': content.field_ucb_people_filter_3|render|striptags|trim|split(' '),
 				'userAccessible': content.field_ucb_people_filter_3_s|render|striptags|trim == 'On',
-				'label': content.field_ucb_people_filter_3_label|render|striptags|trim,
+				'label': ucb_filter_3_label|render|striptags|trim,
 				'restrict': true
 			}
 		},


### PR DESCRIPTION
Changes the People List `Filter 1`, `Filter 2`, and `Filter 3` custom labels to a Global Setting in Site Configuration, rather than being set per-page. These labels will be set under Configuration => Cu Boulder Site Settings => Appearance and Layout.

Resolves #543 

Includes:
- `ucb_site_configuarion` => https://github.com/CuBoulder/ucb_site_configuration/pull/35
-  `tiamat-theme` => https://github.com/CuBoulder/tiamat-theme/pull/560
-  `ucb_custom_entities` => 