### PR TITLE
Issue Display Changes

### DIFF
--- a/css/ucb-issue.css
+++ b/css/ucb-issue.css
@@ -87,7 +87,7 @@ img {
   padding-bottom: 10px;
 }
 
-.issue-content-box {
+.issue-content {
   margin-bottom: 20px;
   margin-top: 20px;
 }
@@ -97,12 +97,6 @@ img {
   background-color: #4B4B4B;
   color: #fff;
   font-weight: bold
-}
-
-.issue-body-box {
-  background-color: #424242;
-  color: #fff;
-  padding: 20px;
 }
 
 .title-thumb-article-thumbnail {

--- a/css/ucb-issue.css
+++ b/css/ucb-issue.css
@@ -8,6 +8,7 @@
   margin-bottom: 20px;
   border-bottom: 1px solid rgba(128, 128, 128, 0.333);
   padding-bottom: 20px;
+  align-items: flex-start;
 }
 
 .issue-section-content-feature {
@@ -70,11 +71,18 @@ img {
   margin-bottom: 10px;
 }
 
-.teaser-article-thumbnail>div>div>div>img,
 .title-thumb-article-thumbnail>div>div>div>img {
   width: 100px;
   height: 100px;
   object-fit: cover;
+}
+
+.teaser-article-thumbnail img{
+  max-height: 100px;
+  max-width: 100px;
+  object-fit: contain;
+  min-height: 100px;
+  min-width: 100px;
 }
 
 .issue-content>.issue-section-content:last-child,
@@ -87,18 +95,69 @@ img {
   padding-bottom: 10px;
 }
 
-.issue-content {
-  margin-bottom: 20px;
-  margin-top: 20px;
-}
-
-.issue-title-box {
-  padding: 20px;
-  background-color: #4B4B4B;
-  color: #fff;
-  font-weight: bold
-}
-
 .title-thumb-article-thumbnail {
   height: 100px;
+}
+
+.issue-section-content-summary .ucb-article-category-icon{
+  display: none;
+}
+
+.issue-article-categories .ucb-article-categories{
+  padding-left: 0px;
+  padding-left: 0px;
+}
+
+
+
+.ucb-article-tags,
+.ucb-article-categories,
+.ucb-article-issue {
+  margin-bottom: 1em;
+  display: flex;
+  font-size: 12px;
+  line-height: 1em;
+}
+
+.ucb-article-category-icon, .ucb-article-tag-icon {
+  background-color: #555555;
+  color: #e7e7e7;
+  padding: 6px;
+}
+
+.ucb-article-categories div,
+.ucb-article-tags div,
+.ucb-article-issue div {
+  display: flex;
+  flex-direction: row;
+  line-height: 1.5em;
+}
+
+.ucb-article-categories a:link,
+.ucb-article-categories a:visited,
+.ucb-article-tags a:link,
+.ucb-article-tags a:visited,
+.ucb-article-issue a:link,
+.ucb-article-issue a:visited {
+  background: #e7e7e7;
+  color: #555;
+  padding: 6px;
+  display: inline-block;
+  margin-right: 8px;
+}
+
+.ucb-article-categories a:hover,
+.ucb-article-tags a:hover,
+.ucb-article-issue a:hover {
+  background: #555;
+  color: #fff;
+}
+
+.ucb-article-tags i.fa-solid,
+.ucb-article-categories i.fa-solid,
+.ucb-article-issue i.fa-solid {
+  padding: 0.5em;
+  background: #555;
+  color: #fff;
+  margin-right: -1em;
 }

--- a/templates/content/node--ucb-issue.html.twig
+++ b/templates/content/node--ucb-issue.html.twig
@@ -19,16 +19,8 @@
   <div class="row">
     <div class="col-sm-4 issue-sidebar-banner">
       {{ content.field_ucb_issue_cover_image|render }}
-      <div class="secondary-issue-image">
-        {{ content.field_ucb_issue_secondary_image }}
-      </div>
-      <div class="issue-content-box">
-        <div class="issue-title-box">
-          {{ label }}
-        </div>
-        <div class="issue-body-box"> 
+      <div class="issue-content">
           {{ content.body }}
-        </div>
       </div>
     </div>
     <div class="col-sm-8">

--- a/templates/paragraphs/paragraph--ucb-issue-section.html.twig
+++ b/templates/paragraphs/paragraph--ucb-issue-section.html.twig
@@ -17,16 +17,20 @@
     {# If teaser #}
         {% if paragraph.field_ucb_issue_section_style.value is same as("0") %}
         <div class="issue-section-content">
+            <div class="teaser-article-thumbnail" id='teaser-article-thumbnail-{{key}}'> 
             <a href="{{ path('entity.node.canonical', {'node': content.field_ucb_issue_article_select['#items'].entity.id}) }}">
-                <div class="teaser-article-thumbnail" id='teaser-article-thumbnail-{{key}}'> {{ item.entity.field_ucb_article_thumbnail|view }} </div>
+                <img src="{{ base_url }}{{ file_url(item.entity.field_ucb_article_thumbnail.entity.field_media_image.entity.fileuri | image_style('focal_image_square')) }}" 
+                alt="{{ item.entity.field_ucb_article_thumbnail.entity.field_media_image.alt }}"
+                >
             </a>
+            </div>
             <div class="issue-section-content-summary">
                 <a class="issue-article-title-link" href="{{ path('entity.node.canonical', {'node': content.field_ucb_issue_article_select['#items'].entity.id}) }}">
                     <h3 class="issue-section-teaser-title">{{item.entity.title.value}}</h3>
                 </a>
                 <div class="issue-article-categories">{{item.entity.field_ucb_article_categories|view}}</div>
                 <p class="issue-section-teaser-summary">{{item.entity.field_ucb_article_summary.value}}</p>
-                <a class="issue-section-teaser-read" href="{{ path('entity.node.canonical', {'node': content.field_ucb_issue_article_select['#items'].entity.id}) }}">READ MORE</a>
+                <a class="issue-section-teaser-read" href="{{ path('entity.node.canonical', {'node': content.field_ucb_issue_article_select['#items'].entity.id}) }}">Read More</a>
             </div>
         </div>
                         
@@ -42,7 +46,7 @@
                     </a>
                     <div class="issue-article-categories">{{item.entity.field_ucb_article_categories|view}}</div>
                     <p class="issue-section-feature-summary">{{item.entity.field_ucb_article_summary.value}}</p>
-                    <a class="issue-section-feature-read" href="{{ path('entity.node.canonical', {'node': content.field_ucb_issue_article_select['#items'].entity.id}) }}">READ MORE</a>
+                    <a class="issue-section-feature-read" href="{{ path('entity.node.canonical', {'node': content.field_ucb_issue_article_select['#items'].entity.id}) }}">Read More</a>
                 </div>
             </div>
 


### PR DESCRIPTION
Fixes the following on Issue Content Types:

- Removes the Secondary Image field from the form and page display. Also removes the hard-coded dark gray box with the title and body in it, as users can use CKEditor5 plugins such as Box, Button, Icons, and Media Library to achieve a variety of left-side layouts. 
- Fixes bug with Teaser view of Categories displaying improperly
- "Read More" capitzalized via CSS instead of hard-coded

Includes:
- `tiamat-theme` => https://github.com/CuBoulder/tiamat-theme/pull/730
- `custom-entities` => https://github.com/CuBoulder/tiamat-custom-entities/pull/107

Resolves https://github.com/CuBoulder/tiamat-theme/issues/704