### PR TITLE
Issue/567

### DIFF
--- a/templates/block/block--content-row.html.twig
+++ b/templates/block/block--content-row.html.twig
@@ -74,8 +74,11 @@
 								{{ image|view }}
 							{% endif %}
 						</div>
+						{% else %}
+						<div class="col-4">
+						</div>
 						{% endif %}
-						<div class="{{ image ? 'col-8 ' }}row-text-container">
+						<div class="col-8 row-text-container">
 							{% if rowLink %}
 								<a href="{{ rowLink }} ">
 									<h3>{{ item.entity.field_row_layout_content_title.0.value }}</h3>
@@ -86,7 +89,7 @@
 							{{item.entity.field_row_layout_content_text|view}}
 						</div>
 					{% else %}
-						<div class="{{ image ? 'col-8 ' }}row-text-container">
+						<div class="col-8 row-text-container">
 							{% if rowLink %}
 								<a href="{{ rowLink }} ">
 									<h3>{{ item.entity.field_row_layout_content_title.0.value }}</h3>


### PR DESCRIPTION
Changes to the teaser alternate so that the image divs are displayed empty if they have no image in them.
This is so that the teasers actually alternate properly for staggered text.

Closes #567 

Sister PR: https://github.com/CuBoulder/tiamat-custom-entities/pull/88