### PR TITLE
Removed stray character typo on the video reveal block

### DIFF
--- a/templates/block/block--video-reveal.html.twig
+++ b/templates/block/block--video-reveal.html.twig
@@ -62,7 +62,7 @@
 					<span class="ucb-video-reveal-icon">
 						<i class="fa-solid fa-circle-play"></i>
 					</span>
-					<span class="ucb-video-reveal-text">A{{ content.field_video_reveal_text_overlay|render}}</span>
+					<span class="ucb-video-reveal-text">{{ content.field_video_reveal_text_overlay|render}}</span>
 				</div>
 				<div class="ucb-video-reveal-image">
 					{{ content.field_video_reveal_image|render }}


### PR DESCRIPTION
Removed the "A" hard-coded in the render of the text of the video reveal block.  