### PR TITLE
Events Calendar Background matches Section background color

### DIFF
--- a/css/block/events-calendar.css
+++ b/css/block/events-calendar.css
@@ -1,7 +1,5 @@
 .ucb-events-calendar {
   overflow: auto;
-  background: white;
-  color: black;
 }
 
 .ucb-events-calendar .localist_minicalendar_events {
@@ -298,6 +296,18 @@ table.localist_minicalendar_minicalendar caption {
   transition: background-color 0.25s ease, border-color 0.25s ease, color 0.25s ease;
   background-color: #0277BD;
   color: white !important;
+}
+
+/* Section Background Color Overrides for Dark Backgrounds */
+.ucb-bootstrap-layout__background-color--dark-gray .localist_widget_container li a,
+.ucb-bootstrap-layout__background-color--black .localist_widget_container li a {
+  color: #fff
+}
+
+.ucb-bootstrap-layout__background-color--dark-gray .localist_widget_container li a:hover,
+.ucb-bootstrap-layout__background-color--black .localist_widget_container li a:hover {
+  text-decoration: underline;
+  color: #D3D3D3;
 }
 
 @media screen and (min-width: 600px) {

--- a/css/block/events-calendar.css
+++ b/css/block/events-calendar.css
@@ -309,6 +309,18 @@ table.localist_minicalendar_minicalendar caption {
   text-decoration: underline;
   color: #D3D3D3;
 }
+.ucb-bootstrap-layout__background-color--gold .localist_widget_container li a {
+  color: black
+}
+
+.ucb-bootstrap-layout__background-color--gold .localist_widget_container li a:hover {
+  text-decoration: underline;
+  color: #444;
+}
+
+.ucb-bootstrap-layout__background-color--gold .ucb-events-calendar .localist_widget_container .action_button a:link{
+  color: black
+}
 
 @media screen and (min-width: 600px) {
   .template-5 .le-date-wrapper .le-date-month {


### PR DESCRIPTION
Adjusts the `Events Calendar` so it matches the background color of the section it is placed in, rather than being always white. Text color adjusted to white for black and dark gray section backgrounds. 

@jcsparks - Let me know if gold section background needs some text color adjustments, I could make an override for that that makes the text a darker gray / black than the default. 

Resolves #564 