### PR TITLE
Corrects Article Title Background Image display issues

### DIFF
--- a/css/ucb-article.css
+++ b/css/ucb-article.css
@@ -193,3 +193,8 @@ i.fa-regular.fa-calendar {
 .backgroundTitleDiv > div > div > .media-image-caption{
   display: none;
 }
+
+/* Fixes display issues on Article Header Image caused by .imageMediaStyle display */
+.backgroundTitleDiv .imageMediaStyle {
+  display: block;
+}

--- a/css/ucb-article.css
+++ b/css/ucb-article.css
@@ -194,7 +194,11 @@ i.fa-regular.fa-calendar {
   display: none;
 }
 
-/* Fixes display issues on Article Header Image caused by .imageMediaStyle display */
+/* These fixes display issues on Article Header Image caused by .imageMediaStyle defaults */
 .backgroundTitleDiv .imageMediaStyle {
   display: block;
+}
+
+.backgroundTitleDiv .imageMediaStyle img{
+  padding-bottom: 0px;
 }


### PR DESCRIPTION
Corrects styles for `Article Title Background` with Overlays (under Advanced Style Options on Article Nodes)

Resolves #566 