### PR TITLE
Newsletter: Minor Bug Fixes

### DIFF
--- a/templates/content/node--newsletter--email-html.html.twig
+++ b/templates/content/node--newsletter--email-html.html.twig
@@ -247,7 +247,9 @@ td>h3>a{
                                 {# Newsletter Taxonomy Image -- might need to be a separate table #}
                                 <tr>
                                     <td style="-moz-hyphens: none; -webkit-hyphens: none; border-collapse: collapse !important; hyphens: none; word-break: break-word; padding: 10px; text-align: left; vertical-align: top; font-family: Helvetica, Arial, sans-serif; font-weight: normal; line-height: 19px; margin: 0; font-size: 14px;">
+                                        {% if node.field_newsletter_type.entity.field_newsletter_name_image.entity.uri.value %}
                                         <img style="object-fit:cover;-ms-interpolation-mode: bicubic; clear: both; display: block; float: left; height: 167px !important; max-width: 100% !important; outline: none; text-decoration: none; width: 250px !important; max-height: auto !important;"src="{{base_url}}{{ file_url(node.field_newsletter_type.entity.field_newsletter_name_image.entity.uri.value) }}">
+                                        {% endif %}
                                     </td>
                                 </tr>
                                 {# Date & View on Website Link #}

--- a/templates/paragraphs/paragraph--newsletter-section--email-html.html.twig
+++ b/templates/paragraphs/paragraph--newsletter-section--email-html.html.twig
@@ -41,7 +41,7 @@
 								{% elseif item.entity.field_newsletter_article_select.entity.field_ucb_article_content.entity.field_article_media_selection.entity.field_media.entity.field_media_image.alt|render %}
 								<td align="center" style="text-align: left; padding-right:10px; padding-left:10px;padding-bottom:20px">
 									<a href="{{base_url}}{{ path('entity.node.canonical', {'node': item.entity.field_newsletter_article_select.target_id}) }}">
-									<img width="100%" src="{{base_url}}{{file_url(item.entity.field_newsletter_article_select.entity.field_ucb_article_content.entity.field_article_media_selection.entity.field_media.fileuri|image_style('focal_image_square'))}}"/>
+									<img width="100%" src="{{base_url}}{{file_url(item.entity.field_newsletter_article_select.entity.field_ucb_article_content.entity.field_article_media_selection.entity.field_media.entity.field_media_image.entity.fileuri|image_style('focal_image_square'))}}"/>
 									</a>
 								</td>
 									{# Code to render user made content #}


### PR DESCRIPTION
Adjusts the following on the Newsletter:
- If user elects to omit the optional image on a _Newsletter Taxonomy_, it will no longer render that img element in the header
- **Article Sections ( _Feature Style_ )** - For the Feature Style Article Sections, Articles without a thumbnail will check the Article for an Image uploaded as Article Content, and use that in place of a thumbnail if available. This functionality worked in the Teaser display, but there was an error that would prevent the backup image to display in the Feature Style render.

Resolves #595 