### PR TITLE
Article Slider: Fix with 6+ Articles

### DIFF
--- a/js/ucb-article-slider-block.js
+++ b/js/ucb-article-slider-block.js
@@ -148,13 +148,11 @@ class ArticleSliderBlockElement extends HTMLElement {
 
         // Case for Too many articles
         if(finalArticles.length >= count || (finalArticles.length >= count && NEXTJSONURL)){
-            finalArticles.length = count
-            this.renderDisplay(finalArticles)
+            finalArticles.length = count;
         }
 
         // Have articles and want to proceed
-        if(finalArticles.length > 0 && !NEXTJSONURL){
-          // this.renderDisplay( finalArticles)
+        if((finalArticles.length >= 0 && !NEXTJSONURL) || (finalArticles.length == count && NEXTJSONURL)){
           this.renderDisplay(finalArticles)
         }
     }


### PR DESCRIPTION
Fixes a bug where 6+ Articles would cause the `Article Slider` to additionally repeat Articles in a long column

Resolves #781 