### PR TITLE
Content Row: Block Changes

### DIFF
--- a/css/block/content-row.css
+++ b/css/block/content-row.css
@@ -15,7 +15,7 @@
   padding: 1.5em;
 }
 
-.row-content {
+.ucb-content-row-teaser {
   border-bottom: 2px solid rgba(128, 128, 128, 0.333);
   margin-bottom: 20px;
 }

--- a/css/block/content-row.css
+++ b/css/block/content-row.css
@@ -16,17 +16,14 @@
 }
 
 .row-content {
-  margin-bottom: 1em;
+  border-bottom: 2px solid rgba(128, 128, 128, 0.333);
+  margin-bottom: 20px;
 }
-
-.row-text-container {
-  padding: 0 1em;
+.ucb-content-row-teaser{
+  display: flex;
+  flex-direction: column;
+  margin-bottom: 20px;
 }
-
-.row-card .row-text-container {
-  padding: 1em;
-}
-
 .row-fill {
   display: flex;
   overflow: hidden;
@@ -104,6 +101,12 @@
 
 .ucb-teaser-lg-row{
   align-items: center;
+  margin-bottom: 20px;
+}
+
+.row-image-container{
+  width: calc(100px + var(--bs-gutter-x));
+  height: auto;
   margin-bottom: 20px;
 }
 

--- a/css/block/content-row.css
+++ b/css/block/content-row.css
@@ -143,3 +143,9 @@
     padding-right: 0;
   }
 }
+@media screen and (max-width: 576px) {
+  .ucb-teaser-lg-row-even{
+    flex-direction: column-reverse;
+  }
+}
+

--- a/css/block/content-row.css
+++ b/css/block/content-row.css
@@ -102,6 +102,10 @@
   width: 100%;
 }
 
+.ucb-teaser-lg-row{
+  align-items: center;
+}
+
 @media screen and (max-width: 975px) {
   .small-feature-row {
     margin-top: 1em;

--- a/css/block/content-row.css
+++ b/css/block/content-row.css
@@ -24,6 +24,10 @@
   flex-direction: column;
   margin-bottom: 20px;
 }
+.row-text-container-tile{ 
+  padding: 80px 40px
+}
+
 .row-fill {
   display: flex;
   overflow: hidden;
@@ -108,6 +112,20 @@
   width: calc(100px + var(--bs-gutter-x));
   height: auto;
   margin-bottom: 20px;
+}
+
+.row-image-container-tile-even {
+  padding-left: 0px;
+  padding-right: calc(var(--bs-gutter-x) * .5);
+  padding-top: 0px;
+  padding-bottom: 0px;
+}
+
+.row-image-container-tile-odd{
+  padding-left: calc(var(--bs-gutter-x) * .5);
+  padding-right: 0px;
+  padding-top: 0px;
+  padding-bottom: 0px;
 }
 
 @media screen and (max-width: 975px) {

--- a/css/block/content-row.css
+++ b/css/block/content-row.css
@@ -104,6 +104,7 @@
 
 .ucb-teaser-lg-row{
   align-items: center;
+  margin-bottom: 20px;
 }
 
 @media screen and (max-width: 975px) {

--- a/templates/block/block--content-row.html.twig
+++ b/templates/block/block--content-row.html.twig
@@ -229,7 +229,7 @@
 			<div class="row row-content ucb-teaser-lg-row">
 			{% set image = item.entity.field_row_layout_content_image.0 %}
 				{% if image %}
-				<div class="col-md-4 col-sm-6 row-image-container">
+				<div class="col-lg-4 col-md-6 col-sm-12 row-image-container">
 					{% if rowLink %}
 						<a href="{{ rowLink }} ">
 							<img class="ucb-content-row-img-lg" src="{{item.entity.field_row_layout_content_image.entity.field_media_image.entity.fileuri|image_style('focal_image_wide')}}"></img>
@@ -239,7 +239,7 @@
 					{% endif %}
 				</div>
 				{% endif %}
-				<div class="{{ image ? 'col-md-8 col-sm-6' : 'col-sm-12' }} row-text-container">
+				<div class="{{ image ? 'col-lg-8 col-md-6 col-sm-12' : 'col-sm-12' }} row-text-container">
 					{% if rowLink %}
 						<a href="{{ rowLink }} ">
 							<h3>{{ item.entity.field_row_layout_content_title.0.value }}</h3>

--- a/templates/block/block--content-row.html.twig
+++ b/templates/block/block--content-row.html.twig
@@ -22,7 +22,6 @@
 
 {% set layoutSelection = content['#block_content'].field_row_layout_selection.value %}
 
-<p> Layout Selection : {{layoutSelection}}</p>
 {% block content %}
 	<div{{attributes.addClass(classes)}}>
 		{{ title_prefix }}
@@ -71,7 +70,7 @@
 						<div class="col-sm-5 col-xs-12 row-image-container-lg">
 							{% if rowLink %}
 								<a href="{{ rowLink }} ">
-									<img class="ucb-content-row-img-lg" src="{{item.entity.field_row_layout_content_image.entity.field_media_image.entity.fileuri|image_style('focal_image_wide')}}"></img>
+									<img alt="{{item.entity.field_row_layout_content_image.entity.field_media_image.alt}}" class="ucb-content-row-img-lg" src="{{item.entity.field_row_layout_content_image.entity.field_media_image.entity.fileuri|image_style('focal_image_wide')}}"></img>
 								</a>
 							{% else %}
 								{{ image|view }}
@@ -105,10 +104,10 @@
 						<div class="col-sm-5 col-xs-12 row-image-container-lg">
 							{% if rowLink %}
 								<a href="{{ rowLink }} ">
-									<img class="ucb-content-row-img-lg" src="{{item.entity.field_row_layout_content_image.entity.field_media_image.entity.fileuri|image_style('focal_image_wide')}}"></img>
+									<img alt="{{item.entity.field_row_layout_content_image.entity.field_media_image.alt}}" class="ucb-content-row-img-lg" src="{{item.entity.field_row_layout_content_image.entity.field_media_image.entity.fileuri|image_style('focal_image_wide')}}"></img>
 								</a>
 							{% else %}
-								<img class="ucb-content-row-img-lg" src="{{item.entity.field_row_layout_content_image.entity.field_media_image.entity.fileuri|image_style('focal_image_wide')}}"></img>
+								<img alt="{{item.entity.field_row_layout_content_image.entity.field_media_image.alt}}" class="ucb-content-row-img-lg" src="{{item.entity.field_row_layout_content_image.entity.field_media_image.entity.fileuri|image_style('focal_image_wide')}}"></img>
 							{% endif %}
 						</div>
 						{% endif %}
@@ -119,18 +118,23 @@
 		{% elseif layoutSelection == 2 %}
 			{% for key, item in content['#block_content'].field_row_layout_content %}
 				{% set rowLink = item.entity.field_row_layout_content_link.0.url|render %}
-				<div class="row d-flex row-content">
+				{% set tileBackground = "height:100%;background-image:url('" ~ file_url(item.entity.field_row_layout_content_image.entity.field_media_image.entity.fileuri|image_style('focal_image_square')) ~ "');background-repeat:no-repeat;background-position:center;background-size:cover;" %}
+				<div class="row d-flex row-content-tiles">
 					{% if (loop.index is odd) %}
-						<div class="col-6 row-image-container">
+						<div class="col-6 row-image-container-tile-odd">
 							{% if rowLink %}
 								<a href="{{ rowLink }} ">
-									{{ item.entity.field_row_layout_content_image|view }}
+									{# TO DO -- Make this a DIV with background img #}
+									{# {{ item.entity.field_row_layout_content_image|view }} #}
+									<div class="ucb-content-row-left" style={{tileBackground}}></div>
 								</a>
 							{% else %}
-								{{ item.entity.field_row_layout_content_image|view }}
+								{# TO DO -- Make this a DIV with background img #}
+								{# {{ item.entity.field_row_layout_content_image|view }} #}
+								<div style={{tileBackground}}></div>
 							{% endif %}
 						</div>
-						<div class="col-6 row-text-container">
+						<div class="col-6 row-text-container-tile">
 							{% if rowLink %}
 								<a href="{{ rowLink }} ">
 									<h3>{{item.entity.field_row_layout_content_title.0.value }}</h3>
@@ -141,7 +145,7 @@
 							{{item.entity.field_row_layout_content_text|view}}
 						</div>
 					{% else %}
-						<div class="col-6 row-text-container">
+						<div class="col-6 row-text-container-tile">
 							{% if rowLink %}
 								<a href="{{ rowLink }} ">
 									<h3>{{item.entity.field_row_layout_content_title.0.value }}</h3>
@@ -151,13 +155,17 @@
 							{% endif %}
 							{{item.entity.field_row_layout_content_text|view}}
 						</div>
-						<div class="col-6 row-image-container">
+						<div class="col-6 row-image-container-tile-even">
 							{% if rowLink %}
 								<a href="{{ rowLink }} ">
-									{{ item.entity.field_row_layout_content_image|view }}
+									{# TO DO -- Make this a DIV with background img #}
+									{# {{ item.entity.field_row_layout_content_image|view }} #}
+									<div style="{{tileBackground}}"></div>
 								</a>
 							{% else %}
-								{{ item.entity.field_row_layout_content_image|view }}
+								{# TO DO -- Make this a DIV with background img #}
+								{# {{ item.entity.field_row_layout_content_image|view }} #}
+								<div style="{{tileBackground}}"></div>
 							{% endif %}
 						</div>
 					{% endif %}
@@ -234,7 +242,7 @@
 				<div class="col-lg-4 col-md-6 col-sm-12 row-image-container-lg">
 					{% if rowLink %}
 						<a href="{{ rowLink }} ">
-							<img class="ucb-content-row-img-lg" src="{{item.entity.field_row_layout_content_image.entity.field_media_image.entity.fileuri|image_style('focal_image_wide')}}"></img>
+							<img alt="{{item.entity.field_row_layout_content_image.entity.field_media_image.alt}}" class="ucb-content-row-img-lg" src="{{item.entity.field_row_layout_content_image.entity.field_media_image.entity.fileuri|image_style('focal_image_wide')}}"></img>
 						</a>
 					{% else %}
 						{{ image|view }}

--- a/templates/block/block--content-row.html.twig
+++ b/templates/block/block--content-row.html.twig
@@ -59,26 +59,26 @@
 				</div>
 			{% endfor %}
 			{# Teaser Large Alternate Row Layout #}
-		{% elseif layoutSelection == 1 %}
+			{% elseif layoutSelection == 1 %}
 			{% for key, item in content['#block_content'].field_row_layout_content %}
 				{% set rowLink = item.entity.field_row_layout_content_link.0.url|render %}
-				<div class="row d-flex row-content">
-					{% if (loop.index is odd) %}{% set image = item.entity.field_row_layout_content_image.0 %}
+				<div class="row d-flex row-content ucb-teaser-lg-row">
+					{% set image = item.entity.field_row_layout_content_image.0 %}
+					{% if (loop.index is odd) %}
 						{% if image %}
-						<div class="col-4 row-image-container">
+						<div class="col-sm-5 col-xs-12 row-image-container">
 							{% if rowLink %}
 								<a href="{{ rowLink }} ">
-									{{ image|view }}
+									<img class="ucb-content-row-img-lg" src="{{item.entity.field_row_layout_content_image.entity.field_media_image.entity.fileuri|image_style('focal_image_wide')}}"></img>
 								</a>
 							{% else %}
 								{{ image|view }}
 							{% endif %}
 						</div>
+						<div class="col-sm-7 col-xs-12 row-text-container">
 						{% else %}
-						<div class="col-4">
-						</div>
+						<div class="col-12 row-text-container">
 						{% endif %}
-						<div class="col-8 row-text-container">
 							{% if rowLink %}
 								<a href="{{ rowLink }} ">
 									<h3>{{ item.entity.field_row_layout_content_title.0.value }}</h3>
@@ -89,7 +89,7 @@
 							{{item.entity.field_row_layout_content_text|view}}
 						</div>
 					{% else %}
-						<div class="col-8 row-text-container">
+						<div class="{{ image ? 'col-sm-7 col-xs-12' : 'col-12' }} row-text-container">
 							{% if rowLink %}
 								<a href="{{ rowLink }} ">
 									<h3>{{ item.entity.field_row_layout_content_title.0.value }}</h3>
@@ -100,13 +100,13 @@
 							{{item.entity.field_row_layout_content_text|view}}
 						</div>
 						{% if image %}
-						<div class="col-4 row-image-container">
+						<div class="col-sm-5 col-xs-12 row-image-container">
 							{% if rowLink %}
 								<a href="{{ rowLink }} ">
-									{{ item.entity.field_row_layout_content_image|view }}
+									<img class="ucb-content-row-img-lg" src="{{item.entity.field_row_layout_content_image.entity.field_media_image.entity.fileuri|image_style('focal_image_wide')}}"></img>
 								</a>
 							{% else %}
-								{{ item.entity.field_row_layout_content_image|view }}
+								<img class="ucb-content-row-img-lg" src="{{item.entity.field_row_layout_content_image.entity.field_media_image.entity.fileuri|image_style('focal_image_wide')}}"></img>
 							{% endif %}
 						</div>
 						{% endif %}

--- a/templates/block/block--content-row.html.twig
+++ b/templates/block/block--content-row.html.twig
@@ -34,7 +34,8 @@
 		{% if layoutSelection == 0 %}
 			{% for key, item in content['#block_content'].field_row_layout_content %}
 				{% set rowLink = item.entity.field_row_layout_content_link.0.url|render %}
-				<div class="row row-content">{% set image = item.entity.field_row_layout_content_image.0 %}
+				<div class="row-content ucb-content-row-teaser">{% set image = item.entity.field_row_layout_content_image.0 %}
+					<div class="row">
 					{% if image %}
 					<div class="col-sm-2 row-image-container">
 						{% if rowLink %}
@@ -55,6 +56,7 @@
 							<h3>{{ item.entity.field_row_layout_content_title.0.value }}</h3>
 						{% endif %}
 						{{item.entity.field_row_layout_content_text|view}}
+					</div>
 					</div>
 				</div>
 			{% endfor %}

--- a/templates/block/block--content-row.html.twig
+++ b/templates/block/block--content-row.html.twig
@@ -68,7 +68,7 @@
 					{% set image = item.entity.field_row_layout_content_image.0 %}
 					{% if (loop.index is odd) %}
 						{% if image %}
-						<div class="col-sm-5 col-xs-12 row-image-container">
+						<div class="col-sm-5 col-xs-12 row-image-container-lg">
 							{% if rowLink %}
 								<a href="{{ rowLink }} ">
 									<img class="ucb-content-row-img-lg" src="{{item.entity.field_row_layout_content_image.entity.field_media_image.entity.fileuri|image_style('focal_image_wide')}}"></img>
@@ -102,7 +102,7 @@
 							{{item.entity.field_row_layout_content_text|view}}
 						</div>
 						{% if image %}
-						<div class="col-sm-5 col-xs-12 row-image-container">
+						<div class="col-sm-5 col-xs-12 row-image-container-lg">
 							{% if rowLink %}
 								<a href="{{ rowLink }} ">
 									<img class="ucb-content-row-img-lg" src="{{item.entity.field_row_layout_content_image.entity.field_media_image.entity.fileuri|image_style('focal_image_wide')}}"></img>
@@ -231,7 +231,7 @@
 			<div class="row row-content ucb-teaser-lg-row">
 			{% set image = item.entity.field_row_layout_content_image.0 %}
 				{% if image %}
-				<div class="col-lg-4 col-md-6 col-sm-12 row-image-container">
+				<div class="col-lg-4 col-md-6 col-sm-12 row-image-container-lg">
 					{% if rowLink %}
 						<a href="{{ rowLink }} ">
 							<img class="ucb-content-row-img-lg" src="{{item.entity.field_row_layout_content_image.entity.field_media_image.entity.fileuri|image_style('focal_image_wide')}}"></img>

--- a/templates/block/block--content-row.html.twig
+++ b/templates/block/block--content-row.html.twig
@@ -22,7 +22,7 @@
 
 {% set layoutSelection = content['#block_content'].field_row_layout_selection.value %}
 
-
+<p> Layout Selection : {{layoutSelection}}</p>
 {% block content %}
 	<div{{attributes.addClass(classes)}}>
 		{{ title_prefix }}
@@ -58,7 +58,7 @@
 					</div>
 				</div>
 			{% endfor %}
-			{# Teaser Alternate Row Layout #}
+			{# Teaser Large Alternate Row Layout #}
 		{% elseif layoutSelection == 1 %}
 			{% for key, item in content['#block_content'].field_row_layout_content %}
 				{% set rowLink = item.entity.field_row_layout_content_link.0.url|render %}
@@ -162,7 +162,7 @@
 				</div>
 			{% endfor %}
 			{# Features Row Layout #}
-		{% else %}
+		{% elseif layoutSelection == 3 %}
 			<div class="row row-col-lg-2 row-col-1 feature-row">
 				{% for key, item in content['#block_content'].field_row_layout_content %}
 					{% set rowLink = item.entity.field_row_layout_content_link.0.url|render %}
@@ -222,6 +222,35 @@
 					{% endif %}
 				{% endfor %}
 			</div>
+		{% else %}
+		{# Teaser Large Layout #}
+		{% for key, item in content['#block_content'].field_row_layout_content %}
+			{% set rowLink = item.entity.field_row_layout_content_link.0.url|render %}
+			<div class="row row-content ucb-teaser-lg-row">
+			{% set image = item.entity.field_row_layout_content_image.0 %}
+				{% if image %}
+				<div class="col-md-4 col-sm-6 row-image-container">
+					{% if rowLink %}
+						<a href="{{ rowLink }} ">
+							<img class="ucb-content-row-img-lg" src="{{item.entity.field_row_layout_content_image.entity.field_media_image.entity.fileuri|image_style('focal_image_wide')}}"></img>
+						</a>
+					{% else %}
+						{{ image|view }}
+					{% endif %}
+				</div>
+				{% endif %}
+				<div class="{{ image ? 'col-md-8 col-sm-6' : 'col-sm-12' }} row-text-container">
+					{% if rowLink %}
+						<a href="{{ rowLink }} ">
+							<h3>{{ item.entity.field_row_layout_content_title.0.value }}</h3>
+						</a>
+					{% else %}
+						<h3>{{ item.entity.field_row_layout_content_title.0.value }}</h3>
+					{% endif %}
+					{{item.entity.field_row_layout_content_text|view}}
+				</div>
+			</div>
+		{% endfor %}
 		{% endif %}
 	</div>
 {% endblock content %}

--- a/templates/block/block--content-row.html.twig
+++ b/templates/block/block--content-row.html.twig
@@ -62,8 +62,9 @@
 			{# Teaser Large Alternate Row Layout #}
 			{% elseif layoutSelection == 1 %}
 			{% for key, item in content['#block_content'].field_row_layout_content %}
+				{% set oddOrEven = loop.index is odd ? 'odd' : 'even' %}
 				{% set rowLink = item.entity.field_row_layout_content_link.0.url|render %}
-				<div class="row d-flex row-content ucb-teaser-lg-row">
+				<div class="row d-flex row-content ucb-teaser-lg-row ucb-teaser-lg-row-{{oddOrEven}}">
 					{% set image = item.entity.field_row_layout_content_image.0 %}
 					{% if (loop.index is odd) %}
 						{% if image %}

--- a/templates/block/block--content-row.html.twig
+++ b/templates/block/block--content-row.html.twig
@@ -33,10 +33,10 @@
 		{# Teaser Row Layout #}
 		{% if layoutSelection == 0 %}
 			{% for key, item in content['#block_content'].field_row_layout_content %}
-				{% set rowLink = item.entity.field_row_layout_content_link.0.url.uri %}
+				{% set rowLink = item.entity.field_row_layout_content_link.0.url|render %}
 				<div class="row row-content">{% set image = item.entity.field_row_layout_content_image.0 %}
 					{% if image %}
-					<div class="col-4 row-image-container">
+					<div class="col-sm-2 row-image-container">
 						{% if rowLink %}
 							<a href="{{ rowLink }} ">
 								{{ image|view }}
@@ -46,7 +46,7 @@
 						{% endif %}
 					</div>
 					{% endif %}
-					<div class="{{ image ? 'col-8 ' }}row-text-container">
+					<div class="{{ image ? 'col-sm-10 ' : 'col-sm-12' }} row-text-container">
 						{% if rowLink %}
 							<a href="{{ rowLink }} ">
 								<h3>{{ item.entity.field_row_layout_content_title.0.value }}</h3>
@@ -61,7 +61,7 @@
 			{# Teaser Alternate Row Layout #}
 		{% elseif layoutSelection == 1 %}
 			{% for key, item in content['#block_content'].field_row_layout_content %}
-				{% set rowLink = item.entity.field_row_layout_content_link.0.url.uri %}
+				{% set rowLink = item.entity.field_row_layout_content_link.0.url|render %}
 				<div class="row d-flex row-content">
 					{% if (loop.index is odd) %}{% set image = item.entity.field_row_layout_content_image.0 %}
 						{% if image %}
@@ -116,7 +116,7 @@
 			{# Tiles Row Layout #}
 		{% elseif layoutSelection == 2 %}
 			{% for key, item in content['#block_content'].field_row_layout_content %}
-				{% set rowLink = item.entity.field_row_layout_content_link.0.url.uri %}
+				{% set rowLink = item.entity.field_row_layout_content_link.0.url|render %}
 				<div class="row d-flex row-content">
 					{% if (loop.index is odd) %}
 						<div class="col-6 row-image-container">
@@ -163,9 +163,9 @@
 			{% endfor %}
 			{# Features Row Layout #}
 		{% else %}
-			<div class="row row-cols-lg-2 row-cols-1 feature-row">
+			<div class="row row-col-lg-2 row-col-1 feature-row">
 				{% for key, item in content['#block_content'].field_row_layout_content %}
-					{% set rowLink = item.entity.field_row_layout_content_link.0.url.uri %}
+					{% set rowLink = item.entity.field_row_layout_content_link.0.url|render %}
 					{% set smallFeatureBGValue = "background-image:url(#{ file_url( item.entity.field_row_layout_content_image.entity.field_media_image.entity.fileuri ) });background-repeat:no-repeat;background-position:center;background-size:cover;" %}
 					{% if (loop.index0 % 3 == 0) or (loop.index0 == 0) %}
 						<div class="col-lg-7">


### PR DESCRIPTION
Adjusts the following on the `Content Row` blocks:
- On the "Configure Block" modal, switched the order of the tabs so 'Row Content' is on the left and open by default and 'Row Design' is on the right and hidden
- Added three teaser displays: `Large Teaser`, `Large Teaser Alternate`, and `Teaser`. Previously the teaser displays available were Teaser and Teaser Alternate.
- The `Large Teaser` and `Large Teaser Alternate` displays use the focal image wide style images rather than square.
- Adjusts style of the `Teaser` display to mirror other teaser-list style elements, such as the Article List. 
- Adjusted style of the `Tile` style display to more closely mirror the D7 version, which achieved the tile effect with images and text alternating. 
- Fixes bug where internal links, such as `/homepage` would cause a WSOD when added to Row Layout Content

Includes:
- `tiamat-theme` => https://github.com/CuBoulder/tiamat-theme/pull/687
- `custom-entities` => https://github.com/CuBoulder/tiamat-custom-entities/pull/99

Resolves https://github.com/CuBoulder/tiamat-theme/issues/673
Resolves https://github.com/CuBoulder/tiamat-theme/issues/674
Resolves https://github.com/CuBoulder/tiamat-theme/issues/675