### PR TITLE
Additional Issue Fixes

### DIFF
--- a/css/ucb-issue.css
+++ b/css/ucb-issue.css
@@ -65,8 +65,7 @@ img {
 }
 
 .feature-article-thumbnail>div>div>div>img {
-  max-width: 700px;
-  max-height: 275px;
+  aspect-ratio: 2 / 1;
   object-fit: cover;
   margin-bottom: 10px;
 }

--- a/css/ucb-issue.css
+++ b/css/ucb-issue.css
@@ -1,5 +1,5 @@
-.secondary-issue-image {
-  margin-top: 20px;
+.issue-content{
+  margin-top: 10px;
 }
 
 .issue-section-content {

--- a/templates/content/node--ucb-issue.html.twig
+++ b/templates/content/node--ucb-issue.html.twig
@@ -3,11 +3,13 @@
 {% set classes = [
   'node',
   'node--type-' ~ node.bundle|clean_class,
+  'container',
+  'ucb-content-wrapper',
   not node.isPublished() ? 'node--unpublished',
   view_mode ? 'node--view-mode-' ~ view_mode|clean_class,
 ] %}
 
-<div class="container">
+<div {{attributes.addClass(classes)}}>
   <div class="row">
     <header role="banner" class="ucb-article-banner">
       <h1{{ title_attributes.addClass(is_front ? 'sr-only') }}>

--- a/templates/paragraphs/paragraph--ucb-issue-section.html.twig
+++ b/templates/paragraphs/paragraph--ucb-issue-section.html.twig
@@ -55,9 +55,15 @@
     {# title & thumbnail #}
         {% elseif paragraph.field_ucb_issue_section_style.value is same as ("2") %}
         <div class="issue-section-content">
-            <a href="{{ path('entity.node.canonical', {'node': item.entity.id}) }}">
-                <div class="title-thumb-article-thumbnail" id='title-thumb-article-thumbnail-{{key}}'> {{ item.entity.field_ucb_article_thumbnail|view }} </div>
-            </a>
+            {% if item.entity.field_ucb_article_thumbnail.entity.field_media_image %}
+            <div class="teaser-article-thumbnail" id='teaser-article-thumbnail-{{key}}'>
+                <a href="{{ path('entity.node.canonical', {'node': item.entity.id}) }}">
+                    <img src="{{ base_url }}{{ file_url(item.entity.field_ucb_article_thumbnail.entity.field_media_image.entity.fileuri | image_style('focal_image_square')) }}" 
+                            alt="{{ item.entity.field_ucb_article_thumbnail.entity.field_media_image.alt }}"
+                            >
+                </a>
+            </div>
+            {% endif %}
             <div class="issue-section-content-summary">
                 <a class="issue-article-title-link" href="{{ path('entity.node.canonical', {'node': item.entity.id}) }}">
                     {{item.entity.title.value}}

--- a/templates/paragraphs/paragraph--ucb-issue-section.html.twig
+++ b/templates/paragraphs/paragraph--ucb-issue-section.html.twig
@@ -19,7 +19,7 @@
         <div class="issue-section-content">
             {% if item.entity.field_ucb_article_thumbnail.entity.field_media_image %}
                 <div class="teaser-article-thumbnail" id='teaser-article-thumbnail-{{key}}'> 
-                    <a href="{{ path('entity.node.canonical', {'node': content.field_ucb_issue_article_select['#items'].entity.id}) }}">
+                    <a href="{{ path('entity.node.canonical', {'node': item.entity.id}) }}">
                         <img src="{{ base_url }}{{ file_url(item.entity.field_ucb_article_thumbnail.entity.field_media_image.entity.fileuri | image_style('focal_image_square')) }}" 
                         alt="{{ item.entity.field_ucb_article_thumbnail.entity.field_media_image.alt }}"
                         >
@@ -27,39 +27,39 @@
                 </div>
             {% endif %}
             <div class="issue-section-content-summary">
-                <a class="issue-article-title-link" href="{{ path('entity.node.canonical', {'node': content.field_ucb_issue_article_select['#items'].entity.id}) }}">
+                <a class="issue-article-title-link" href="{{ path('entity.node.canonical', {'node': item.entity.id}) }}">
                     <h3 class="issue-section-teaser-title">{{item.entity.title.value}}</h3>
                 </a>
                 <div class="issue-article-categories">{{item.entity.field_ucb_article_categories|view}}</div>
                 <p class="issue-section-teaser-summary">{{item.entity.field_ucb_article_summary.value}}</p>
-                <a class="issue-section-teaser-read" href="{{ path('entity.node.canonical', {'node': content.field_ucb_issue_article_select['#items'].entity.id}) }}">Read More</a>
+                <a class="issue-section-teaser-read" href="{{ path('entity.node.canonical', {'node': item.entity.id}) }}">Read More</a>
             </div>
         </div>
                         
     {# If feature #}
         {% elseif paragraph.field_ucb_issue_section_style.value is same as ("1") %}
             <div class="issue-section-content-feature">
-                <a href="{{ path('entity.node.canonical', {'node': content.field_ucb_issue_article_select['#items'].entity.id}) }}">
+                <a href="{{ path('entity.node.canonical', {'node': item.entity.id}) }}">
                     <div class="feature-article-thumbnail" id='feature-article-thumbnail-{{key}}'> {{ item.entity.field_ucb_article_thumbnail|view }} </div>
                 </a>
                 <div class="issue-section-content-summary">
-                    <a class="issue-article-title-link" href="{{ path('entity.node.canonical', {'node': content.field_ucb_issue_article_select['#items'].entity.id}) }}">
+                    <a class="issue-article-title-link" href="{{ path('entity.node.canonical', {'node': item.entity.id}) }}">
                         <h3 class="issue-section-feature-title">{{item.entity.title.value}}</h3>
                     </a>
                     <div class="issue-article-categories">{{item.entity.field_ucb_article_categories|view}}</div>
                     <p class="issue-section-feature-summary">{{item.entity.field_ucb_article_summary.value}}</p>
-                    <a class="issue-section-feature-read" href="{{ path('entity.node.canonical', {'node': content.field_ucb_issue_article_select['#items'].entity.id}) }}">Read More</a>
+                    <a class="issue-section-feature-read" href="{{ path('entity.node.canonical', {'node': item.entity.id}) }}">Read More</a>
                 </div>
             </div>
 
     {# title & thumbnail #}
         {% elseif paragraph.field_ucb_issue_section_style.value is same as ("2") %}
         <div class="issue-section-content">
-            <a href="{{ path('entity.node.canonical', {'node': content.field_ucb_issue_article_select['#items'].entity.id}) }}">
+            <a href="{{ path('entity.node.canonical', {'node': item.entity.id}) }}">
                 <div class="title-thumb-article-thumbnail" id='title-thumb-article-thumbnail-{{key}}'> {{ item.entity.field_ucb_article_thumbnail|view }} </div>
             </a>
             <div class="issue-section-content-summary">
-                <a class="issue-article-title-link" href="{{ path('entity.node.canonical', {'node': content.field_ucb_issue_article_select['#items'].entity.id}) }}">
+                <a class="issue-article-title-link" href="{{ path('entity.node.canonical', {'node': item.entity.id}) }}">
                     {{item.entity.title.value}}
                 </a>
             </div>
@@ -68,7 +68,7 @@
     {# title only #}
         {% else %}
         <div class="issue-section-title-only">
-            <a class="issue-article-title-link" href="{{ path('entity.node.canonical', {'node': content.field_ucb_issue_article_select['#items'].entity.id}) }}">
+            <a class="issue-article-title-link" href="{{ path('entity.node.canonical', {'node': item.entity.id}) }}">
                 {{item.entity.title.value}}
             </a>
         </div>

--- a/templates/paragraphs/paragraph--ucb-issue-section.html.twig
+++ b/templates/paragraphs/paragraph--ucb-issue-section.html.twig
@@ -30,7 +30,9 @@
                 <a class="issue-article-title-link" href="{{ path('entity.node.canonical', {'node': item.entity.id}) }}">
                     <h3 class="issue-section-teaser-title">{{item.entity.title.value}}</h3>
                 </a>
-                <div class="issue-article-categories">{{item.entity.field_ucb_article_categories|view}}</div>
+                    {% if item.entity.field_ucb_article_thumbnail.entity.field_media_image or item.entity.field_ucb_article_summary.value%}
+                        <div class="issue-article-categories">{{item.entity.field_ucb_article_categories|view}}</div>
+                    {% endif %}
                 <p class="issue-section-teaser-summary">{{item.entity.field_ucb_article_summary.value}}</p>
                 <a class="issue-section-teaser-read" href="{{ path('entity.node.canonical', {'node': item.entity.id}) }}">Read More</a>
             </div>
@@ -46,7 +48,9 @@
                     <a class="issue-article-title-link" href="{{ path('entity.node.canonical', {'node': item.entity.id}) }}">
                         <h3 class="issue-section-feature-title">{{item.entity.title.value}}</h3>
                     </a>
-                    <div class="issue-article-categories">{{item.entity.field_ucb_article_categories|view}}</div>
+                        {% if item.entity.field_ucb_article_thumbnail.entity.field_media_image or item.entity.field_ucb_article_summary.value%}
+                            <div class="issue-article-categories">{{item.entity.field_ucb_article_categories|view}}</div>
+                        {% endif %}
                     <p class="issue-section-feature-summary">{{item.entity.field_ucb_article_summary.value}}</p>
                     <a class="issue-section-feature-read" href="{{ path('entity.node.canonical', {'node': item.entity.id}) }}">Read More</a>
                 </div>


### PR DESCRIPTION
## "Issue" Content Type Changes
-  Fixed a bug where all Articles in a section would link to the first Article in the section
-  Articles that do NOT have a thumbnail or a summary will no longer show the Categories
-  Fixed bug that would sometimes cause images to break display in Title + Thumbnail renders
-  Changed "Feature" style images to take up 100% of the available space and keep an aspect ratio consistent with other Feature images
-  Added spacing between Cover Image and Body, as well as between the Main Menu of the site and the Node Title of "Issue" pages

Resolves #772 



