### PR TITLE
Styles search results page

### DIFF
--- a/boulder_base.libraries.yml
+++ b/boulder_base.libraries.yml
@@ -350,6 +350,12 @@ ucb-search-modal:
     theme:
       css/ucb-search-modal.css: {}
 
+ucb-search-page:
+  version: 1.x
+  css:
+    theme:
+      css/ucb-search-page.css: {}
+
 ucb-menu:
   version: 1.x
   js:

--- a/css/ucb-search-page.css
+++ b/css/ucb-search-page.css
@@ -1,0 +1,147 @@
+#google-cse-results {
+  margin-bottom: 20px;
+}
+
+#google-cse-results .gsc-control-cse, #google-cse-results .gsc-control-cse .gsc-table-result {
+  font-size: 1em;
+  font: inherit;
+}
+
+#google-cse-results .gsc-control-cse {
+  padding: 0;
+}
+
+#google-cse-results .gsc-result.gsc-promotion {
+  border: 1px solid #e0e0e0;
+  padding: 10px;
+  font-size: 1.1em;
+  background: #f7f7f7;
+  margin-bottom: 20px;
+}
+
+#google-cse-results .gsc-result.gsc-promotion a.gs-title:link *,
+#google-cse-results .gsc-result.gsc-promotion a.gs-title:visited * {
+  color: #01578b;
+}
+
+#google-cse-results .gsc-result {
+  padding: 10px 0;
+  border-bottom: 1px solid #e0e0e0;
+}
+
+#google-cse-results .gsc-result .gs-result {
+  display: flex;
+  flex-direction: column;
+}
+
+#google-cse-results .gsc-result .gs-result .gsc-thumbnail-inside {
+  order: 1;
+}
+
+#google-cse-results .gsc-result .gs-result .gsc-url-top {
+  order: 3;
+}
+
+#google-cse-results .gsc-result .gs-result .gsc-table-result {
+  order: 2;
+}
+
+#google-cse-results .gsc-result .gs-result a.gs-visibleUrl,
+#google-cse-results .gsc-result .gs-result .gs-visibleUrl {
+  color: #757575;
+}
+
+#google-cse-results .gsc-result .gs-result .gs-spelling a {
+  color: #0277BD;
+}
+
+#google-cse-results .gsc-result .gs-result .gs-spelling-original,
+#google-cse-results .gsc-result .gs-result .gs-visibleUrl {
+  font-size: 75%;
+}
+
+#google-cse-results .gsc-result .gs-title {
+  height: auto;
+}
+
+#google-cse-results .gsc-result a.gs-title {
+  color: #0277BD;
+  display: block;
+  text-decoration: none;
+  font-size: 1.1em;
+}
+
+#google-cse-results .gsc-result a.gs-title b {
+  font-weight: bold;
+  color: #01578b;
+}
+
+#google-cse-results .gsc-result .gsc-url-bottom {
+  font-size: .85em;
+  color: #757575;
+}
+
+#google-cse-results .gsc-result:hover {
+  -webkit-box-shadow: none;
+  -moz-box-shadow: none;
+  box-shadow: none;
+}
+
+#google-cse-results .gsc-cursor {
+  padding: 20px 0;
+  display: block;
+}
+
+#google-cse-results .gsc-cursor .gsc-cursor-page {
+  display: inline-block;
+  margin: 0;
+  margin-right: -1px;
+  padding: 0;
+  text-align: center;
+  border: 1px solid #e0e0e0;
+  white-space: nowrap;
+  line-height: 1;
+  padding: 8px;
+  text-decoration: none;
+  color: #0277BD;
+}
+
+#google-cse-results .gsc-cursor .gsc-cursor-page:hover {
+  background: #e0e0e0;
+  color: #01578b;
+}
+
+#google-cse-results .gsc-cursor .gsc-cursor-page.gsc-cursor-current-page {
+  background-color: #0277BD;
+  border: 1px solid #0277BD;
+  color: #fff;
+}
+
+#google-cse-results .gsc-branding-text,
+#google-cse-results .gcsc-branding-text {
+  vertical-align: top;
+  padding-bottom: 2px;
+  text-align: right;
+  font-size: 11px;
+  margin-right: 2px;
+  color: #666;
+  white-space: nowrap;
+}
+
+#google-cse-results .gs-web-image-box,
+#google-cse-results .gs-promotion-image-box {
+  float: none;
+  padding: 2px 8px 2px 0;
+  width: auto;
+}
+
+#google-cse-results .gs-web-image-box img.gs-image,
+#google-cse-results .gs-web-image-box img.gs-promotion-image,
+#google-cse-results .gs-promotion-image-box img.gs-image,
+#google-cse-results .gs-promotion-image-box img.gs-promotion-image {
+  width: 100%;
+  height: auto;
+  display: none;
+  vertical-align: middle;
+  max-width: none;
+}

--- a/css/ucb-search-page.css
+++ b/css/ucb-search-page.css
@@ -1,3 +1,75 @@
+.ucb-search-page-content {
+  padding-top: 20px;
+}
+
+.ucb-search-page-content #block-boulder-base-content > h2 {
+  display: none;
+}
+
+#search-form {
+  padding-bottom: 20px;
+}
+
+#search-form #edit-basic {
+  display: flex;
+  flex-direction: row;
+  border: 5px solid #e0e0e0;
+}
+
+#search-form #edit-basic .form-item {
+  flex: 1;
+}
+
+#search-form #edit-basic #edit-submit {
+  flex: 0;
+}
+
+#search-form #edit-basic label {
+  position: absolute;
+  display: block;
+  left: -999%;
+}
+
+#search-form #edit-basic .form-search {
+  width: 100%;
+  font-size: 1em;
+  line-height: 40px;
+  height: 40px;
+  padding: 0 8px;
+  -webkit-border-radius: 0;
+  -moz-border-radius: 0;
+  border-radius: 0;
+  border: none;
+  -webkit-appearance: none;
+  outline-offset: 0px;
+  transition: outline-offset .1s ease-in-out;
+}
+
+#search-form #edit-basic .form-search:focus {
+  outline: #0277BD solid 2px;
+  outline-offset: 3px;
+}
+
+#search-form #edit-basic #edit-submit {
+  line-height: 40px;
+  height: 40px;
+  padding: 0 8px;
+  -webkit-box-shadow: none;
+  -moz-box-shadow: none;
+  box-shadow: none;
+  -webkit-border-radius: 0;
+  -moz-border-radius: 0;
+  border-radius: 0;
+  border: none;
+  -webkit-appearance: none;
+  margin: 0;
+  transition: background-color 0.5s ease;
+}
+
+#search-form .search-help-link {
+  display: none;
+}
+
 #google-cse-results {
   margin-bottom: 20px;
 }

--- a/templates/layout/page--search.html.twig
+++ b/templates/layout/page--search.html.twig
@@ -1,0 +1,64 @@
+{#
+/**
+ * @file
+ * Theme override to display a single page.
+ *
+ * The doctype, html, head and body tags are not in this template. Instead they
+ * can be found in the html.html.twig template in this directory.
+ *
+ * Available variables:
+ *
+ * General utility variables:
+ * - base_path: The base URL path of the Drupal installation. Will usually be
+ *   "/" unless you have installed Drupal in a sub-directory.
+ * - is_front: A flag indicating if the current page is the front page.
+ * - logged_in: A flag indicating if the user is registered and signed in.
+ * - is_admin: A flag indicating if the user has permission to access
+ *   administration pages.
+ *
+ * Site identity:
+ * - front_page: The URL of the front page. Use this instead of base_path when
+ *   linking to the front page. This includes the language domain or prefix.
+ *
+ * Page content (in order of occurrence in the default page.html.twig):
+ * - messages: Status and error messages. Should be displayed prominently.
+ * - node: Fully loaded node, if there is an automatically-loaded node
+ *   associated with the page and the node ID is the second argument in the
+ *   page's path (e.g. node/12345 and node/12345/revisions, but not
+ *   comment/reply/12345).
+ *
+ * Regions:
+ * - page.header: Items for the header region.
+ * - page.primary_menu: Items for the primary menu region.
+ * - page.secondary_menu: Items for the secondary menu region.
+ * - page.highlighted: Items for the highlighted content region.
+ * - page.help: Dynamic help text, mostly for admin pages.
+ * - page.content: The main content of the current page.
+ * - page.sidebar_first: Items for the first sidebar.
+ * - page.sidebar_second: Items for the second sidebar.
+ * - page.footer: Items for the footer region.
+ * - page.breadcrumb: Items for the breadcrumb region.
+ *
+ * @see template_preprocess_page()
+ * @see html.html.twig
+ */
+#}
+
+{{ attach_library('boulder_base/ucb-search-page') }}
+
+<div class="layout-container ucb-page-container">
+  {{ block("page_header", "page.html.twig") }}
+  <div class="ucb-page-content">
+    {{ page.highlighted }}
+    {{ page.help }}
+    <main role="main">
+      <div class="ucb-above-content-region container">
+        {{ page.above_content }}
+      </div>
+      <div class="layout-content container">
+        {{ page.content }}
+      </div>
+    </main>
+  </div>
+  {{ block("page_footer", "page.html.twig") }}
+</div>

--- a/templates/layout/page--search.html.twig
+++ b/templates/layout/page--search.html.twig
@@ -55,7 +55,8 @@
       <div class="ucb-above-content-region container">
         {{ page.above_content }}
       </div>
-      <div class="layout-content container">
+      <div class="ucb-search-page-content container">
+	    <h1>Search</h1>
         {{ page.content }}
       </div>
     </main>


### PR DESCRIPTION
Resolves CuBoulder/tiamat-theme#535 – A site's search page created using the [Google Programmable Search Engine](https://www.drupal.org/project/google_cse) module is now styled properly. Correct settings for the search page (may already be defaults):

- Display Drupal-provided search input: **✓**
- Display search results: **On this site (requires JavaScript)**
- Layout of Search Engine: **Results only**

"Display Google watermark" is on for D7 Express and works fine here too, whether to enable it is a possible future topic of discussion.