### PR TITLE
Social Media Menu - Now Icons Only

### DIFF
--- a/templates/navigation/menu--social-media-menu.html.twig
+++ b/templates/navigation/menu--social-media-menu.html.twig
@@ -61,7 +61,7 @@
 					</span>
 				</a>
 			{% elseif 'FACEBOOK' in formattedContent %}
-				<a href="{{ item.url }}" class="icon-a" title="FaceBook" alt="FaceBook">
+				<a href="{{ item.url }}" class="icon-a" title="Facebook" alt="Facebook">
 					<span class="icon-div">
 						<span class="sr-only">Facebook</span>
 						<span class="icon-bg icon-bg-facebook">

--- a/templates/navigation/menu--social-media-menu.html.twig
+++ b/templates/navigation/menu--social-media-menu.html.twig
@@ -58,17 +58,15 @@
 						<span class="icon-bg icon-bg-twitter">
 							<i class="fa-brands fa-twitter icon-foreground"></i>
 						</span>
-						<span class="vertical-icon-span">Twitter</span>
 					</span>
 				</a>
 			{% elseif 'FACEBOOK' in formattedContent %}
 				<a href="{{ item.url }}" class="icon-a" title="FaceBook" alt="FaceBook">
 					<span class="icon-div">
-						<span class="sr-only">FaceBook</span>
+						<span class="sr-only">Facebook</span>
 						<span class="icon-bg icon-bg-facebook">
 							<i class="fa-brands fa-facebook-f icon-foreground"></i>
 						</span>
-						<span class="vertical-icon-span">FaceBook</span>
 					</span>
 				</a>
 
@@ -79,7 +77,6 @@
 						<span class="icon-bg icon-bg-instagram">
 							<i class="fa-brands fa-instagram icon-foreground"></i>
 						</span>
-						<span class="vertical-icon-span">Instagram</span>
 					</span>
 				</a>
 
@@ -90,7 +87,6 @@
 						<span class="icon-bg icon-bg-linkedin">
 							<i class="fa-brands fa-linkedin-in icon-foreground"></i>
 						</span>
-						<span class="vertical-icon-span">LinkedIn</span>
 					</span>
 				</a>
 
@@ -101,7 +97,6 @@
 						<span class="icon-bg icon-bg-youtube">
 							<i class="fa-brands fa-youtube icon-foreground"></i>
 						</span>
-						<span class="vertical-icon-span">YouTube</span>
 					</span>
 				</a>
 			{% elseif 'PINTREST' in formattedContent %}
@@ -111,7 +106,6 @@
 							<span class="icon-bg icon-bg-pintrest">
 								<i class="fa-brands fa-pinterest-p icon-foreground"></i>
 							</span>
-							<span class="vertical-icon-span">Pintrest</span>
 						</span>
 					</a>
 			{% elseif 'FLICKR' in formattedContent %}
@@ -121,7 +115,6 @@
 							<span class="icon-bg icon-bg-flickr">
 								<i class="fa-brands fa-flickr icon-foreground"></i>
 							</span>
-							<span class="vertical-icon-span">Flickr</span>
 						</span>
 					</a>
 			{% elseif 'VIMEO' in formattedContent %}
@@ -131,7 +124,6 @@
 							<span class="icon-bg icon-bg-vimeo">
 								<i class="fa-brands fa-vimeo-v icon-foreground"></i>
 							</span>
-							<span class="vertical-icon-span">Vimeo</span>
 						</span>
 					</a>
 			{% elseif 'WORDPRESS' in formattedContent %}
@@ -141,7 +133,6 @@
 							<span class="icon-bg icon-bg-wordpress">
 								<i class="fa-brands fa-wordpress-simple icon-foreground"></i>
 							</span>
-							<span class="vertical-icon-span">WordPress</span>
 						</span>
 					</a>
 			{% elseif 'TIKTOK' in formattedContent %}
@@ -151,7 +142,6 @@
 							<span class="icon-bg icon-bg-pintrest">
 								<i class="fa-brands fa-tiktok icon-foreground"></i>
 							</span>
-							<span class="vertical-icon-span">TikTok</span>
 						</span>
 					</a>
 			{% elseif 'REDDIT' in formattedContent %}
@@ -161,7 +151,6 @@
 							<span class="icon-bg icon-bg-pintrest">
 								<i class="fa-brands fa-reddit-alien icon-foreground"></i>
 							</span>
-							<span class="vertical-icon-span">Reddit</span>
 						</span>
 					</a>
 
@@ -172,7 +161,6 @@
 							<span class="icon-bg icon-bg-patreon">
 								<i class="fa-brands fa-patreon icon-foreground"></i>
 							</span>
-							<span class="vertical-icon-span">Patreon</span>
 						</span>
 					</a>
 
@@ -183,7 +171,6 @@
 							<span class="icon-bg icon-bg-discord">
 								<i class="fa-brands fa-discord icon-foreground"></i>
 							</span>
-							<span class="vertical-icon-span">Discord</span>
 						</span>
 					</a>
 			{% else %}
@@ -193,7 +180,6 @@
 						<span class="icon-bg icon-bg-link">
 							<i class="fa-solid fa-up-right-from-square icon-foreground"></i>
 						</span>
-						<span class="vertical-icon-span">Link</span>
 					</span>
 				</a>
 

--- a/templates/navigation/menu--social-media-menu.html.twig
+++ b/templates/navigation/menu--social-media-menu.html.twig
@@ -51,16 +51,7 @@
                 <li{{ item.attributes.addClass(classes) }}>
 {% set formattedContent = item.url |render|striptags|trim|upper %}
 
-			{% if ('TWITTER' in formattedContent) or ('WWW.X.COM' in formattedContent)  %}
-				<a href="{{ item.url }}" class="icon-a" title="Twitter" alt="Twitter">
-					<span class="icon-div">
-						<span class="sr-only">Twitter</span>
-						<span class="icon-bg icon-bg-twitter">
-							<i class="fa-brands fa-x-twitter icon-foreground"></i>
-						</span>
-					</span>
-				</a>
-			{% elseif 'FACEBOOK' in formattedContent %}
+			{% if 'FACEBOOK' in formattedContent %}
 				<a href="{{ item.url }}" class="icon-a" title="Facebook" alt="Facebook">
 					<span class="icon-div">
 						<span class="sr-only">Facebook</span>
@@ -173,6 +164,17 @@
 							</span>
 						</span>
 					</a>
+
+			{% elseif ('TWITTER' in formattedContent) or ('X.COM' in formattedContent)  %}
+				<a href="{{ item.url }}" class="icon-a" title="Twitter" alt="Twitter">
+					<span class="icon-div">
+						<span class="sr-only">Twitter</span>
+						<span class="icon-bg icon-bg-twitter">
+							<i class="fa-brands fa-x-twitter icon-foreground"></i>
+						</span>
+					</span>
+				</a>
+
 			{% else %}
 				<a href="{{ item.url }}" class="icon-a" title="Social Media" alt="Social Media">
 					<span class="icon-div">

--- a/templates/navigation/menu--social-media-menu.html.twig
+++ b/templates/navigation/menu--social-media-menu.html.twig
@@ -51,12 +51,12 @@
                 <li{{ item.attributes.addClass(classes) }}>
 {% set formattedContent = item.url |render|striptags|trim|upper %}
 
-			{% if 'TWITTER' in formattedContent %}
+			{% if ('TWITTER' in formattedContent) or ('WWW.X.COM' in formattedContent)  %}
 				<a href="{{ item.url }}" class="icon-a" title="Twitter" alt="Twitter">
 					<span class="icon-div">
 						<span class="sr-only">Twitter</span>
 						<span class="icon-bg icon-bg-twitter">
-							<i class="fa-brands fa-twitter icon-foreground"></i>
+							<i class="fa-brands fa-x-twitter icon-foreground"></i>
 						</span>
 					</span>
 				</a>


### PR DESCRIPTION
Social Media Menu is now icons only, fixes bug where the site name would display. Fixes spelling of 'Facebook'.

There was a: `<span class="vertical-icon-span"> * _siteNameHere_ * </span>`  on the template that was causing the site names to appear next to the respective logo on each link in the social media menu. These spans did not appear to be used anywhere else in d10, so they were removed to resolve the issue.

Resolves #586 
