### PR TITLE
Newsletter: Display Changes + New Features

### DIFF
--- a/boulder_base.theme
+++ b/boulder_base.theme
@@ -213,6 +213,25 @@ function boulder_base_preprocess_node__ucb_article(array &$variables) {
 	}
 }
 
+/**
+ * Implements hook_preprocess_HOOK() for node templates.
+ */
+function boulder_base_preprocess_node(&$variables) {
+  if ($variables['node']->getType() == 'newsletter') {
+    $menu_name = 'social-media-menu';
+    $menu_tree = \Drupal::menuTree();
+    $parameters = $menu_tree->getCurrentRouteMenuTreeParameters($menu_name);
+    $tree = $menu_tree->load($menu_name, $parameters);
+    $manipulators = [
+      ['callable' => 'menu.default_tree_manipulators:checkAccess'],
+      ['callable' => 'menu.default_tree_manipulators:generateIndexAndSort'],
+    ];
+    $tree = $menu_tree->transform($tree, $manipulators);
+    $variables['social_media_menu'] = $menu_tree->build($tree);
+  }
+}
+
+
 /***
  *  Custom theme settings worker function
  ***/

--- a/css/style.css
+++ b/css/style.css
@@ -876,6 +876,11 @@ div.table-vertical table td {
   border-bottom: none;
 }
 
+/* Needed for the Newsletter */
+#email-preview table, #email-preview tr, #email-preview td{
+  border: none;
+}
+
 .ucb-heading-font-normal h1,
 .ucb-heading-font-normal h2,
 .ucb-heading-font-normal h3,

--- a/css/ucb-newsletter.css
+++ b/css/ucb-newsletter.css
@@ -45,3 +45,10 @@
   width: 160px;
   height: 160px;
 }
+
+.ucb-article-unpublished{
+  background-color: yellow;
+  text-align: center;
+  padding:10px 0px;
+  font-weight: bold;
+}

--- a/css/ucb-newsletter.css
+++ b/css/ucb-newsletter.css
@@ -61,3 +61,14 @@
 .ucb-newsletter-section-content .ucb-article-categories{
   padding: 0;
 }
+
+/* Social Colors for Preview display */
+.newsletter-social-classic a,
+.newsletter-social-darkbox a,
+.newsletter-social-simple a {
+  color: #fff;
+}
+.newsletter-social-minimal a, 
+.newsletter-social-lightbox a{
+  color: black;
+}

--- a/css/ucb-newsletter.css
+++ b/css/ucb-newsletter.css
@@ -52,3 +52,12 @@
   padding:10px 0px;
   font-weight: bold;
 }
+
+/* Hides icon */
+.ucb-newsletter-section-content .ucb-article-category-icon{
+  display: none;
+}
+
+.ucb-newsletter-section-content .ucb-article-categories{
+  padding: 0;
+}

--- a/templates/content/node--newsletter--email-html.html.twig
+++ b/templates/content/node--newsletter--email-html.html.twig
@@ -364,53 +364,42 @@ td>h3>a{
                                 </table>
                                 {% endif %}
                             {% endif %}
-                        <!--Promo Blocks-->
-                        <table role="presentation"  border="0" width="100%" cellspacing="0" style="border-collapse: collapse; border-spacing: 0; padding: 0; text-align: left; vertical-align: top; width: 100%; color: #222222; font-family: Helvetica, Arial, sans-serif; font-weight: normal; line-height: 19px; margin: 0; font-size: 14px; background-color: white">
-                            <tbody>
-                                <tr>
-                                    <td class="promo-block-row" align="center" style="text-align: left; padding-right:10px; padding-left:10px">
-                                        <!--Promo Block 1-->
-                                        <table role="presentation">
-                                            <tbody>
-                                        {% if content.field_newsletter_block_title_one|render %}
-                                                <tr>
-                                                    <td style="text-align: left; padding-right:10px; padding-left:10px">
-                                                        <h3>{{ content.field_newsletter_block_title_one|render }}</h3>
-                                                    </td>
-                                                </tr>
-                                        {% endif %}
-                
-                                        {% if content.field_newsletter_block_text_one|render %}
-                                            <tr style="text-align: left; padding-right:10px; padding-left:10px"> 
-                                                <td align="center" style="text-align: left; padding-right:10px; padding-left:10px">{{ content.field_newsletter_block_text_one|render }}</td>
-                                            </tr>
-                                        {% endif %}
-                                            </tbody>
-                                        </table>
-                                    </td>
-                                    <td class="promo-block-row" align="center" style="text-align: left; padding-right:10px; padding-left:10px">
-                                     <!--Promo Block 2-->
-                                        <table role="presentation">
-                                            <tbody>
-                                    {% if content.field_newsletter_block_title_two|render %}
-                                                <tr class="">
-                                                    <td style="text-align: left; padding-right:10px; padding-left:10px"> 
-                                                        <h3>{{ content.field_newsletter_block_title_two|render }}</h3>
-                                                    </td>
-                                                </tr>
-                                    {% endif %}
-                                    {% if content.field_newsletter_block_text_two|render %}
-                                    <tr>
-                                        <td style="text-align: left; padding-right:10px; padding-left:10px">    {{ content.field_newsletter_block_text_two|render }}</td>
+                            
+                            <!--Promo Blocks-->
+                            {% set blocksToRender = [] %}
+
+                            {# Preprocess blocks to filter out ones with empty or single-space values #}
+                            {% for key, block in content.field_newsletter_content_blocks %}
+                                {% if key|first != '#' %}
+                                    {% set paragraphItem = block['#paragraph'] %}
+                                    {% set title = paragraphItem.field_newsletter_block_title.value|default('') %}
+                                    {% set text = paragraphItem.field_newsletter_block_text.value|default('') %}
                                     
-                                    </tr>
+                                    {# Check if title or text is not just a space and not empty #}
+                                    {% if title|trim is not empty or text|trim is not empty %}
+                                        {% set blocksToRender = blocksToRender|merge([block]) %}
                                     {% endif %}
-                                            </tbody>
-                                            </table>
-                                            </td>
-                                </tr>
-                            </tbody>
-                        </table>
+                                {% endif %}
+                            {% endfor %}
+
+                            {# Render the blocks side by side #}
+                            {% if blocksToRender %}
+                                <table role="presentation" border="0" width="100%" cellspacing="0" style="border-collapse: collapse; border-spacing: 0; padding: 0; text-align: left; vertical-align: top; width: 100%; color: #222222; font-family: Helvetica, Arial, sans-serif; font-weight: normal; line-height: 19px; margin: 0; font-size: 14px; background-color: white" class="row row-content ucb-newsletter-blocks">
+                                    <tbody>
+                                        {% for i in 0..(blocksToRender|length - 1) %}
+                                            {% if loop.index is odd %}
+                                                <tr>
+                                            {% endif %}
+                                                    <td class="promo-block-row" align="center" style=" width:50%;align-content:baseline;text-align: left; padding-right:10px; padding-left:10px">
+                                                        {{ blocksToRender[i] }}
+                                                    </td>
+                                            {% if loop.index is even or loop.last %}
+                                                </tr>
+                                            {% endif %}
+                                        {% endfor %}
+                                    </tbody>
+                                </table>
+                            {% endif %}
                         <!--Ad Two-->
                         {% if content.field_newsletter_promo_image_two|render %}
                         {% if content.field_newsletter_promo_link_two|render %}

--- a/templates/content/node--newsletter--email-html.html.twig
+++ b/templates/content/node--newsletter--email-html.html.twig
@@ -229,6 +229,11 @@ td>h3>a{
     font-size: 10px;
 }
 
+.newsletter-social-media-menu .social-media-item{
+    display: inline-block;
+    padding: 10px;
+}
+
 
 @media only screen and (max-width: 500px) {
   .promo-block-row {
@@ -461,13 +466,22 @@ td>h3>a{
                             </table>
                         </td>
                     </tr>
+                    {# Social share #}
+                    <tr>
+                        <td>
+                            {% if social_media_menu %}
+                            <center style="margin-bottom: 1em;font-size: 1.25rem; line-height: 1.25;" class="social-media-menu newsletter-social-media-menu">
+                                {{ social_media_menu }}
+                            </center>
+                            {% endif %}
+                        </td>
+                    </tr>
                 </tbody>
             </table>
         </center>
         {% endif %}
     </center>
     {% if designType == 'lightbox' or designType == 'darkbox' %}
-
                     </td>
     </tr>
     </tbody>

--- a/templates/content/node--newsletter--email-html.html.twig
+++ b/templates/content/node--newsletter--email-html.html.twig
@@ -467,6 +467,7 @@ td>h3>a{
                         </td>
                     </tr>
                     {# Social share #}
+                    {% if node.field_newsletter_social_links.value == 1 %}
                     <tr>
                         <td>
                             {% if social_media_menu %}
@@ -476,6 +477,7 @@ td>h3>a{
                             {% endif %}
                         </td>
                     </tr>
+                    {% endif %}
                 </tbody>
             </table>
         </center>

--- a/templates/content/node--newsletter--email-html.html.twig
+++ b/templates/content/node--newsletter--email-html.html.twig
@@ -208,6 +208,27 @@ td>h3>a{
     color: #0277BD;
 }
 
+.ucb-article-categories{
+    padding: 0;
+}
+
+.ucb-article-categories .ucb-article-category-icon{
+    display: none;
+}
+
+.ucb-article-categories a{
+    color: #666;
+    background-color: #e7e7e7;
+    padding: 3px;
+    line-height: 100%;
+    margin: 0 5px 5px 0;
+    font-weight: 600;
+    text-decoration: none;
+    display: inline-block;
+    text-transform: uppercase;
+    font-size: 75%;
+}
+
 
 @media only screen and (max-width: 500px) {
   .promo-block-row {

--- a/templates/content/node--newsletter--email-html.html.twig
+++ b/templates/content/node--newsletter--email-html.html.twig
@@ -226,7 +226,7 @@ td>h3>a{
     text-decoration: none;
     display: inline-block;
     text-transform: uppercase;
-    font-size: 75%;
+    font-size: 10px;
 }
 
 
@@ -271,6 +271,12 @@ td>h3>a{
                                         {% if node.field_newsletter_type.entity.field_newsletter_name_image.entity.uri.value %}
                                         <img style="object-fit:cover;-ms-interpolation-mode: bicubic; clear: both; display: block; float: left; height: 167px !important; max-width: 100% !important; outline: none; text-decoration: none; width: 250px !important; max-height: auto !important;"src="{{base_url}}{{ file_url(node.field_newsletter_type.entity.field_newsletter_name_image.entity.uri.value) }}">
                                         {% endif %}
+                                    </td>
+                                </tr>
+                                {# Newsletter title #}
+                                <tr>
+                                    <td style="padding-left:10px; text-align:left">
+                                        <span>{{node.field_newsletter_type.entity.label}}</span>
                                     </td>
                                 </tr>
                                 {# Date & View on Website Link #}

--- a/templates/content/node--newsletter--email-html.html.twig
+++ b/templates/content/node--newsletter--email-html.html.twig
@@ -330,11 +330,22 @@ td>h3>a{
                         <!--Ad One-->
                             {% if content.field_newsletter_promo_image_one|render %}
                                 {% if content.field_newsletter_promo_link_one|render %}
+                            {# Extract the link URL and trim it #}
+                            {% set link_url_one = content.field_newsletter_promo_link_one|render|striptags|trim %}
+
+                            {# Check if the link is external or internal #}
+                            {% if link_url_one starts with 'http' or link_url_one starts with 'www' %}
+                                {# It's an external link; use it as is #}
+                                {% set final_url_one = link_url_one %}
+                            {% else %}
+                                {# It's an internal link; prepend the base URL #}
+                                {% set final_url_one = base_url ~ link_url_one %}
+                            {% endif %}
                                 <table role="presentation"  border="0" width="100%" cellspacing="0" style="border-collapse: collapse; border-spacing: 0; padding: 0; text-align: left; vertical-align: top; width: 100%; color: #222222; font-family: Helvetica, Arial, sans-serif; font-weight: normal; line-height: 19px; margin: 0; font-size: 14px; background-color: white;">
                                     <tbody>
                                         <tr>
                                             <td align="center" style="text-align: left; padding-right:10px; padding-left:10px;padding-bottom:20px">
-                                                <a href="{{ content.field_newsletter_promo_link_one|render|striptags|trim }}">
+                                                <a href="{{ final_url_one}}">
                                                     <img width="100%" src="{{base_url}}{{file_url(node.field_newsletter_promo_image_one.entity.field_media_image.entity.fileuri|image_style('focal_image_square'))}}"/>
                                                 </a>
                                             </td>
@@ -403,11 +414,22 @@ td>h3>a{
                         <!--Ad Two-->
                         {% if content.field_newsletter_promo_image_two|render %}
                         {% if content.field_newsletter_promo_link_two|render %}
+                        {# Extract the link URL and trim it #}
+                            {% set link_url = content.field_newsletter_promo_link_two|render|striptags|trim %}
+
+                            {# Check if the link is external or internal #}
+                            {% if link_url starts with 'http://' or link_url starts with 'https://' %}
+                                {# It's an external link; use it as is #}
+                                {% set final_url = link_url %}
+                            {% else %}
+                                {# It's an internal link; prepend the base URL #}
+                                {% set final_url = base_url ~ link_url %}
+                            {% endif %}
                         <table role="presentation"  border="0" width="100%" cellspacing="0" style="border-collapse: collapse; border-spacing: 0; padding: 0; text-align: left; vertical-align: top; height: 100%; width: 100%; color: #222222; font-family: Helvetica, Arial, sans-serif; font-weight: normal; line-height: 19px; margin: 0; font-size: 14px; background-color: white;">
                             <tbody>
                                 <tr>
                                     <td width="500px" style="text-align: left; padding-right:10px; padding-left:10px;padding-bottom:20px"> 
-                                        <a href="{{ content.field_newsletter_promo_link_two|render|striptags|trim }}">
+                                        <a href="{{ final_url }}">
                                             <img width="100%" src="{{base_url}}{{file_url(node.field_newsletter_promo_image_two.entity.field_media_image.entity.fileuri|image_style('focal_image_square'))}}"/>
                                         </a>
                                     </td>

--- a/templates/content/node--newsletter--email-html.html.twig
+++ b/templates/content/node--newsletter--email-html.html.twig
@@ -469,7 +469,7 @@ td>h3>a{
                     {# Social share #}
                     {% if node.field_newsletter_social_links.value == 1 %}
                         {% if social_media_menu and social_media_menu|length > 1 %}
-                        <tr>
+                        <tr class="newsletter-social-{{designType}}">
                             <td>
                                 <center style="margin-bottom: 1em;font-size: 1.25rem; line-height: 1.25;" class="social-media-menu newsletter-social-media-menu">
                                     {{ social_media_menu }}

--- a/templates/content/node--newsletter--email-html.html.twig
+++ b/templates/content/node--newsletter--email-html.html.twig
@@ -468,15 +468,15 @@ td>h3>a{
                     </tr>
                     {# Social share #}
                     {% if node.field_newsletter_social_links.value == 1 %}
-                    <tr>
-                        <td>
-                            {% if social_media_menu %}
-                            <center style="margin-bottom: 1em;font-size: 1.25rem; line-height: 1.25;" class="social-media-menu newsletter-social-media-menu">
-                                {{ social_media_menu }}
-                            </center>
-                            {% endif %}
-                        </td>
-                    </tr>
+                        {% if social_media_menu and social_media_menu|length > 1 %}
+                        <tr>
+                            <td>
+                                <center style="margin-bottom: 1em;font-size: 1.25rem; line-height: 1.25;" class="social-media-menu newsletter-social-media-menu">
+                                    {{ social_media_menu }}
+                                </center>
+                            </td>
+                        </tr>
+                        {% endif %}
                     {% endif %}
                 </tbody>
             </table>

--- a/templates/content/node--newsletter.html.twig
+++ b/templates/content/node--newsletter.html.twig
@@ -58,7 +58,9 @@
 
     {# Newsletter Blocks #}
     <div class="row row-content ucb-newsletter-blocks">
-      <div class="col-lg-6 col-12">
+        {{ content.field_newsletter_content_blocks|render }}
+
+      {# <div class="col-lg-6 col-12">
         {% if content.field_newsletter_block_title_one|render %}
           <h3>{{ content.field_newsletter_block_title_one|render }}</h3>
         {% endif %}
@@ -75,7 +77,7 @@
         {% if content.field_newsletter_block_text_two|render %}
           {{ content.field_newsletter_block_text_two|render }}
         {% endif %}
-      </div>
+      </div> #}
     </div>
 
     {# Newsletter Promo/Ad Two #}

--- a/templates/content/node--newsletter.html.twig
+++ b/templates/content/node--newsletter.html.twig
@@ -56,6 +56,7 @@
       {% endif %}
     </div>
 
+    {% if content.field_newsletter_content_blocks|render %}
     {# Newsletter Blocks #}
     <div class="row row-content ucb-newsletter-blocks">
         {{ content.field_newsletter_content_blocks|render }}
@@ -79,6 +80,7 @@
         {% endif %}
       </div> #}
     </div>
+  {% endif %}
 
     {# Newsletter Promo/Ad Two #}
     <div class="row row-content ucb-newsletter-promo-one">

--- a/templates/field/field--field-ucb-article-categories.html.twig
+++ b/templates/field/field--field-ucb-article-categories.html.twig
@@ -1,6 +1,7 @@
 {#
 /**
  * @file Contains the template to display the category list on an article.
+ * Also used on pages such as the Newsletter and Issues
  */
 #}
 {# Only shows Taxonomy terms with display = true #}
@@ -12,7 +13,12 @@
       <i class="fa-solid fa-folder-open"></i>
     </div>
     {% for item in items|sort %}
-      {{ item.content }}
+      {# This canonical URL setting is needed for the Newsletter HTML, otherwise the links get rendered as relative such as `file:///taxonomy/term/1` #}
+      {% set term_id = item.content['#options'].entity.id %}
+      {% set term_url = url('entity.taxonomy_term.canonical', {'taxonomy_term': term_id}) %}
+      <a href="{{ term_url }}">
+        {{ item.content['#title'] }}
+      </a>
     {% endfor %}
   </div>
 {% endif %}

--- a/templates/field/field--node--field-newsletter-content-blocks--newsletter.html.twig
+++ b/templates/field/field--node--field-newsletter-content-blocks--newsletter.html.twig
@@ -1,0 +1,3 @@
+{% for item in items %}
+    {{ item.content }}
+{% endfor %}

--- a/templates/paragraphs/paragraph--newsletter-section--email-html.html.twig
+++ b/templates/paragraphs/paragraph--newsletter-section--email-html.html.twig
@@ -35,21 +35,21 @@
 								{% if item.entity.field_newsletter_article_select.entity.field_ucb_article_thumbnail.entity.field_media_image.alt|render %}
 								<td align="center" style="text-align: left; padding-right:10px; padding-left:10px; padding-bottom:20px">
 									<a href="{{base_url}}{{ path('entity.node.canonical', {'node': item.entity.field_newsletter_article_select.target_id}) }}">
-									<img width="100%" src="{{base_url}}{{file_url(item.entity.field_newsletter_article_select.entity.field_ucb_article_thumbnail.entity.field_media_image.entity.fileuri|image_style('focal_image_square'))}}"/>
+									<img width="100%" style="aspect-ratio:2/1;object-fit:cover;" src="{{base_url}}{{file_url(item.entity.field_newsletter_article_select.entity.field_ucb_article_thumbnail.entity.field_media_image.entity.fileuri|image_style('focal_image_wide'))}}"/>
 									</a>
 								</td>
 									{# Code to render selected article content (!thumbnail) #}
 								{% elseif item.entity.field_newsletter_article_select.entity.field_ucb_article_content.entity.field_article_media_selection.entity.field_media.entity.field_media_image.alt|render %}
 								<td align="center" style="text-align: left; padding-right:10px; padding-left:10px;padding-bottom:20px">
 									<a href="{{base_url}}{{ path('entity.node.canonical', {'node': item.entity.field_newsletter_article_select.target_id}) }}">
-									<img width="100%" src="{{base_url}}{{file_url(item.entity.field_newsletter_article_select.entity.field_ucb_article_content.entity.field_article_media_selection.entity.field_media.entity.field_media_image.entity.fileuri|image_style('focal_image_square'))}}"/>
+									<img width="100%" style="aspect-ratio:2/1;object-fit:cover;" src="{{base_url}}{{file_url(item.entity.field_newsletter_article_select.entity.field_ucb_article_content.entity.field_article_media_selection.entity.field_media.entity.field_media_image.entity.fileuri|image_style('focal_image_wide'))}}"/>
 									</a>
 								</td>
 									{# Code to render user made content #}
 								{% elseif item.entity.field_newsletter_content_image.entity.field_media_image.alt|render %}
 								<td align="center" style="text-align: left; padding-right:10px; padding-left:10px;padding-bottom:20px;">
 									<a href="{{base_url}}{{ path('entity.node.canonical', {'node': item.entity.field_newsletter_article_select.target_id}) }}">
-									<img width="100%" src="{{base_url}}{{file_url(item.entity.field_newsletter_content_image.entity.field_media_image.entity.fileuri|image_style('focal_image_square'))}}"/>
+									<img width="100%" style="aspect-ratio:2/1;object-fit:cover;" src="{{base_url}}{{file_url(item.entity.field_newsletter_content_image.entity.field_media_image.entity.fileuri|image_style('focal_image_wide'))}}"/>
 									</a>
 								</td>
 								{% endif %}

--- a/templates/paragraphs/paragraph--newsletter-section--email-html.html.twig
+++ b/templates/paragraphs/paragraph--newsletter-section--email-html.html.twig
@@ -10,11 +10,10 @@
 
 
 {% set base_url = url('<front>')|render|split('/', -1)|join('/') %}
-
 <table role="presentation"  border="0" width="100%" cellspacing="0" style="border-collapse: collapse; border-spacing: 0; text-align: left; vertical-align: top; width: 100%; color: #222222; font-family: Helvetica, Arial, sans-serif; font-weight: normal; line-height: 19px; margin: 0; font-size: 14px; background-color: white;">
 	<tbody>
   		<tr>
-			<td align="center" style="text-align: left; padding-right:10px; padding-left:10px;padding-top:20px; padding-bottom:20px;">
+			<td align="center" style="font-size:20px;text-align: left; padding-right:10px; padding-left:10px;padding-top:20px; padding-bottom:20px;">
       			<h2>{{ content.field_newsletter_section_title|render|striptags|trim }}</h2>
 	  		</td>
  		</tr>
@@ -56,7 +55,7 @@
 				{# Code to render selected article title/url #}
 					{% if item.entity.field_newsletter_article_select.entity.title.value|render %}
 					<tr id="feature-article-title-email-{{key}}">
-						<td align="center" style="text-align: left; padding-right:10px; padding-left:10px"align="center" style="text-align: left; padding-right:10px; padding-left:10px">
+						<td align="center" style="font-size:18px;text-align: left; padding-right:10px; padding-left:10px"align="center" style="text-align: left; padding-right:10px; padding-left:10px">
 							<h3>
 								<a href="{{base_url}}{{ path('entity.node.canonical', {'node': item.entity.field_newsletter_article_select.target_id}) }}">
 									{{ item.entity.field_newsletter_article_select.entity.title.value|render|striptags|trim }}
@@ -95,13 +94,23 @@
 						{# Code to render selected article content (article text) #}
 					{% elseif item.entity.field_newsletter_article_select.entity.field_ucb_article_content.entity.field_article_text.value|render %}
 						<tr id="feature-article-summary-text-email-{{key}}">
-							<td align="center" style="text-align: left; padding-right:10px; padding-left:10px">{{ item.entity.field_newsletter_article_select.entity.field_ucb_article_content.entity.field_article_text|view }}</td>
+							{% set textContent = item.entity.field_newsletter_article_select.entity.field_ucb_article_content.entity.field_article_text.value|striptags %}
+							{% set maxLength = 300 %}
+							{% if textContent|length > maxLength %}
+								{% set trimmedText = textContent|slice(0, maxLength)|trim ~ '...' %}
+							{% else %}
+								{% set trimmedText = textContent %}
+							{% endif %}
+							{# {{ item.entity.field_newsletter_article_select.entity.field_ucb_article_content.entity.field_article_text.value|striptags|raw }} #}
+							<td align="center" style="text-align: left; padding-right:10px; padding-left:10px">{{ trimmedText }}</td>
 						</tr>
 
 						{# Code to render user made content (content text) #}
 					{% elseif item.entity.field_newsletter_content_text.value|render %}
 						<tr id="feature-article-summary-user-text-email-{{key}}">
-							<td align="center" style="text-align: left; padding-right:10px; padding-left:10px">{{ item.entity.field_newsletter_content_text|view }}</td>
+							<td align="center" style="text-align: left; padding-right:10px; padding-left:10px">
+								{{ item.entity.field_newsletter_content_text|view }}
+							</td>
 						</tr>
 					{% endif %}
 						</tbody>
@@ -150,7 +159,7 @@
 													{# Code to render selected article title/url #}
 													{% if item.entity.field_newsletter_article_select.entity.title.value|render %}
 													<td>
-														<h3>
+														<h3 style="font-size: 18px;">
 														<a href="{{base_url}}{{ path('entity.node.canonical', {'node': item.entity.field_newsletter_article_select.target_id}) }}">
 															{{ item.entity.field_newsletter_article_select.entity.title.value|render|striptags|trim }}
 														</a>
@@ -160,7 +169,7 @@
 													{# Code to render user made content (title) #}
 												{% elseif item.entity.field_newsletter_content_title.value|render %}
 												<td>
-													<h3>
+													<h3 style="font-size: 18px;">
 														{{ item.entity.field_newsletter_content_title|view }}
 													</h3>
 												</td>
@@ -186,22 +195,29 @@
 							{% endif %}
 								{# Code to render selected article content (summary) #}
 							{% if item.entity.field_newsletter_article_select.entity.field_ucb_article_summary.value|render %}
-														<tr>
-															<td>{{ item.entity.field_newsletter_article_select.entity.field_ucb_article_summary|view }}</td>
-														</tr>
+								<tr>
+									<td>{{ item.entity.field_newsletter_article_select.entity.field_ucb_article_summary|view }}</td>
+								</tr>
 						
-														{# Code to render selected article content (article text) #}
-													{% elseif item.entity.field_newsletter_article_select.entity.field_ucb_article_content.entity.field_article_text.value|render %}
-														<tr>
-															<td>{{ item.entity.field_newsletter_article_select.entity.field_ucb_article_content.entity.field_article_text|view }}</td>
-														</tr>
-						
-														{# Code to render user made content (content text) #}
-													{% elseif item.entity.field_newsletter_content_text.value|render %}
-														<tr>
-															<td>{{ item.entity.field_newsletter_content_text|view }}</td>
-														</tr>
-													{% endif %}
+								{# Code to render selected article content (article text) #}
+							{% elseif item.entity.field_newsletter_article_select.entity.field_ucb_article_content.entity.field_article_text.value|render %}
+								<tr>
+									{% set textContent = item.entity.field_newsletter_article_select.entity.field_ucb_article_content.entity.field_article_text.value|striptags %}
+									{% set maxLength = 300 %}
+									{% if textContent|length > maxLength %}
+										{% set trimmedText = textContent|slice(0, maxLength)|trim ~ '...' %}
+									{% else %}
+										{% set trimmedText = textContent %}
+									{% endif %}
+									<td>{{ trimmedText }}</td>
+								</tr>
+
+								{# Code to render user made content (content text) #}
+							{% elseif item.entity.field_newsletter_content_text.value|render %}
+								<tr>
+									<td>{{ item.entity.field_newsletter_content_text|view }}</td>
+								</tr>
+							{% endif %}
 											</tbody>
 										</table>
 									</td>

--- a/templates/paragraphs/paragraph--newsletter-section--email-html.html.twig
+++ b/templates/paragraphs/paragraph--newsletter-section--email-html.html.twig
@@ -177,7 +177,6 @@
 								{% if item.entity.field_newsletter_article_select.entity.field_ucb_article_categories is not empty %}
 								<tr>
 									<td class="article-teaser-meta tags" style="padding-bottom: 10px;">
-															{# TO DO - Fix categories #}
 										{{ item.entity.field_newsletter_article_select.entity.field_ucb_article_categories|view }}
 									</td>
 								</tr>

--- a/templates/paragraphs/paragraph--newsletter-section--email-html.html.twig
+++ b/templates/paragraphs/paragraph--newsletter-section--email-html.html.twig
@@ -80,13 +80,6 @@
 				<tr>
 					<td class="tags" align="center" style="text-align: left; padding-right:10px; padding-left:10px; padding-bottom:10px">{{ item.entity.field_newsletter_article_select.entity.field_ucb_article_categories|view }}</td>
 				</tr>
-
-				{# Code to render user made content (categories) #}
-				{% elseif item.entity.field_news_content_categories is not empty %}
-				<tr>
-					<td class="tags" align="center" style="text-align: left; padding-right:10px; padding-left:10px; padding-bottom:10px">{{ item.entity.field_news_content_categories|view }}</td>
-				</tr>
-				{% endif %}
 					{# Code to render selected article content (summary) #}
 					{% if item.entity.field_newsletter_article_select.entity.field_ucb_article_summary.value|render %}
 						<tr id="feature-article-summary-email-{{key}}">
@@ -186,15 +179,6 @@
 										{{ item.entity.field_newsletter_article_select.entity.field_ucb_article_categories|view }}
 									</td>
 								</tr>
-								{# Code to render user made content (categories) #}
-							{% elseif item.entity.field_news_content_categories is not empty %}
-							<tr>
-								<td class="tags" style="padding-bottom: 10px;">
-														{# TO DO - Fix categories #}
-									{{ item.entity.field_news_content_categories|view }}
-								</td>
-							</tr>
-							{% endif %}
 								{# Code to render selected article content (summary) #}
 							{% if item.entity.field_newsletter_article_select.entity.field_ucb_article_summary.value|render %}
 								<tr>

--- a/templates/paragraphs/paragraph--newsletter-section--email-html.html.twig
+++ b/templates/paragraphs/paragraph--newsletter-section--email-html.html.twig
@@ -132,7 +132,7 @@
 							<tbody>
 								<tr class="email-feature-art-row"style="border-bottom: solid rgba(128, 128, 128, 0.333);">
 									{# Image #}
-									<td valign="top" width="100px" height="100px" style="text-align: left; padding-right:10px; padding-left:10px">
+									<td valign="top" width="27%"style="text-align: left; padding-right:10px; padding-left:10px">
 											{# Code to render selected article content (thumbnail) #}
 											{% if item.entity.field_newsletter_article_select.entity.field_ucb_article_thumbnail.entity.field_media_image.alt|render %}
 												<img
@@ -153,7 +153,7 @@
 											{% endif %}
 									</td>
 									{# Header, Summary, Cats #}
-									<td>
+									<td width="72%">
 										<table role="presentation">
 											<tbody>
 												{# Header #}

--- a/templates/paragraphs/paragraph--newsletter-section--email-html.html.twig
+++ b/templates/paragraphs/paragraph--newsletter-section--email-html.html.twig
@@ -25,6 +25,8 @@
 		<!--Feature Style Section-->
 			{% for key, item in paragraph.field_newsletter_section_select %}
 				{%  if key|first != '#' %}
+				{# Unpublished check #}
+ 					{% if item.entity.field_newsletter_article_select.entity.isPublished() %}
 					{# Code to render selected article content (thumbnail) #}
 					<!--Feature Article-->
 					<table role="presentation" style="padding-bottom: 20px;">
@@ -116,11 +118,14 @@
 						</tbody>
 					</table>
 				{% endif %}
+				{% endif %}
 			{% endfor %}
 		{% else %}
 		<!--Teaser Section-->
 				{% for key, item in paragraph.field_newsletter_section_select %}
 					{%  if key|first != '#' %}
+					{# Unpublished check #}
+ 					{% if item.entity.field_newsletter_article_select.entity.isPublished() %}
 					<!--Teaser Article-->
 					<center align="left">
 						<table role="presentation" width="100%" style="padding-bottom: 20px;">
@@ -131,22 +136,19 @@
 											{# Code to render selected article content (thumbnail) #}
 											{% if item.entity.field_newsletter_article_select.entity.field_ucb_article_thumbnail.entity.field_media_image.alt|render %}
 												<img
-												width="100px"
-												height="100px"
+												width="130" style="max-width:100%; height:auto;"
 												src="{{base_url}}{{ item.entity.field_newsletter_article_select.entity.field_ucb_article_thumbnail.entity.field_media_image.entity.fileuri|image_style('focal_image_square') }}" alt="{{ item.entity.field_newsletter_article_select.entity.field_ucb_article_thumbnail.entity.field_media_image.alt|render }}"/>
 				
 												{# Code to render selected article content (!thumbnail) #}
 											{% elseif item.entity.field_newsletter_article_select.entity.field_ucb_article_content.entity.field_article_media_selection.entity.field_media.entity.field_media_image.alt|render %}
 												<img
-												width="100px"
-												height="100px"
+												width="130" style="max-width:100%; height:auto;"
 												src="{{base_url}}{{ item.entity.field_newsletter_article_select.entity.field_ucb_article_content.entity.field_article_media_selection.entity.field_media.entity.field_media_image.entity.fileuri|image_style('focal_image_square') }}" alt="{{ item.entity.field_newsletter_article_select.entity.field_ucb_article_content.entity.field_article_media_selection.entity.field_media.entity.field_media_image.alt|render }}"/>
 				
 												{# Code to render user made content #}
 											{% elseif item.entity.field_newsletter_content_image.entity.field_media_image.alt|render %}
 												<img
-												width="100px"
-												height="100px"
+												width="130" style="max-width:100%; height:auto;"
 												 src="{{base_url}}{{ item.entity.field_newsletter_content_image.entity.field_media_image.entity.fileuri|image_style('focal_image_square') }}" alt="{{ item.entity.field_newsletter_content_image.entity.field_media_image.alt|render }}"/>
 											{% endif %}
 									</td>
@@ -225,6 +227,7 @@
 							</tbody>
 						</table>
 					</center>
+					{% endif %}
 				{% endif %}
 			{% endfor %}
 		{% endif %}

--- a/templates/paragraphs/paragraph--newsletter-section--email-html.html.twig
+++ b/templates/paragraphs/paragraph--newsletter-section--email-html.html.twig
@@ -80,6 +80,8 @@
 				<tr>
 					<td class="tags" align="center" style="text-align: left; padding-right:10px; padding-left:10px; padding-bottom:10px">{{ item.entity.field_newsletter_article_select.entity.field_ucb_article_categories|view }}</td>
 				</tr>
+				{% endif %}
+
 					{# Code to render selected article content (summary) #}
 					{% if item.entity.field_newsletter_article_select.entity.field_ucb_article_summary.value|render %}
 						<tr id="feature-article-summary-email-{{key}}">
@@ -179,6 +181,8 @@
 										{{ item.entity.field_newsletter_article_select.entity.field_ucb_article_categories|view }}
 									</td>
 								</tr>
+								{% endif %}
+
 								{# Code to render selected article content (summary) #}
 							{% if item.entity.field_newsletter_article_select.entity.field_ucb_article_summary.value|render %}
 								<tr>

--- a/templates/paragraphs/paragraph--newsletter-section-content.html.twig
+++ b/templates/paragraphs/paragraph--newsletter-section-content.html.twig
@@ -1,0 +1,26 @@
+{%
+  set classes = [
+    'paragraph',
+    'paragraph--type--' ~ paragraph.bundle|clean_class,
+    view_mode ? 'paragraph--view-mode--' ~ view_mode|clean_class,
+    not paragraph.isPublished() ? 'paragraph--unpublished'
+  ]
+%}
+
+{% block paragraph %}
+	{% block content %}
+   <div class="col-lg-6 col-12">
+        {# {% if content.field_newsletter_block_title|render %}
+          <h3>{{ content.field_newsletter_block_title|render }}</h3>
+        {% endif %}
+
+        {% if content.field_newsletter_block_text|render %}
+          {{ content.field_newsletter_block_text|render }}
+        {% endif %} #}
+        {{content}}
+      </div>
+	{% endblock %}
+{% endblock paragraph %}
+
+
+

--- a/templates/paragraphs/paragraph--newsletter-section.html.twig
+++ b/templates/paragraphs/paragraph--newsletter-section.html.twig
@@ -73,14 +73,6 @@
 							{{ item.entity.field_newsletter_article_select.entity.field_ucb_article_categories|view }}
 						</div>
 
-						{# Code to render user made content (categories) #}
-					{% elseif item.entity.field_news_content_categories is not empty %}
-						<div class="article-teaser-meta">
-							{{ item.entity.field_news_content_categories|view }}
-						</div>
-					{% endif %}
-
-
 					{# Code to render selected article content (summary) #}
 					{% if item.entity.field_newsletter_article_select.entity.field_ucb_article_summary.value|render %}
 						<div class="article-summary" id="feature-article-summary-{{key}}">
@@ -141,22 +133,11 @@
 								</h3>
 							{% endif %}
 
-
 							{# Code to render selected article content (categories) #}
 							{% if item.entity.field_newsletter_article_select.entity.field_ucb_article_categories is not empty %}
 								<div class="article-teaser-meta">
 									{{ item.entity.field_newsletter_article_select.entity.field_ucb_article_categories|view }}
 								</div>
-
-								{# Code to render user made content (categories) #}
-							{% elseif item.entity.field_news_content_categories is not empty %}
-								<div class="article-teaser-meta">
-									{{ item.entity.field_news_content_categories|view }}
-								</div>
-							{% endif %}
-
-
-
 
 							{# Code to render selected article content (summary) #}
 							{% if item.entity.field_newsletter_article_select.entity.field_ucb_article_summary.value|render %}

--- a/templates/paragraphs/paragraph--newsletter-section.html.twig
+++ b/templates/paragraphs/paragraph--newsletter-section.html.twig
@@ -16,12 +16,24 @@
   ]
 %}
 
+
 {% block paragraph %}
 	<div{{attributes.addClass(classes)}}>
 		<h2>{{ content.field_newsletter_section_title }}</h2>
+		{# Unpublished Content Warning #}
+		{% if logged_in == 'true' %}
+				{% for key, item in paragraph.field_newsletter_section_select %}
+				{%  if key|first != '#' %}
+					{% if not item.entity.field_newsletter_article_select.entity.isPublished() %}
+						<p class="ucb-article-unpublished"> Section Content Warning: {{ item.entity.field_newsletter_article_select.entity.title.value|render|striptags|trim }} is unpublished. </p>
+					{% endif %}
+				{% endif %}
+			{% endfor %}
+		{% endif %}
 		{% if paragraph.field_newsletter_section_style.value is same as("0") %}
 			{% for key, item in paragraph.field_newsletter_section_select %}
 				{%  if key|first != '#' %}
+					<div class="ucb-newsletter-section-article {{unpublishedClass}}">
 					{# Code to render selected article content (thumbnail) #}
 					{% if item.entity.field_newsletter_article_select.entity.field_ucb_article_thumbnail.entity.field_media_image.alt|render %}
 						<div id='feature-article-thumbnail-{{key}}' class="feature-article-img"> {{ item.entity.field_newsletter_article_select.entity.field_ucb_article_thumbnail|view }} </div>
@@ -38,6 +50,7 @@
 					{# Code to render selected article title/url #}
 					{% if item.entity.field_newsletter_article_select.entity.title.value|render %}
 					<div id="feature-article-title-{{key}}">
+						{# Warning for unpublished Article #}
 						<h3>
 							<a href="{{ path('entity.node.canonical', {'node': item.entity.field_newsletter_article_select.target_id}) }}">
 								{{ item.entity.field_newsletter_article_select.entity.title.value|render|striptags|trim }}
@@ -86,6 +99,7 @@
 							{{ item.entity.field_newsletter_content_text|view }}
 						</div>
 					{% endif %}
+					</div>
 				{% endif %}
 			{% endfor %}
 		{% else %}
@@ -153,7 +167,14 @@
 								{# Code to render selected article content (article text) #}
 							{% elseif item.entity.field_newsletter_article_select.entity.field_ucb_article_content.entity.field_article_text.value|render %}
 								<div class="article-summary">
-									{{ item.entity.field_newsletter_article_select.entity.field_ucb_article_content.entity.field_article_text|view }}
+									{% set textContent = item.entity.field_newsletter_article_select.entity.field_ucb_article_content.entity.field_article_text.value|striptags %}
+									{% set maxLength = 300 %}
+									{% if textContent|length > maxLength %}
+										{% set trimmedText = textContent|slice(0, maxLength)|trim ~ '...' %}
+									{% else %}
+										{% set trimmedText = textContent %}
+									{% endif %}
+									{{ trimmedText }}
 								</div>
 
 								{# Code to render user made content (content text) #}

--- a/templates/paragraphs/paragraph--newsletter-section.html.twig
+++ b/templates/paragraphs/paragraph--newsletter-section.html.twig
@@ -72,7 +72,7 @@
 						<div class="article-teaser-meta">
 							{{ item.entity.field_newsletter_article_select.entity.field_ucb_article_categories|view }}
 						</div>
-
+					{% endif %}
 					{# Code to render selected article content (summary) #}
 					{% if item.entity.field_newsletter_article_select.entity.field_ucb_article_summary.value|render %}
 						<div class="article-summary" id="feature-article-summary-{{key}}">
@@ -138,6 +138,7 @@
 								<div class="article-teaser-meta">
 									{{ item.entity.field_newsletter_article_select.entity.field_ucb_article_categories|view }}
 								</div>
+							{% endif %}
 
 							{# Code to render selected article content (summary) #}
 							{% if item.entity.field_newsletter_article_select.entity.field_ucb_article_summary.value|render %}

--- a/templates/paragraphs/paragraph--newsletter-section.html.twig
+++ b/templates/paragraphs/paragraph--newsletter-section.html.twig
@@ -24,8 +24,11 @@
 		{% if logged_in == 'true' %}
 				{% for key, item in paragraph.field_newsletter_section_select %}
 				{%  if key|first != '#' %}
+				{# TO DO : need to fix for user made content #}
 					{% if not item.entity.field_newsletter_article_select.entity.isPublished() %}
+						{% if item.entity.field_newsletter_article_select.entity.bundle() == 'ucb_article' %}
 						<p class="ucb-article-unpublished"> Section Content Warning: {{ item.entity.field_newsletter_article_select.entity.title.value|render|striptags|trim }} is unpublished. </p>
+						{% endif %}
 					{% endif %}
 				{% endif %}
 			{% endfor %}

--- a/templates/paragraphs/paragraph--ucb-newsletter-text-block--email-html.html.twig
+++ b/templates/paragraphs/paragraph--ucb-newsletter-text-block--email-html.html.twig
@@ -1,0 +1,17 @@
+{%
+  set classes = [
+    'paragraph',
+    'paragraph--type--' ~ paragraph.bundle|clean_class,
+    view_mode ? 'paragraph--view-mode--' ~ view_mode|clean_class,
+    not paragraph.isPublished() ? 'paragraph--unpublished'
+  ]
+%}
+
+{% block paragraph %}
+        {% if content.field_newsletter_block_title|render %}
+          <h3>{{ content.field_newsletter_block_title|render }}</h3>
+        {% endif %}
+        {% if content.field_newsletter_block_text|render %}
+          {{ content.field_newsletter_block_text|render }}
+        {% endif %}
+{% endblock paragraph %}

--- a/templates/paragraphs/paragraph--ucb-newsletter-text-block.html.twig
+++ b/templates/paragraphs/paragraph--ucb-newsletter-text-block.html.twig
@@ -1,0 +1,19 @@
+{%
+  set classes = [
+    'paragraph',
+    'paragraph--type--' ~ paragraph.bundle|clean_class,
+    view_mode ? 'paragraph--view-mode--' ~ view_mode|clean_class,
+    not paragraph.isPublished() ? 'paragraph--unpublished'
+  ]
+%}
+
+{% block paragraph %}
+   <div class="col-lg-6 col-12">
+        {% if content.field_newsletter_block_title|render %}
+          <h3>{{ content.field_newsletter_block_title|render }}</h3>
+        {% endif %}
+        {% if content.field_newsletter_block_text|render %}
+          {{ content.field_newsletter_block_text|render }}
+        {% endif %}
+      </div>
+{% endblock paragraph %}


### PR DESCRIPTION
A rather large update to the Newsletter Node, includes the following:

### New Features
- Unpublished articles should not display in a Newsletter, and provide a yellow content warning for users in the section they are included in on the web version.
- Newsletter Text Blocks previously had two fixed Text Blocks. This has been updated to a paragraph type with no limit.
- Custom content no longer includes a category field.
- Ability to add Social Media Links to the Footer area. This will use the Social Media Menu links from the site and has a simple on/off checkbox to apply.

### Display Changes
- Adds Newsletter type title in header. This is set on the Newsletter Taxonomy.
- 'Feature' thumbnails fixed to a 2:1 aspect ratio
- Section headers fixed to 20px
- Article titles fixed to 18px
- Category links fixed to 10px, and a dark gray that is accessible with the light gray background
- Article text should be trimmed to ~50 words plus "..." unless a summary is used
- Teaser - style thumbnails are max of 130px but allowed to scale downwards if viewed on a smaller device

Includes:
- `tiamat-theme` => https://github.com/CuBoulder/tiamat-theme/pull/770
- `custom-entities` => https://github.com/CuBoulder/tiamat-custom-entities/pull/112

Resolves https://github.com/CuBoulder/tiamat-theme/issues/706