### PR TITLE
Standardizes Display of Accordion - style Elements

### DIFF
--- a/css/block/expandable-content.css
+++ b/css/block/expandable-content.css
@@ -17,6 +17,7 @@
   font-family: "Roboto", "Helvetica Neue", Helvetica, Arial, sans-serif;
   background-color: transparent;
   box-shadow: none;
+  text-decoration: none;
 }
 
 .ucb-expandable-content .accordion-button:not(.collapsed)::after, .ucb-expandable-content .accordion-button::after {

--- a/css/ucb-faq-page.css
+++ b/css/ucb-faq-page.css
@@ -7,10 +7,38 @@
 }
 
 .accordion-header .accordion-button h3 {
-    font-size: 100%;
     margin: 0;
+    margin-left: 10px;
+    color: #0277bd;
+    font-size: 18px;
 }
 
+.accordion-button::after, .accordion-button:not(.collapsed)::after {
+    background-image: initial;
+}
+
+.accordion-button::before {
+    content: '\f0fe  ' !important;
+    font-weight: 900 !important;
+    font-family: "Font Awesome 6 Free - Solid" ;
+    color: #0277bd;
+    font-size: 18px;
+}
+  
+.accordion-button:not(.collapsed)::before {
+    content: '\f146  ' !important;
+    font-weight: 900 !important;
+    font-family: "Font Awesome 6 Free - Solid";
+    color: #0277bd;
+    font-size: 18px;
+}
+
+.accordion-header .accordion-button:hover h3,
+.accordion-header .accordion-button:hover::before,
+.accordion-header .accordion-button:not(.collapsed):hover::before {
+  color: #b71c1c !important;
+}
+  
 .accordion .accordion-item button.accordion-button {
     color: inherit;
     padding: 0;


### PR DESCRIPTION
Standardizes style of Accordion elements. This modifies the style of the `FAQ Page` and `Expandable Content` block in the following ways:
- Adjusts the `FAQ Page` to mirror the Expandable Content's style (blue text, larger type, red hover, + / - icons on toggle instead of a chevron)
- Removes the underlined text-decoration on `Expandable Content`'s title links

Resolves #672 