### PR TITLE
People List Page & People List Block - Bug Fixes & Edge Case Handling

### DIFF
--- a/js/ucb-people-list-block.js
+++ b/js/ucb-people-list-block.js
@@ -382,7 +382,12 @@ class PeopleListBlockElement extends HTMLElement {
 				if (personAttributeData['field_ucb_person_primary_link']) {
 					thisPerson.primaryLinkURI =  personAttributeData['field_ucb_person_primary_link']['uri'];
 					thisPerson.primaryLinkTitle = personAttributeData['field_ucb_person_primary_link']['title'];
-				}				
+				}
+			// This makes relative internal urls absolute, needed for multisite with single domain
+			if (thisPerson.primaryLinkURI.startsWith('internal:/')) {
+				thisPerson.primaryLinkURI = this.getAttribute('site-base') + thisPerson.primaryLinkURI.replace('internal:/', '/');
+			}
+			console.log(thisPerson.primaryLinkURI)				
 			// needed to verify body exists on the Person page, if so, use that
 			if (personAttributeData['body']) {
 				// use summary if available
@@ -583,67 +588,60 @@ class PeopleListBlockElement extends HTMLElement {
 	}
 	generateLinkIcon(linkURI) {
 		var linkIcon = "fa-solid fa-link primaryLinkIcon";
-		if (linkURI.indexOf("internal:/") == 0) {
-			return linkIcon;
-		} else {
-			const linkData = new URL(linkURI).hostname.split(".")[1].toUpperCase();
-			switch (linkData) {
-				case 'FACEBOOK' :
-					linkIcon =  "fa-brands fa-facebook primaryLinkIcon";
+
+		try {
+			const url = new URL(linkURI);
+			const domainParts = url.hostname.toLowerCase().split('.');
+			const domain = domainParts.length > 1 ? domainParts[domainParts.length - 2] : url.hostname;
+	
+			switch (domain.toUpperCase()) {
+				case 'FACEBOOK':
+					linkIcon = "fa-brands fa-facebook primaryLinkIcon";
 					break;
-				
-				case 'TWITTER' :
-					linkIcon =  "fa-brands fa-twitter primaryLinkIcon";
+				case 'TWITTER':
+					linkIcon = "fa-brands fa-twitter primaryLinkIcon";
 					break;
-				
-				case 'FLICKR' :
-					linkIcon =  "fa-brands fa-flickr primaryLinkIcon";
+				case 'FLICKR':
+					linkIcon = "fa-brands fa-flickr primaryLinkIcon";
 					break;
-				
-				case 'LINKEDIN' :
-					linkIcon =  "fa-brands fa-linkedin primaryLinkIcon";
+				case 'LINKEDIN':
+					linkIcon = "fa-brands fa-linkedin primaryLinkIcon";
 					break;
-				
-				case 'YOUTUBE' :
-					linkIcon =  "fa-brands fa-youtube primaryLinkIcon";
+				case 'YOUTUBE':
+					linkIcon = "fa-brands fa-youtube primaryLinkIcon";
 					break;
-				
-				case 'INSTAGRAM' :
-					linkIcon =  "fa-brands fa-instagram primaryLinkIcon";
+				case 'INSTAGRAM':
+					linkIcon = "fa-brands fa-instagram primaryLinkIcon";
 					break;
-				
-				case 'DISCORD' :
-					linkIcon =  "fa-brands fa-discord primaryLinkIcon";
+				case 'DISCORD':
+					linkIcon = "fa-brands fa-discord primaryLinkIcon";
 					break;
-				
-				case 'PINTREST' :
-					linkIcon =  "fa-brands fa-pinterest-p primaryLinkIcon";
+				case 'PINTEREST':
+					linkIcon = "fa-brands fa-pinterest-p primaryLinkIcon";
 					break;
-					
-				case 'VIMEO' :
-					linkIcon =  "fa-brands fa-vimeo-v primaryLinkIcon";
+				case 'VIMEO':
+					linkIcon = "fa-brands fa-vimeo-v primaryLinkIcon";
 					break;
-				
-				case 'WORDPRESS' :
-					linkIcon =  "fa-brands fa-wordpress-simple primaryLinkIcon";
+				case 'WORDPRESS':
+					linkIcon = "fa-brands fa-wordpress-simple primaryLinkIcon";
 					break;
-				
-				case 'TIKTOK' :
-					linkIcon =  "fa-brands fa-tiktok primaryLinkIcon";
+				case 'TIKTOK':
+					linkIcon = "fa-brands fa-tiktok primaryLinkIcon";
 					break;
-				
-				case 'REDDIT' :
-					linkIcon =  "fa-brands fa--reddit-alien primaryLinkIcon";
+				case 'REDDIT':
+					linkIcon = "fa-brands fa-reddit-alien primaryLinkIcon";
 					break;
-				
-				case 'PATREON' :
-					linkIcon =  "fa-brands fa-patreon primaryLinkIcon";
+				case 'PATREON':
+					linkIcon = "fa-brands fa-patreon primaryLinkIcon";
 					break;
-				default :
-					linkIcon =  "fa-solid fa-link primaryLinkIcon";																																																					
+				default:
+					linkIcon = "fa-solid fa-link primaryLinkIcon";
 			}
+		} catch (e) {
+			console.error(`Error processing URL ${linkURI}:`, e);
 		}
-	return linkIcon;
+		
+		return linkIcon;
 	}
 }
 

--- a/js/ucb-people-list-block.js
+++ b/js/ucb-people-list-block.js
@@ -253,6 +253,7 @@ class PeopleListBlockElement extends HTMLElement {
 	}
 
 	static getTaxonomyName(taxonomy, termId) {
+		if(!termId) return
 		return taxonomy.find( ({ id }) => id === termId ).name;
 	}
 

--- a/js/ucb-people-list-block.js
+++ b/js/ucb-people-list-block.js
@@ -387,7 +387,6 @@ class PeopleListBlockElement extends HTMLElement {
 			if (thisPerson.primaryLinkURI.startsWith('internal:/')) {
 				thisPerson.primaryLinkURI = this.getAttribute('site-base') + thisPerson.primaryLinkURI.replace('internal:/', '/');
 			}
-			console.log(thisPerson.primaryLinkURI)				
 			// needed to verify body exists on the Person page, if so, use that
 			if (personAttributeData['body']) {
 				// use summary if available

--- a/js/ucb-people-list-block.js
+++ b/js/ucb-people-list-block.js
@@ -599,7 +599,7 @@ class PeopleListBlockElement extends HTMLElement {
 					linkIcon = "fa-brands fa-facebook primaryLinkIcon";
 					break;
 				case 'TWITTER':
-					linkIcon = "fa-brands fa-twitter primaryLinkIcon";
+					linkIcon = "fa-brands fa-x-twitter primaryLinkIcon";
 					break;
 				case 'FLICKR':
 					linkIcon = "fa-brands fa-flickr primaryLinkIcon";

--- a/js/ucb-people-list.js
+++ b/js/ucb-people-list.js
@@ -404,7 +404,11 @@ class PeopleListElement extends HTMLElement {
 				if (personAttributeData['field_ucb_person_primary_link']) {
 					thisPerson.primaryLinkURI =  personAttributeData['field_ucb_person_primary_link']['uri'];
 					thisPerson.primaryLinkTitle = personAttributeData['field_ucb_person_primary_link']['title'];
-				}				
+				}
+				// This makes relative internal urls absolute, needed for multisite with single domain
+				 if (thisPerson.primaryLinkURI.startsWith('internal:/')) {
+					thisPerson.primaryLinkURI = this.getAttribute('site-base') + thisPerson.primaryLinkURI.replace('internal:/', '/');
+				}
 			// needed to verify body exists on the Person page, if so, use that
 			if (personAttributeData['body']) {
 				// use summary if available
@@ -746,68 +750,62 @@ class PeopleListElement extends HTMLElement {
 	}
 	generateLinkIcon(linkURI) {
 		var linkIcon = "fa-solid fa-link primaryLinkIcon";
-		if (linkURI.indexOf("internal:/") == 0) {
-			return linkIcon;
-		} else {
-			const linkData = new URL(linkURI).hostname.split(".")[1].toUpperCase();
-			switch (linkData) {
-				case 'FACEBOOK' :
-					linkIcon =  "fa-brands fa-facebook primaryLinkIcon";
+
+		try {
+			const url = new URL(linkURI);
+			const domainParts = url.hostname.toLowerCase().split('.');
+			const domain = domainParts.length > 1 ? domainParts[domainParts.length - 2] : url.hostname;
+	
+			switch (domain.toUpperCase()) {
+				case 'FACEBOOK':
+					linkIcon = "fa-brands fa-facebook primaryLinkIcon";
 					break;
-				
-				case 'TWITTER' :
-					linkIcon =  "fa-brands fa-twitter primaryLinkIcon";
+				case 'TWITTER':
+					linkIcon = "fa-brands fa-twitter primaryLinkIcon";
 					break;
-				
-				case 'FLICKR' :
-					linkIcon =  "fa-brands fa-flickr primaryLinkIcon";
+				case 'FLICKR':
+					linkIcon = "fa-brands fa-flickr primaryLinkIcon";
 					break;
-				
-				case 'LINKEDIN' :
-					linkIcon =  "fa-brands fa-linkedin primaryLinkIcon";
+				case 'LINKEDIN':
+					linkIcon = "fa-brands fa-linkedin primaryLinkIcon";
 					break;
-				
-				case 'YOUTUBE' :
-					linkIcon =  "fa-brands fa-youtube primaryLinkIcon";
+				case 'YOUTUBE':
+					linkIcon = "fa-brands fa-youtube primaryLinkIcon";
 					break;
-				
-				case 'INSTAGRAM' :
-					linkIcon =  "fa-brands fa-instagram primaryLinkIcon";
+				case 'INSTAGRAM':
+					linkIcon = "fa-brands fa-instagram primaryLinkIcon";
 					break;
-				
-				case 'DISCORD' :
-					linkIcon =  "fa-brands fa-discord primaryLinkIcon";
+				case 'DISCORD':
+					linkIcon = "fa-brands fa-discord primaryLinkIcon";
 					break;
-				
-				case 'PINTREST' :
-					linkIcon =  "fa-brands fa-pinterest-p primaryLinkIcon";
+				case 'PINTEREST':
+					linkIcon = "fa-brands fa-pinterest-p primaryLinkIcon";
 					break;
-					
-				case 'VIMEO' :
-					linkIcon =  "fa-brands fa-vimeo-v primaryLinkIcon";
+				case 'VIMEO':
+					linkIcon = "fa-brands fa-vimeo-v primaryLinkIcon";
 					break;
-				
-				case 'WORDPRESS' :
-					linkIcon =  "fa-brands fa-wordpress-simple primaryLinkIcon";
+				case 'WORDPRESS':
+					linkIcon = "fa-brands fa-wordpress-simple primaryLinkIcon";
 					break;
-				
-				case 'TIKTOK' :
-					linkIcon =  "fa-brands fa-tiktok primaryLinkIcon";
+				case 'TIKTOK':
+					linkIcon = "fa-brands fa-tiktok primaryLinkIcon";
 					break;
-				
-				case 'REDDIT' :
-					linkIcon =  "fa-brands fa--reddit-alien primaryLinkIcon";
+				case 'REDDIT':
+					linkIcon = "fa-brands fa-reddit-alien primaryLinkIcon";
 					break;
-				
-				case 'PATREON' :
-					linkIcon =  "fa-brands fa-patreon primaryLinkIcon";
+				case 'PATREON':
+					linkIcon = "fa-brands fa-patreon primaryLinkIcon";
 					break;
-				default :
-					linkIcon =  "fa-solid fa-link primaryLinkIcon";																																																					
+				default:
+					linkIcon = "fa-solid fa-link primaryLinkIcon";
 			}
+		} catch (e) {
+			console.error(`Error processing URL ${linkURI}:`, e);
 		}
-	return linkIcon;
+		
+		return linkIcon;
 	}
+	
 }
 
 customElements.define('ucb-people-list', PeopleListElement);

--- a/js/ucb-people-list.js
+++ b/js/ucb-people-list.js
@@ -290,6 +290,7 @@ class PeopleListElement extends HTMLElement {
 	}
 
 	static getTaxonomyName(taxonomy, termId) {
+		if(!termId) return
 		return taxonomy.find( ({ id }) => id === termId ).name;
 	}
 

--- a/js/ucb-people-list.js
+++ b/js/ucb-people-list.js
@@ -761,7 +761,7 @@ class PeopleListElement extends HTMLElement {
 					linkIcon = "fa-brands fa-facebook primaryLinkIcon";
 					break;
 				case 'TWITTER':
-					linkIcon = "fa-brands fa-twitter primaryLinkIcon";
+					linkIcon = "fa-brands fa-x-twitter primaryLinkIcon";
 					break;
 				case 'FLICKR':
 					linkIcon = "fa-brands fa-flickr primaryLinkIcon";

--- a/templates/block/block--ucb-people-list-block.html.twig
+++ b/templates/block/block--ucb-people-list-block.html.twig
@@ -65,6 +65,7 @@
   {{ content.body }}
 {# People List Block - Main Block#}
 <people-list-block
+	site-base= "{{url('<front>')|render|trim('/')}}"
     base-uri="{{ url('<front>')|render|trim('/') }}/jsonapi"
     config="{{ config|json_encode }}"
     user-config="{}"

--- a/templates/content/node--ucb-people-list-page.html.twig
+++ b/templates/content/node--ucb-people-list-page.html.twig
@@ -76,6 +76,7 @@
   </div>
   {% endif %}
   <ucb-people-list{{ create_attribute({
+    'site-base': url('<front>')|render|trim('/'),
     'base-uri': url('<front>')|render|trim('/') ~ '/jsonapi',
     config: config|json_encode,
     'user-config': '{}' }) }}>

--- a/templates/field/field--field-ucb-person-links.html.twig
+++ b/templates/field/field--field-ucb-person-links.html.twig
@@ -43,7 +43,7 @@
 
 						{% elseif 'TWITTER' in linkUrlUpper %}
 							<span class="sr-only">Twitter</span>
-							<i class="fa-brands fa-twitter"></i>
+							<i class="fa-brands fa-x-twitter"></i>
 							<a href="{{ linkUrl }}" class="ucb-person-social-link ucb-person-twitter-link" title="Twitter" alt="Twitter">
 								<span>{{ linkTitle }}</span>
 							</a>

--- a/templates/field/field--field_ucb_person_primary_link.html.twig
+++ b/templates/field/field--field_ucb_person_primary_link.html.twig
@@ -10,7 +10,7 @@
 			{% if item.content['#url']|render|first == '/' %}
 				<span class="sr-only">Primary Link</span>
 				<i class="fa-solid fa-link primaryLinkIcon"></i>
-				<a href="{{ item.content['#url']|render }}" class="ucb-person-social-link ucb-person-other-link" title="Social Media" alt="Social Media">
+				<a href="{{ item.content['#url']|render }}" class="ucb-person-social-link ucb-person-other-link">
 					{% if linkTitle|render %}
 						<span>{{ linkTitle }}</span>
 					{% else %}


### PR DESCRIPTION
Provides the following bug fixes to the `People List Block` and the `People List Page`
## People List Page & People List Block
- Fixes a bug with internal links throwing an error. Adjusts so internal links will convert to absolute pathing, which should allow for our multi-site, single domain sites to use internal links. 
- No termId present on a Person causing a JavaScript error preventing a full render. Was able to cause this error with multiple people and one without any terms attached. This error was present on both `People List Page` and `People List Block`.
- Swaps Twitter's bird to Twitter's X... ( X 's X?)...whatever you want to call it, the bird icon is now an X icon.

## People List Page Only
- No terms existing for a taxonomy, and the `People List Page` having that taxonomy selected for `Group By` caused a white screen and no errors. Adjusted this to show an error specifying the reason for a white screen: `Grouping by ${groupBy} is requested, but taxonomy data is missing. Please adjust your page's 'Group By' setting or make sure taxonomy data exists for that term.`
- Terms existing for a taxonomy and `Group By` for that taxonomy selected on a `Person List Page`... but no Person has terms on that taxonomy caused the same white screen. Adjusted this to show an error specifying this white screen case: `No results found for the '${groupBy}' grouping.`

Resolves #659 

