### PR TITLE
Article List Block Adjustments

### DIFF
--- a/css/block/ucb-article-grid-block.css
+++ b/css/block/ucb-article-grid-block.css
@@ -32,8 +32,7 @@
 }
 
 .ucb-article-grid-card-img{
-    height: 225px !important;
     object-fit: cover !important;
-    width: 450px !important;
+    aspect-ratio: 2/1;
 }
 

--- a/css/block/ucb-article-list-block.css
+++ b/css/block/ucb-article-list-block.css
@@ -38,13 +38,13 @@
 .ucb-article-card-img-wide {
   height: 500px !important;
   object-fit: cover !important;
-  margin-bottom: 20px;
+  margin-bottom: 10px;
   width: 100%;
 }
 
 .ucb-article-card-img-full {
   width: 100% !important;
-  margin-bottom: 20px;
+  margin-bottom: 10px;
 
 }
 
@@ -69,6 +69,16 @@
   font-weight: normal;
   margin: 0;
   line-height: 1.3;
+}
+.ucb-article-card-title-feature {
+    font-size: 130%;
+    font-weight: bolder;
+    margin: 0 0 10px 0;
+    line-height: 1.3;
+}
+
+.ucb-article-card-title-teaser{
+  display: block;
 }
 
 @media only screen and (max-width: 600px) {

--- a/css/ucb-article-list.css
+++ b/css/ucb-article-list.css
@@ -14,7 +14,7 @@
 }
 
 .ucb-article-card-container {
-  border-bottom: 2px solid rgba(128, 128, 128, 0.333);
+  border-bottom: 1px solid rgba(128, 128, 128, 0.333);
   margin-bottom: 20px;
 }
 

--- a/js/ucb-article-feature-block.js
+++ b/js/ucb-article-feature-block.js
@@ -308,18 +308,14 @@ class ArticleFeatureBlockElement extends HTMLElement {
                     articleImgLink.className = 'ucb-article-img-link'
                     articleImgLink.href = article.link;
                     articleImgLink.appendChild(articleImg)
-        
-                    // Title
-                    var articleTitle = document.createElement('h3')
-                    articleTitle.className = 'ucb-article-feature-secondary-title'
+
                     //Title Link 
                     var articleTitleLink = document.createElement('a')
                     articleTitleLink.href = article.link;
                     articleTitleLink.innerText = article.title;
-                    articleTitle.appendChild(articleTitleLink)
         
                     articleContainer.appendChild(articleImgLink)
-                    articleContainer.appendChild(articleTitle)
+                    articleContainer.appendChild(articleTitleLink)
                     secondaryContainer.appendChild(articleContainer)
                     }
                 })
@@ -410,17 +406,12 @@ class ArticleFeatureBlockElement extends HTMLElement {
             articleImgLink.href = article.link;
             articleImgLink.appendChild(articleImg)
 
-            // Title
-            var articleTitle = document.createElement('h3')
-            articleTitle.className = 'ucb-article-feature-secondary-title'
-            //Title Link 
             var articleTitleLink = document.createElement('a')
             articleTitleLink.href = article.link;
             articleTitleLink.innerText = article.title;
-            articleTitle.appendChild(articleTitleLink)
 
             articleContainer.appendChild(articleImgLink)
-            articleContainer.appendChild(articleTitle)
+            articleContainer.appendChild(articleTitleLink)
             secondaryContainer.appendChild(articleContainer)
             }
         })
@@ -511,17 +502,13 @@ class ArticleFeatureBlockElement extends HTMLElement {
                     articleImgLink.href = article.link;
                     articleImgLink.appendChild(articleImg)
         
-                    // Title
-                    var articleTitle = document.createElement('h3')
-                    articleTitle.className = 'ucb-article-feature-secondary-title'
                     //Title Link 
                     var articleTitleLink = document.createElement('a')
                     articleTitleLink.href = article.link;
                     articleTitleLink.innerText = article.title;
-                    articleTitle.appendChild(articleTitleLink)
         
                     articleContainer.appendChild(articleImgLink)
-                    articleContainer.appendChild(articleTitle)
+                    articleContainer.appendChild(articleTitleLink)
                     secondaryContainer.appendChild(articleContainer)
                     }
                 })

--- a/js/ucb-article-feature-block.js
+++ b/js/ucb-article-feature-block.js
@@ -308,14 +308,18 @@ class ArticleFeatureBlockElement extends HTMLElement {
                     articleImgLink.className = 'ucb-article-img-link'
                     articleImgLink.href = article.link;
                     articleImgLink.appendChild(articleImg)
-
+        
+                    // Title
+                    var articleTitle = document.createElement('h3')
+                    articleTitle.className = 'ucb-article-feature-secondary-title'
                     //Title Link 
                     var articleTitleLink = document.createElement('a')
                     articleTitleLink.href = article.link;
                     articleTitleLink.innerText = article.title;
+                    articleTitle.appendChild(articleTitleLink)
         
                     articleContainer.appendChild(articleImgLink)
-                    articleContainer.appendChild(articleTitleLink)
+                    articleContainer.appendChild(articleTitle)
                     secondaryContainer.appendChild(articleContainer)
                     }
                 })
@@ -357,7 +361,7 @@ class ArticleFeatureBlockElement extends HTMLElement {
                 featureImgLink.appendChild(featureImg)
 
                 // Title
-                var featureTitle = document.createElement('h2')
+                var featureTitle = document.createElement('h3')
                 featureTitle.className = 'ucb-feature-article-header'
                 // Title Link
                 var featureTitleLink = document.createElement('a')
@@ -406,12 +410,17 @@ class ArticleFeatureBlockElement extends HTMLElement {
             articleImgLink.href = article.link;
             articleImgLink.appendChild(articleImg)
 
+            // Title
+            var articleTitle = document.createElement('h3')
+            articleTitle.className = 'ucb-article-feature-secondary-title'
+            //Title Link 
             var articleTitleLink = document.createElement('a')
             articleTitleLink.href = article.link;
             articleTitleLink.innerText = article.title;
+            articleTitle.appendChild(articleTitleLink)
 
             articleContainer.appendChild(articleImgLink)
-            articleContainer.appendChild(articleTitleLink)
+            articleContainer.appendChild(articleTitle)
             secondaryContainer.appendChild(articleContainer)
             }
         })
@@ -502,13 +511,17 @@ class ArticleFeatureBlockElement extends HTMLElement {
                     articleImgLink.href = article.link;
                     articleImgLink.appendChild(articleImg)
         
+                    // Title
+                    var articleTitle = document.createElement('h3')
+                    articleTitle.className = 'ucb-article-feature-secondary-title'
                     //Title Link 
                     var articleTitleLink = document.createElement('a')
                     articleTitleLink.href = article.link;
                     articleTitleLink.innerText = article.title;
+                    articleTitle.appendChild(articleTitleLink)
         
                     articleContainer.appendChild(articleImgLink)
-                    articleContainer.appendChild(articleTitleLink)
+                    articleContainer.appendChild(articleTitle)
                     secondaryContainer.appendChild(articleContainer)
                     }
                 })

--- a/js/ucb-article-grid-block.js
+++ b/js/ucb-article-grid-block.js
@@ -165,11 +165,11 @@ class ArticleGridBlockElement extends HTMLElement {
         // Case for Too many articles
         if(finalArticles.length >= count || (finalArticles.length >= count && NEXTJSONURL)){
           finalArticles.length = count
-          this.renderDisplay(finalArticles, includeSummary)
       }
 
         // Have articles and want to proceed
-        if(finalArticles.length > 0 && !NEXTJSONURL){
+        if((finalArticles.length >= 0 && !NEXTJSONURL) || (finalArticles.length = count && NEXTJSONURL)){
+          finalArticles.length = count
           this.renderDisplay(finalArticles, includeSummary)
         }
     }

--- a/js/ucb-article-grid-block.js
+++ b/js/ucb-article-grid-block.js
@@ -146,7 +146,7 @@ class ArticleGridBlockElement extends HTMLElement {
         // Case for not enough articles selected and extra articles available
         if(finalArticles.length < count && NEXTJSONURL){
             fetch(NEXTJSONURL).then(this.handleError)
-            .then((data) => this.build(data, count, display, excludeCatArray, excludeTagArray, finalArticles))
+            .then((data) => this.build(data, count, includeSummary, excludeCatArray, excludeTagArray, finalArticles))
             .catch(Error=> {
               console.error('There was an error fetching data from the API - Please try again later.')
               console.error(Error)
@@ -168,7 +168,7 @@ class ArticleGridBlockElement extends HTMLElement {
       }
 
         // Have articles and want to proceed
-        if((finalArticles.length >= 0 && !NEXTJSONURL) || (finalArticles.length = count && NEXTJSONURL)){
+        if((finalArticles.length >= 0 && !NEXTJSONURL) || (finalArticles.length == count && NEXTJSONURL)){
           finalArticles.length = count
           this.renderDisplay(finalArticles, includeSummary)
         }

--- a/js/ucb-article-list-block.js
+++ b/js/ucb-article-list-block.js
@@ -275,8 +275,8 @@ class ArticleListBlockElement extends HTMLElement {
           var headerLink = document.createElement('a');
           headerLink.href = articleLink;
 
-          var articleHeader = document.createElement('h2');
-          articleHeader.classList = 'ucb-article-card-title'
+          var articleHeader = document.createElement('h3');
+          articleHeader.classList = 'ucb-article-card-title-feature'
           articleHeader.innerText = articleTitle;
 
           headerLink.appendChild(articleHeader);
@@ -349,8 +349,8 @@ class ArticleListBlockElement extends HTMLElement {
           var headerLink = document.createElement('a');
           headerLink.href = articleLink;
 
-          var articleHeader = document.createElement('h2');
-          articleHeader.classList = 'ucb-article-card-title'
+          var articleHeader = document.createElement('h3');
+          articleHeader.classList = 'ucb-article-card-title-feature'
           articleHeader.innerText = articleTitle;
 
           headerLink.appendChild(articleHeader);
@@ -417,12 +417,7 @@ class ArticleListBlockElement extends HTMLElement {
 
             var headerLink = document.createElement('a');
             headerLink.href = articleLink;
-
-            var articleHeader = document.createElement('h2');
-            articleHeader.classList = 'ucb-article-card-title'
-            articleHeader.innerText = articleTitle;
-
-            headerLink.appendChild(articleHeader);
+            headerLink.innerText = articleTitle
 
             articleBody.appendChild(headerLink)
 
@@ -451,12 +446,7 @@ class ArticleListBlockElement extends HTMLElement {
 
           var headerLink = document.createElement('a');
           headerLink.href = articleLink;
-
-          var articleHeader = document.createElement('h2');
-          articleHeader.classList = 'ucb-article-card-title'
-          articleHeader.innerText = articleTitle;
-
-          headerLink.appendChild(articleHeader);
+          headerLink.innerText = articleTitle
 
           articleBody.appendChild(headerLink)
 
@@ -499,14 +489,14 @@ class ArticleListBlockElement extends HTMLElement {
             var articleBody = document.createElement('div');
             articleBody.classList = 'col px-3 ucb-article-card-data';
 
-            var headerLink = document.createElement('a');
-            headerLink.href = articleLink;
+            var headerStrong = document.createElement('strong');
 
-            var articleHeader = document.createElement('h2');
-            articleHeader.classList = 'ucb-article-card-title'
+            var articleHeader = document.createElement('a');
+            articleHeader.classList = 'ucb-article-card-title-teaser'
+            articleHeader.href = articleLink;
             articleHeader.innerText = articleTitle;
 
-            headerLink.appendChild(articleHeader);
+            headerStrong.appendChild(articleHeader);
 
             var date = document.createElement('span');
             date.classList = 'ucb-article-card-date'
@@ -526,7 +516,7 @@ class ArticleListBlockElement extends HTMLElement {
             srOnly.innerText = ` about ${articleTitle}`
             readMore.appendChild(srOnly)
 
-            articleBody.appendChild(headerLink)
+            articleBody.appendChild(headerStrong)
             articleBody.appendChild(date)
             articleBody.appendChild(articleSummary)
             articleBody.appendChild(readMore)


### PR DESCRIPTION
Modifies various Article List Nodes and Blocks in the following ways:

## Article List -- Page
- Adjusts row border from 2px to 1px

## Article Grid
- Thumbnails are now a 2/1 aspect ratio
- Resolved bug where having count 3 and 3 articles would result a duplicated row

## Article List Block
- Adjusts header markup to use strong `<a>` tags instead of `<h2>`'s

## Article Feature Block
- Adjusts header markup to use stylized `<h3>`'s across all article cards

Resolves https://github.com/CuBoulder/tiamat-theme/issues/718
Resolves https://github.com/CuBoulder/tiamat-theme/issues/719
Resolves https://github.com/CuBoulder/tiamat-theme/issues/724
Resolves https://github.com/CuBoulder/tiamat-theme/issues/714