### PR TITLE
CU Boulder Site Configuration 2.6

### DIFF
--- a/config/install/boulder_base.settings.yml
+++ b/config/install/boulder_base.settings.yml
@@ -15,17 +15,10 @@ ucb_sidebar_position: '0'
 ucb_be_boulder: '1'
 ucb_rave_alerts: 1
 ucb_sticky_menu: 0
-ucb_gtm_account: ''
 ucb_secondary_menu_default_links: 0
 ucb_secondary_menu_position: inline
 ucb_secondary_menu_button_display: 0
 ucb_footer_menu_default_links: 0
 ucb_social_share_position: '0'
 ucb_breadcrumb_nav: 1
-ucb_date_format:  '0'
 ucb_use_custom_logo: false
-ucb_filter_1_label: 'Filter 1'
-ucb_filter_2_label: 'Filter 2'
-ucb_filter_3_label: 'Filter 3'
-
-

--- a/templates/content/node--ucb-article.html.twig
+++ b/templates/content/node--ucb-article.html.twig
@@ -14,76 +14,76 @@
 {# Used for hiding site title visibly using sr-only bootstrap class, if front page #}
 {% set isFrontPage = '' %}
 {% if is_front %}
-	{% set isFrontPage = 'sr-only' %}
+  {% set isFrontPage = 'sr-only' %}
 {% endif %}
 
 {% set excludeCats = related_articles_exclude_categories %}
-{% set excludeTags = drupal_config('ucb_site_configuration.settings', 'related_articles_exclude_tags') %}
+{% set excludeTags = related_articles_exclude_tags %}
 
 {# DATE FORMATTER - use global setting for all, unless override in article provided #}
-{% set global_date_format = drupal_config('boulder_base.settings', 'ucb_date_format') %}
+{% set global_date_format = article_date_format %}
 {% set showDate = true %}
 {% set localDateOverride = content.field_ucb_article_date_override|render|striptags|trim %}
 
 {# Local Date/Time Overrides, else use Global Settings #}
-	{% if localDateOverride != 0 %}
-		{% if localDateOverride == 1 %}
-		{% set article_date_format = node.created.value|date("n/j/Y") %}
-	{% elseif localDateOverride == 2 %}
-		{% set article_date_format = node.created.value|date("M. j, Y") %}
-	{% elseif localDateOverride == 3 %}
-		{% set article_date_format = node.created.value|date("l, M. j, Y") %}
-	{% elseif localDateOverride == 4 %}
-		{% set article_date_format = node.created.value|date("m/j/y  - g:i a", "America/Denver") %}
-	{% elseif localDateOverride == 5 %}
-		{% set article_date_format = node.created.value|date("M. d, Y  - g:i a", "America/Denver") %}
-	{% elseif localDateOverride == 6 %}
-		{% set article_date_format = node.created.value|date("l, M. j, Y  - g:i a", "America/Denver") %}
-	{% elseif localDateOverride == 7 %}
-		{% set article_date_format = "hidden" %}
-		{% set showDate = false %}
-	{% else %}
-		{% set article_date_format = node.created.value|date('F d, Y') %}
-	{% endif %}
+  {% if localDateOverride != 0 %}
+    {% if localDateOverride == 1 %}
+    {% set date_formatted = node.created.value|date("n/j/Y") %}
+  {% elseif localDateOverride == 2 %}
+    {% set date_formatted = node.created.value|date("M. j, Y") %}
+  {% elseif localDateOverride == 3 %}
+    {% set date_formatted = node.created.value|date("l, M. j, Y") %}
+  {% elseif localDateOverride == 4 %}
+    {% set date_formatted = node.created.value|date("m/j/y  - g:i a", "America/Denver") %}
+  {% elseif localDateOverride == 5 %}
+    {% set date_formatted = node.created.value|date("M. d, Y  - g:i a", "America/Denver") %}
+  {% elseif localDateOverride == 6 %}
+    {% set date_formatted = node.created.value|date("l, M. j, Y  - g:i a", "America/Denver") %}
+  {% elseif localDateOverride == 7 %}
+    {% set date_formatted = "hidden" %}
+    {% set showDate = false %}
+  {% else %}
+    {% set date_formatted = node.created.value|date('F d, Y') %}
+  {% endif %}
 {% else %}
-	{# Global Settings #}
-	{# short date #}
-		{% if global_date_format == "0" %}
-		{% set article_date_format = node.created.value|date("n/j/Y") %}
-		{# medium date #}
-	{% elseif global_date_format == "1"%}
-		{% set article_date_format = node.created.value|date("M. j, Y") %}
-		{# long date #}
-	{% elseif global_date_format == "2"%}
-		{% set article_date_format = node.created.value|date("l, M. j, Y") %}
-		{# short date w time #}
-	{% elseif global_date_format == "3" %}
-		{% set article_date_format = node.created.value|date("m/j/y  - g:i a", "America/Denver") %}
-		{# medium date w time #}
-	{% elseif global_date_format == "4" %}
-		{% set article_date_format = node.created.value|date("M. d, Y  - g:i a", "America/Denver") %}
-		{# long date with time #}
-	{% elseif global_date_format == "5" %}
-		{% set article_date_format = node.created.value|date("l, M. j, Y  - g:i a", "America/Denver") %}
-		{# none - hide #}
-	{% elseif global_date_format == "6" %}
-		{% set article_date_format = "hidden" %}
-		{% set showDate = false %}
-	{% else %}
-		{% set article_date_format = node.created.value|date('F d, Y') %}
-	{% endif %}
+  {# Global Settings #}
+  {# short date #}
+    {% if global_date_format == "0" %}
+    {% set date_formatted = node.created.value|date("n/j/Y") %}
+    {# medium date #}
+  {% elseif global_date_format == "1"%}
+    {% set date_formatted = node.created.value|date("M. j, Y") %}
+    {# long date #}
+  {% elseif global_date_format == "2"%}
+    {% set date_formatted = node.created.value|date("l, M. j, Y") %}
+    {# short date w time #}
+  {% elseif global_date_format == "3" %}
+    {% set date_formatted = node.created.value|date("m/j/y  - g:i a", "America/Denver") %}
+    {# medium date w time #}
+  {% elseif global_date_format == "4" %}
+    {% set date_formatted = node.created.value|date("M. d, Y  - g:i a", "America/Denver") %}
+    {# long date with time #}
+  {% elseif global_date_format == "5" %}
+    {% set date_formatted = node.created.value|date("l, M. j, Y  - g:i a", "America/Denver") %}
+    {# none - hide #}
+  {% elseif global_date_format == "6" %}
+    {% set date_formatted = "hidden" %}
+    {% set showDate = false %}
+  {% else %}
+    {% set date_formatted = node.created.value|date('F d, Y') %}
+  {% endif %}
 {% endif %}
 
 
 {% set pageStyleInt = content.field_ucb_article_style|render|striptags|trim %}
 {% set pageStyleCSS = "" %}
 {% if pageStyleInt == "Traditional"%}
-	{% set pageStyleCSS = "ucb-page-style-traditional" %}
+  {% set pageStyleCSS = "ucb-page-style-traditional" %}
 {% elseif pageStyleInt =="Dark Mode"%}
-	{% set pageStyleCSS = "ucb-page-style-dark" %}
-	{{ attach_library('boulder_base/ucb-article-dark') }}
+  {% set pageStyleCSS = "ucb-page-style-dark" %}
+  {{ attach_library('boulder_base/ucb-article-dark') }}
 {% elseif pageStyleInt =="Zebra Striped"%}
-	{% set pageStyleCSS = "ucb-page-style-striped" %}
+  {% set pageStyleCSS = "ucb-page-style-striped" %}
 {% endif %}
 
 
@@ -101,17 +101,17 @@ pageStyleCSS
 {% set social_share_button_position = drupal_config('ucb2021_base.settings', 'ucb_social_share_position')%}
 {% set social_share_class = "" %}
 {% if social_share_button_position == "0"%}
-	{% set social_share_class = "social-share-none" %}
+  {% set social_share_class = "social-share-none" %}
 {% elseif social_share_button_position=="1"%}
-	{% set social_share_class = "social-share-left-side-below-title" %}
+  {% set social_share_class = "social-share-left-side-below-title" %}
 {% elseif social_share_button_position=="2"%}
-	{% set social_share_class = "social-share-left-side-below-content" %}
+  {% set social_share_class = "social-share-left-side-below-content" %}
 {% elseif social_share_button_position == "3" %}
-	{% set social_share_class = "social-share-below-content"%}
+  {% set social_share_class = "social-share-below-content"%}
 {% elseif social_share_button_position == "4" %}
-	{% set social_share_class = "social-share-below-title" %}
+  {% set social_share_class = "social-share-below-title" %}
 {% else %}
-	{% set social_share_class = "social-share-none" %}
+  {% set social_share_class = "social-share-none" %}
 {% endif %}
 
 {% set myTags %}
@@ -126,7 +126,7 @@ pageStyleCSS
 
 {% set isLoggedIn = "false" %}
 {% if logged_in %}
-	{% set isLoggedIn = "true" %}
+  {% set isLoggedIn = "true" %}
 {% endif %}
 
 
@@ -140,119 +140,119 @@ pageStyleCSS
 {% set overlayClass = ''%}
 
 {% if content.field_ucb_article_header_overlay|render|striptags|trim == 'On' %}
-	{% if textColor is same as 'White' %}
-	{# overlay requested set to dark #}
-		{% set overlayClass = 'ucb-overlay-dark' %}
-	{% else %}
-	{# dark text, so switch to the light overlay instead #}
-		{% set overlayClass = 'ucb-overlay-light' %}
-	{% endif %}
+  {% if textColor is same as 'White' %}
+  {# overlay requested set to dark #}
+    {% set overlayClass = 'ucb-overlay-dark' %}
+  {% else %}
+  {# dark text, so switch to the light overlay instead #}
+    {% set overlayClass = 'ucb-overlay-light' %}
+  {% endif %}
 {% endif %}
 
 {% if not content.field_ucb_article_external_url|render %}
-	<article{{attributes.addClass(classes)}}>
-		<div class="ucb-article" itemscope itemtype="https://schema.org/Article">
-			{# If using a Title Background img, render that #}
-			{% if content.field_article_title_background|render %}
-			<header><h1 class="sr-only">{{ label }}</h1></header>
-				<div class="backgroundTitleDiv {{overlayClass}}">
-					{{ content.field_article_title_background }}
-					<div class="container">
-						<h1 class="centeredTitle article-header-{{textColor}} {{isFrontPage}}">{{label}}</h1>
-					</div>
-				</div>
-			{% endif %}
-			<div class="container">
-				{# If NO Title Background img, render the regular title #}
-				{% if not content.field_article_title_background|render %}
-				<header role="banner" class="ucb-article-banner">
-					<h1 class="ucb-article-heading {{isFrontPage}}">{{ label }}</h1>
-				</header>
-				{% endif %}
-				{% if social_share_button_position == "4" or social_share_button_position == "1"%}
-					<div id={{social_share_class}} class="ucb-social-share-container">
-						{{ drupal_block("social_sharing_buttons_block") }}
-					</div>
-				{% endif %}
-				{% if showDate %}
-					<div role="contentinfo" class="ucb-article-meta">
-						<div class="ucb-article-date">
-							<i class="fa-regular fa-calendar"></i>
-							<span class="sr-only">Published:{{article_date_format}}</span>
-							<span itemprop="datePublished">
-								{{ article_date_format }}
-							</span>
-						</div>
-					{% endif %}
-					{% if content.field_ucb_article_byline|render %}
-						<div class="ucb-article-byline">
-							{% if showDate %}
-								&bull;
-							{% endif %}
+  <article{{attributes.addClass(classes)}}>
+    <div class="ucb-article" itemscope itemtype="https://schema.org/Article">
+      {# If using a Title Background img, render that #}
+      {% if content.field_article_title_background|render %}
+      <header><h1 class="sr-only">{{ label }}</h1></header>
+        <div class="backgroundTitleDiv {{overlayClass}}">
+          {{ content.field_article_title_background }}
+          <div class="container">
+            <h1 class="centeredTitle article-header-{{textColor}} {{isFrontPage}}">{{label}}</h1>
+          </div>
+        </div>
+      {% endif %}
+      <div class="container">
+        {# If NO Title Background img, render the regular title #}
+        {% if not content.field_article_title_background|render %}
+        <header role="banner" class="ucb-article-banner">
+          <h1 class="ucb-article-heading {{isFrontPage}}">{{ label }}</h1>
+        </header>
+        {% endif %}
+        {% if social_share_button_position == "4" or social_share_button_position == "1"%}
+          <div id={{social_share_class}} class="ucb-social-share-container">
+            {{ drupal_block("social_sharing_buttons_block") }}
+          </div>
+        {% endif %}
+        {% if showDate %}
+          <div role="contentinfo" class="ucb-article-meta">
+            <div class="ucb-article-date">
+              <i class="fa-regular fa-calendar"></i>
+              <span class="sr-only">Published:{{date_formatted}}</span>
+              <span itemprop="datePublished">
+                {{ date_formatted }}
+              </span>
+            </div>
+          {% endif %}
+          {% if content.field_ucb_article_byline|render %}
+            <div class="ucb-article-byline">
+              {% if showDate %}
+                &bull;
+              {% endif %}
 
-							By
-							<span class="ucb-article-author-name" itemprop="author">
-								{{ content.field_ucb_article_byline}}
-							</span>
-						</div>
-					{% endif %}
+              By
+              <span class="ucb-article-author-name" itemprop="author">
+                {{ content.field_ucb_article_byline}}
+              </span>
+            </div>
+          {% endif %}
 
-				</div>
-				{% if content.field_article_header_image_text|render %}
-				<p class="ucb-article-supplemental-text">{{content.field_article_header_image_text|render|striptags|trim}}</p>
-				{% endif %}
-			</div>
-			{% if content.field_ucb_article_content|render %}
-				<div role="main" class="ucb-article-body">{{ content.field_ucb_article_content }}</div>
-			{% endif %}
-			{% if content.field_ucb_article_categories|render %}
-				<div role="contentinfo" class="container ucb-article-categories" itemprop="about">
-					<span class="sr-only">Categories:</span>
-					<div class="ucb-article-category-icon">
-						<i class="fa-solid fa-folder-open"></i>
-					</div>
-					{{ content.field_ucb_article_categories }}
-				</div>
-			{% endif %}
-			{% if content.field_ucb_article_tags|render %}
-				<div role="contentinfo" class="container ucb-article-tags" itemprop="keywords">
-					<div class="ucb-article-tag-icon">
-						<span class="sr-only">Tags:</span>
-						<i class="fa-solid fa-tags"></i>
-					</div>
-					{{ content.field_ucb_article_tags }}
-				</div>
-			{% endif %}
-			{% if content.field_appears_in_issue|render %}
-				<div role="contentinfo" class="container ucb-article-issue" itemprop="keywords">
-					<div>
-						<span class="sr-only">Issues:</span>
-						<i class="fa-solid fa-book"></i>
-					</div>
-					{{ content.field_appears_in_issue }}
-				</div>
-			{% endif %}
-			
-			{# Related Articles Block #}
-			<div class="container ucb-related-articles-block" data-loggedin="{{isLoggedIn}}" data-catsjson="{{content.field_ucb_article_categories| json_encode(constant('JSON_PRETTY_PRINT'))}}" data-tagsjson="{{ content.field_ucb_article_tags| json_encode(constant('JSON_PRETTY_PRINT')) }}" data-relatedshown="{{showRelated|striptags|trim}}" data-tags="{{myTags|render|striptags|trim|replace({"\n": "", "\r": "", "\t": ""})}}" data-cats="{{myCats|render|striptags|trim|replace({"\n": "", "\r": "", "\t": ""})}}" data-tagExclude="{{ related_articles_exclude_tags|json_encode() }}" data-catExclude="{{ related_articles_exclude_categories|json_encode() }}">
-				{{content.field_ucb_related_articles_parag}}
-			</div>
-		</div>
-	</article>
+        </div>
+        {% if content.field_article_header_image_text|render %}
+        <p class="ucb-article-supplemental-text">{{content.field_article_header_image_text|render|striptags|trim}}</p>
+        {% endif %}
+      </div>
+      {% if content.field_ucb_article_content|render %}
+        <div role="main" class="ucb-article-body">{{ content.field_ucb_article_content }}</div>
+      {% endif %}
+      {% if content.field_ucb_article_categories|render %}
+        <div role="contentinfo" class="container ucb-article-categories" itemprop="about">
+          <span class="sr-only">Categories:</span>
+          <div class="ucb-article-category-icon">
+            <i class="fa-solid fa-folder-open"></i>
+          </div>
+          {{ content.field_ucb_article_categories }}
+        </div>
+      {% endif %}
+      {% if content.field_ucb_article_tags|render %}
+        <div role="contentinfo" class="container ucb-article-tags" itemprop="keywords">
+          <div class="ucb-article-tag-icon">
+            <span class="sr-only">Tags:</span>
+            <i class="fa-solid fa-tags"></i>
+          </div>
+          {{ content.field_ucb_article_tags }}
+        </div>
+      {% endif %}
+      {% if content.field_appears_in_issue|render %}
+        <div role="contentinfo" class="container ucb-article-issue" itemprop="keywords">
+          <div>
+            <span class="sr-only">Issues:</span>
+            <i class="fa-solid fa-book"></i>
+          </div>
+          {{ content.field_appears_in_issue }}
+        </div>
+      {% endif %}
+      
+      {# Related Articles Block #}
+      <div class="container ucb-related-articles-block" data-loggedin="{{isLoggedIn}}" data-catsjson="{{content.field_ucb_article_categories| json_encode(constant('JSON_PRETTY_PRINT'))}}" data-tagsjson="{{ content.field_ucb_article_tags| json_encode(constant('JSON_PRETTY_PRINT')) }}" data-relatedshown="{{showRelated|striptags|trim}}" data-tags="{{myTags|render|striptags|trim|replace({"\n": "", "\r": "", "\t": ""})}}" data-cats="{{myCats|render|striptags|trim|replace({"\n": "", "\r": "", "\t": ""})}}" data-tagExclude="{{ related_articles_exclude_tags|json_encode() }}" data-catExclude="{{ related_articles_exclude_categories|json_encode() }}">
+        {{content.field_ucb_related_articles_parag}}
+      </div>
+    </div>
+  </article>
 {% else %}
-	<article{{attributes.addClass(classes)}}>
-		<div class="container ucb-article">
-			<h1 class="ucb-article-heading">{{ label }}</h1>
-			{% set externalURL = content.field_ucb_article_external_url[0]['#url']|render|striptags|trim %}
-			<p class="fw-bold">Redirecting to:
-				<a href="{{ externalURL }}">{{ externalURL }}</a>
-			</p>
-			{% if user_can_edit %}
-				<p>(Most visitors without editing permissions will be redirected from this page automatically)</p>
-			{% else %}
-				{# redirect non-authenticated users to the specified URL #}
-				{{ content.field_ucb_article_external_url }}
-			{% endif %}
-		</div>
-	</article>
+  <article{{attributes.addClass(classes)}}>
+    <div class="container ucb-article">
+      <h1 class="ucb-article-heading">{{ label }}</h1>
+      {% set externalURL = content.field_ucb_article_external_url[0]['#url']|render|striptags|trim %}
+      <p class="fw-bold">Redirecting to:
+        <a href="{{ externalURL }}">{{ externalURL }}</a>
+      </p>
+      {% if user_can_edit %}
+        <p>(Most visitors without editing permissions will be redirected from this page automatically)</p>
+      {% else %}
+        {# redirect non-authenticated users to the specified URL #}
+        {{ content.field_ucb_article_external_url }}
+      {% endif %}
+    </div>
+  </article>
 {% endif %}

--- a/templates/content/node--ucb-people-list-page.html.twig
+++ b/templates/content/node--ucb-people-list-page.html.twig
@@ -13,82 +13,73 @@
 {# Used for hiding site title visibly using sr-only bootstrap class, if front page #}
 {% set isFrontPage = '' %}
 {% if is_front %}
-	{% set isFrontPage = 'sr-only' %}
+  {% set isFrontPage = 'sr-only' %}
 {% endif %}
-
-{# Global Labels for Filters 1-3, set in site config#}
-{% set ucb_filter_1_label = drupal_config('boulder_base.settings', 'ucb_filter_1_label') %}
-{% set ucb_filter_2_label = drupal_config('boulder_base.settings', 'ucb_filter_2_label') %}
-{% set ucb_filter_3_label = drupal_config('boulder_base.settings', 'ucb_filter_3_label') %}
-
-{%
-	set classes = [
-		'node',
-		'container',
-		'node--type-' ~ node.bundle|clean_class,
-		node.isPromoted() ? 'node--promoted',
-		node.isSticky() ? 'node--sticky',
-		not node.isPublished() ? 'node--unpublished',
-		view_mode ? 'node--view-mode-' ~ view_mode|clean_class,
-	]
-%}{% 
-	set config = {
-		'taxonomies' : {
-			'department': 'department',
-			'job_type': 'ucb_person_job_type',
-			'filter_1': 'filter_1',
-			'filter_2': 'filter_2',
-			'filter_3': 'filter_3'
-		},
-		'filters': {
-			'department': {
-				'includes': content.field_ucb_people_department|render|striptags|trim|split(' '),
-				'userAccessible': content.field_ucb_people_department_s|render|striptags|trim == 'On',
-				'label': 'Department',
-				'restrict': true
-			},
-			'job_type': {
-				'includes': content.field_ucb_people_job_type|render|striptags|trim|split(' '),
-				'userAccessible': content.field_ucb_people_job_type_s|render|striptags|trim == 'On',
-				'label': 'Job Type',
-				'restrict': true
-			},
-			'filter_1': {
-				'includes': content.field_ucb_people_filter_1|render|striptags|trim|split(' '),
-				'userAccessible': content.field_ucb_people_filter_1_s|render|striptags|trim == 'On',
-				'label': ucb_filter_1_label|render|striptags|trim,
-				'restrict': true
-			},
-			'filter_2': {
-				'includes': content.field_ucb_people_filter_2|render|striptags|trim|split(' '),
-				'userAccessible': content.field_ucb_people_filter_2_s|render|striptags|trim == 'On',
-				'label': ucb_filter_2_label|render|striptags|trim,
-				'restrict': true
-			},
-			'filter_3': {
-				'includes': content.field_ucb_people_filter_3|render|striptags|trim|split(' '),
-				'userAccessible': content.field_ucb_people_filter_3_s|render|striptags|trim == 'On',
-				'label': ucb_filter_3_label|render|striptags|trim,
-				'restrict': true
-			}
-		},
-		'format': content.field_ucb_people_display|render|striptags|trim,
-		'groupby': content.field_ucb_people_group_by|render|striptags|trim,
-		'orderby': content.field_ucb_people_order_by|render|striptags|trim
-	}
-%}
+{% set classes = [
+    'node',
+    'container',
+    'node--type-' ~ node.bundle|clean_class,
+    node.isPromoted() ? 'node--promoted',
+    node.isSticky() ? 'node--sticky',
+    not node.isPublished() ? 'node--unpublished',
+    view_mode ? 'node--view-mode-' ~ view_mode|clean_class,
+ ] %}
+ {% set config = {
+  'taxonomies' : {
+    'department': 'department',
+    'job_type': 'ucb_person_job_type',
+    'filter_1': 'filter_1',
+    'filter_2': 'filter_2',
+    'filter_3': 'filter_3'
+  },
+  'filters': {
+    'department': {
+      'includes': content.field_ucb_people_department|render|striptags|trim|split(' '),
+      'userAccessible': content.field_ucb_people_department_s|render|striptags|trim == 'On',
+      'label': 'Department',
+      'restrict': true
+    },
+    'job_type': {
+      'includes': content.field_ucb_people_job_type|render|striptags|trim|split(' '),
+      'userAccessible': content.field_ucb_people_job_type_s|render|striptags|trim == 'On',
+      'label': 'Job Type',
+      'restrict': true
+    },
+    'filter_1': {
+      'includes': content.field_ucb_people_filter_1|render|striptags|trim|split(' '),
+      'userAccessible': content.field_ucb_people_filter_1_s|render|striptags|trim == 'On',
+      'label': people_list_filter_1_label,
+      'restrict': true
+    },
+    'filter_2': {
+      'includes': content.field_ucb_people_filter_2|render|striptags|trim|split(' '),
+      'userAccessible': content.field_ucb_people_filter_2_s|render|striptags|trim == 'On',
+      'label': people_list_filter_2_label,
+      'restrict': true
+    },
+    'filter_3': {
+      'includes': content.field_ucb_people_filter_3|render|striptags|trim|split(' '),
+      'userAccessible': content.field_ucb_people_filter_3_s|render|striptags|trim == 'On',
+      'label': people_list_filter_3_label,
+      'restrict': true
+    }
+  },
+  'format': content.field_ucb_people_display|render|striptags|trim,
+  'groupby': content.field_ucb_people_group_by|render|striptags|trim,
+  'orderby': content.field_ucb_people_order_by|render|striptags|trim
+} %}
 <article id="ucb-people-list-page"{{attributes.addClass(classes)}}>
-	<div class="ucb-people-list-title">
-		<h1{{title_attributes}} class="{{isFrontPage}}">
-			{{ label }}
-		</h1>
-	</div>
-	{% if content.body|render %}
-	<div class="ucb-person-section ucb-person-body">
-		{{ content.body }}
-	</div>
-	{% endif %}
-	<ucb-people-list base-uri="{{ url('<front>')|render|trim('/') }}/jsonapi" config="{{ config|json_encode }}" user-config="{}">
-		<noscript><div class="ucb-list-msg ucb-error">Please enable JavaScript to see this page.</div></noscript>
-	</ucb-people-list>
+  <div class="ucb-people-list-title">
+    <h1{{title_attributes}} class="{{isFrontPage}}">
+      {{ label }}
+    </h1>
+  </div>
+  {% if content.body|render %}
+  <div class="ucb-person-section ucb-person-body">
+    {{ content.body }}
+  </div>
+  {% endif %}
+  <ucb-people-list base-uri="{{ url('<front>')|render|trim('/') }}/jsonapi" config="{{ config|json_encode }}" user-config="{}">
+    <noscript><div class="ucb-list-msg ucb-error">Please enable JavaScript to see this page.</div></noscript>
+  </ucb-people-list>
 </article>


### PR DESCRIPTION
This update:
- Moves all settings from "Pages and Search" into "General". Search settings are now advanced settings.
- Replaces the "Pages and search" and "Related articles" tabs with a brand new "Content types" tab. All "Related articles" settings have been moved into "Content types".
- Replaces the `edit ucb pages` and `configure ucb related articles` permissions with a new `edit ucb content types` permission.
- Moves the People List filter labels and Article date format into "Content types".
- Moves the GTM account setting into "General" as an advanced setting.

CuBoulder/ucb_site_configuration#36

Sister PR in: [ucb_site_configuration](https://github.com/CuBoulder/ucb_site_configuration/pull/38), [tiamat10-profile](https://github.com/CuBoulder/tiamat10-profile/pull/53)