### PR TITLE
Issue Content: Bug Fixes for "Issue" (Node), Latest Issues Block

### DIFF
--- a/js/ucb-latest-issue-block.js
+++ b/js/ucb-latest-issue-block.js
@@ -19,7 +19,7 @@ class LatestIssueElement extends HTMLElement {
             });
     }
 
-    build(data){
+   async build(data){
         if(data.data.length == 0){
             this.handleError({name : "No Issues Retrieved", message : "There are no Issues created"} , 'No Issues Found')
         } else {
@@ -83,9 +83,19 @@ class LatestIssueElement extends HTMLElement {
             }
             this.toggleMessage('ucb-al-loading');
             this.appendChild(latestIssueContainer)
-
+            const siteTitle = this.getAttribute('siteName');
+            const baseURL = this.getAttribute('baseURL');
+            // Check if Archive Exists:
+            let archiveExists
+            const response = await fetch(`${baseURL}/${siteTitle}/issue/archive`)
+                    .then((data) => {
+                       archiveExists = data.status == 200 ? true : false
+                    })
+                    .catch(Error=> {
+                        console.error(Error)
+                    });
             // Add Archive link if articles >=4
-            if (issues.length >= 4){
+            if (issues.length >= 4 && archiveExists){
                 const archiveContainer = document.createElement('div')
                 archiveContainer.classList = 'ucb-latest-issue-archive-container'
                 const archiveLink = document.createElement('a')

--- a/templates/block/block--ucb-latest-issues-block.html.twig
+++ b/templates/block/block--ucb-latest-issues-block.html.twig
@@ -41,9 +41,9 @@
 		</div>
 	{% endif %}
 	{{ title_suffix }}
-	<current-issue-block>
+	<latest-issue-block>
 		<div id="ucb-al-loading" class="ucb-list-msg ucb-loading-data">
 			<i class="fa-solid fa-spinner fa-3x fa-spin-pulse"></i>
 		</div>
-	</current-issue-block>
+	</latest-issue-block>
 </div>

--- a/templates/block/block--ucb-latest-issues-block.html.twig
+++ b/templates/block/block--ucb-latest-issues-block.html.twig
@@ -11,6 +11,8 @@
 ]
 %}
 
+{% set baseurlJSON = (url('<front>')|render|trim('/'))%}
+
 {# Block/Title/Icon Styles #}
 {% set blockStyles = [
 	content.field_bs_background_style|render|striptags|trim,
@@ -41,7 +43,7 @@
 		</div>
 	{% endif %}
 	{{ title_suffix }}
-	<latest-issue-block>
+	<latest-issue-block baseURL="{{baseurlJSON}}" siteName="{{ site_name|lower|replace({' ': '-', '_': '-'}) }}">
 		<div id="ucb-al-loading" class="ucb-list-msg ucb-loading-data">
 			<i class="fa-solid fa-spinner fa-3x fa-spin-pulse"></i>
 		</div>

--- a/templates/paragraphs/paragraph--ucb-issue-section.html.twig
+++ b/templates/paragraphs/paragraph--ucb-issue-section.html.twig
@@ -17,13 +17,15 @@
     {# If teaser #}
         {% if paragraph.field_ucb_issue_section_style.value is same as("0") %}
         <div class="issue-section-content">
-            <div class="teaser-article-thumbnail" id='teaser-article-thumbnail-{{key}}'> 
-            <a href="{{ path('entity.node.canonical', {'node': content.field_ucb_issue_article_select['#items'].entity.id}) }}">
-                <img src="{{ base_url }}{{ file_url(item.entity.field_ucb_article_thumbnail.entity.field_media_image.entity.fileuri | image_style('focal_image_square')) }}" 
-                alt="{{ item.entity.field_ucb_article_thumbnail.entity.field_media_image.alt }}"
-                >
-            </a>
-            </div>
+            {% if item.entity.field_ucb_article_thumbnail.entity.field_media_image %}
+                <div class="teaser-article-thumbnail" id='teaser-article-thumbnail-{{key}}'> 
+                    <a href="{{ path('entity.node.canonical', {'node': content.field_ucb_issue_article_select['#items'].entity.id}) }}">
+                        <img src="{{ base_url }}{{ file_url(item.entity.field_ucb_article_thumbnail.entity.field_media_image.entity.fileuri | image_style('focal_image_square')) }}" 
+                        alt="{{ item.entity.field_ucb_article_thumbnail.entity.field_media_image.alt }}"
+                        >
+                    </a>
+                </div>
+            {% endif %}
             <div class="issue-section-content-summary">
                 <a class="issue-article-title-link" href="{{ path('entity.node.canonical', {'node': content.field_ucb_issue_article_select['#items'].entity.id}) }}">
                     <h3 class="issue-section-teaser-title">{{item.entity.title.value}}</h3>


### PR DESCRIPTION
Fixes the following bugs related to the "Issue" content type and associated blocks.

## Issue Node
On the Issue Node - fixed visual bug for display on "Teaser" Articles with no thumbnail from displaying a broken `<img>`

## Latest Issues Block
- Fixed bug where the "Latest Issue Block" (up to 4 Issues displayed with a button to see more)  would display a "Current Issue block" (one Issue). The template was pointed at the incorrect web component.
- The "Latest Issue Block" adds an "Issue Archive" button below if more than 4 Issues exist on the site. Added conditional rendering to only show if an Issue Archive exists on the site.

## Issue Archive
Needs a pathauto so the button on the Latest Issues Block works by default (only one expected per site so a similar pathauto to the Class Notes will be implemented)

Includes:
- `tiamat-theme` => https://github.com/CuBoulder/tiamat-theme/pull/773
- `custom-entities` => https://github.com/CuBoulder/tiamat-custom-entities/pull/113

Resolves #765 