### PR TITLE
Updates Articles

### DIFF
--- a/templates/content/node--ucb-article.html.twig
+++ b/templates/content/node--ucb-article.html.twig
@@ -85,7 +85,8 @@
   'node--type-' ~ node.bundle|clean_class,
   not node.isPublished() ? 'node--unpublished',
   view_mode ? 'node--view-mode-' ~ view_mode|clean_class,
-  pageStyleCSS
+  pageStyleCSS,
+  'ucb-content-wrapper'
 ] %}
 
 
@@ -136,10 +137,10 @@
 {% endif %}
 
 {% if not content.field_ucb_article_external_url|render %}
-  <article{{ attributes.addClass('ucb-content-wrapper') }}>
+  <article{{ attributes.addClass(classes, content.field_article_title_background.0 ? 'mt-0') }}>
     <div class="ucb-article" itemscope itemtype="https://schema.org/Article">
       {# If using a Title Background img, render that #}
-      {% if content.field_article_title_background|render %}
+      {% if content.field_article_title_background.0 %}
         <header><h1 class="sr-only">{{ label }}</h1></header>
         <div class="backgroundTitleDiv {{ overlayClass }}">
           {{ content.field_article_title_background }}
@@ -152,7 +153,7 @@
       {% endif %}
       <div class="container">
         {# If NO Title Background img, render the regular title #}
-        {% if not content.field_article_title_background|render %}
+        {% if not content.field_article_title_background.0 %}
           <h1{{ title_attributes.addClass('ucb-article-heading', is_front ? 'sr-only') }}>
             {{ label }}
           </h1>
@@ -171,7 +172,7 @@
               <i class="fa-regular fa-calendar"></i>
               <span class="sr-only">Published:{{ date_formatted }}</span>
               <span itemprop="datePublished">
-              {{ date_formatted }}
+                {{ date_formatted }}
               </span>
             </div>
           {% endif %}
@@ -193,8 +194,8 @@
       {% if content.field_appears_in_issue|render %}
         <div role="contentinfo" class="container ucb-article-issue" itemprop="keywords">
           <div>
-          <span class="sr-only">Issues:</span>
-          <i class="fa-solid fa-book"></i>
+            <span class="sr-only">Issues:</span>
+            <i class="fa-solid fa-book"></i>
           </div>
           {{ content.field_appears_in_issue }}
         </div>

--- a/templates/content/node--ucb-article.html.twig
+++ b/templates/content/node--ucb-article.html.twig
@@ -137,105 +137,98 @@
 
 {% if not content.field_ucb_article_external_url|render %}
   <article{{ attributes.addClass('ucb-content-wrapper') }}>
-  <div class="ucb-article" itemscope itemtype="https://schema.org/Article">
-    {# If using a Title Background img, render that #}
-    {% if content.field_article_title_background|render %}
-    <header><h1 class="sr-only">{{ label }}</h1></header>
-    <div class="backgroundTitleDiv {{ overlayClass }}">
-      {{ content.field_article_title_background }}
-      <div{{ title_attributes.addClass('ucb-article-heading', 'article-header-' ~ textColor, is_front ? 'sr-only') }}>
-        <div class="container">
-          <h1>
+    <div class="ucb-article" itemscope itemtype="https://schema.org/Article">
+      {# If using a Title Background img, render that #}
+      {% if content.field_article_title_background|render %}
+        <header><h1 class="sr-only">{{ label }}</h1></header>
+        <div class="backgroundTitleDiv {{ overlayClass }}">
+          {{ content.field_article_title_background }}
+          <div{{ title_attributes.addClass('ucb-article-heading', 'article-header-' ~ textColor, is_front ? 'sr-only') }}>
+            <div class="container">
+              <h1>{{ label }}</h1>
+            </div>
+          </div>
+        </div>
+      {% endif %}
+      <div class="container">
+        {# If NO Title Background img, render the regular title #}
+        {% if not content.field_article_title_background|render %}
+          <h1{{ title_attributes.addClass('ucb-article-heading', is_front ? 'sr-only') }}>
             {{ label }}
           </h1>
-        </div>
-      </div>
-    </div>
-    {% endif %}
-    <div class="container">
-      {# If NO Title Background img, render the regular title #}
-      {% if not content.field_article_title_background|render %}
-      <h1{{ title_attributes.addClass('ucb-article-heading', is_front ? 'sr-only') }}>
-        {{ label }}
-      </h1>
-      {% endif %}
-      {% if social_share_button_position == "4" or social_share_button_position == "1" %}
-        <div id={{social_share_class}} class="ucb-social-share-container">
-        {{ drupal_block("social_sharing_buttons_block") }}
-        </div>
-      {% endif %}
-      {% if showDate %}
-      <div role="contentinfo" class="ucb-article-meta">
-      <div class="ucb-article-date">
-        <i class="fa-regular fa-calendar"></i>
-        <span class="sr-only">Published:{{ date_formatted }}</span>
-        <span itemprop="datePublished">
-        {{ date_formatted }}
-        </span>
-      </div>
-      {% endif %}
-      {% if content.field_ucb_article_byline|render %}
-      <div class="ucb-article-byline">
-        {% if showDate %}
-        &bull;
         {% endif %}
-
-        By
-        <span class="ucb-article-author-name" itemprop="author">
-        {{ content.field_ucb_article_byline }}
-        </span>
+        {% if content.field_article_header_image_text|render %}
+          <p class="ucb-article-supplemental-text">{{ content.field_article_header_image_text|render|striptags|trim }}</p>
+        {% endif %}
+        {% if social_share_button_position == "4" or social_share_button_position == "1" %}
+          <div id={{social_share_class}} class="ucb-social-share-container">
+            {{ drupal_block("social_sharing_buttons_block") }}
+          </div>
+        {% endif %}
+        <div role="contentinfo" class="ucb-article-meta">
+          {% if showDate %}
+            <div class="ucb-article-date">
+              <i class="fa-regular fa-calendar"></i>
+              <span class="sr-only">Published:{{ date_formatted }}</span>
+              <span itemprop="datePublished">
+              {{ date_formatted }}
+              </span>
+            </div>
+          {% endif %}
+          {% if content.field_ucb_article_byline|render %}
+            <div class="ucb-article-byline">
+              {% if showDate %}&bull; {% endif %}By
+              <span class="ucb-article-author-name" itemprop="author">
+                {{ content.field_ucb_article_byline }}
+              </span>
+            </div>
+          {% endif %}
+        </div>
       </div>
+      {% if content.field_ucb_article_content|render %}
+        <div role="main" class="ucb-article-body">{{ content.field_ucb_article_content }}</div>
+      {% endif %}
+      {{ content.field_ucb_article_categories }}
+      {{ content.field_ucb_article_tags }}
+      {% if content.field_appears_in_issue|render %}
+        <div role="contentinfo" class="container ucb-article-issue" itemprop="keywords">
+          <div>
+          <span class="sr-only">Issues:</span>
+          <i class="fa-solid fa-book"></i>
+          </div>
+          {{ content.field_appears_in_issue }}
+        </div>
       {% endif %}
 
-    </div>
-    {% if content.field_article_header_image_text|render %}
-    <p class="ucb-article-supplemental-text">{{ content.field_article_header_image_text|render|striptags|trim }}</p>
-    {% endif %}
-    </div>
-    {% if content.field_ucb_article_content|render %}
-    <div role="main" class="ucb-article-body">{{ content.field_ucb_article_content }}</div>
-    {% endif %}
-    {{ content.field_ucb_article_categories }}
-    {{ content.field_ucb_article_tags }}
-    {% if content.field_appears_in_issue|render %}
-    <div role="contentinfo" class="container ucb-article-issue" itemprop="keywords">
-      <div>
-      <span class="sr-only">Issues:</span>
-      <i class="fa-solid fa-book"></i>
+      {# Related Articles Block #}
+      <div{{ create_attribute({
+          class: ['container', 'ucb-related-articles-block'],
+          'data-loggedin': logged_in ? 'true' : 'false',
+          'data-catsjson': content.field_ucb_article_categories|json_encode(constant('JSON_PRETTY_PRINT')),
+          'data-tagsjson': content.field_ucb_article_tags|json_encode(constant('JSON_PRETTY_PRINT')),
+          'data-relatedshown': showRelated|striptags|trim,
+          'data-tags': myTags|render|striptags|trim|replace({"\n": "", "\r": "", "\t": ""}),
+          'data-cats': myCats|render|striptags|trim|replace({"\n": "", "\r": "", "\t": ""}),
+          'data-tagExclude': related_articles_exclude_tags|json_encode(),
+          'data-catExclude': related_articles_exclude_categories|json_encode() }) }}>
+        {{ content.field_ucb_related_articles_parag }}
       </div>
-      {{ content.field_appears_in_issue }}
     </div>
-    {% endif %}
-
-    {# Related Articles Block #}
-    <div{{ create_attribute({
-      class: ['container', 'ucb-related-articles-block'],
-      'data-loggedin': logged_in ? 'true' : 'false',
-      'data-catsjson': content.field_ucb_article_categories|json_encode(constant('JSON_PRETTY_PRINT')),
-      'data-tagsjson': content.field_ucb_article_tags|json_encode(constant('JSON_PRETTY_PRINT')),
-      'data-relatedshown': showRelated|striptags|trim,
-      'data-tags': myTags|render|striptags|trim|replace({"\n": "", "\r": "", "\t": ""}),
-      'data-cats': myCats|render|striptags|trim|replace({"\n": "", "\r": "", "\t": ""}),
-      'data-tagExclude': related_articles_exclude_tags|json_encode(),
-      'data-catExclude': related_articles_exclude_categories|json_encode() }) }}>
-      {{ content.field_ucb_related_articles_parag }}
-    </div>
-  </div>
   </article>
 {% else %}
   <article{{attributes.addClass(classes)}}>
-  <div class="container ucb-article">
-    <h1 class="ucb-article-heading">{{ label }}</h1>
-    {% set externalURL = content.field_ucb_article_external_url[0]['#url']|render|striptags|trim %}
-    <p class="fw-bold">Redirecting to:
-    <a href="{{ externalURL }}">{{ externalURL }}</a>
-    </p>
-    {% if user_can_edit %}
-    <p>(Most visitors without editing permissions will be redirected from this page automatically)</p>
-    {% else %}
-    {# redirect non-authenticated users to the specified URL #}
-    {{ content.field_ucb_article_external_url }}
-    {% endif %}
-  </div>
+    <div class="container ucb-article">
+      <h1 class="ucb-article-heading">{{ label }}</h1>
+      {% set externalURL = content.field_ucb_article_external_url[0]['#url']|render|striptags|trim %}
+      <p class="fw-bold">Redirecting to:
+        <a href="{{ externalURL }}">{{ externalURL }}</a>
+      </p>
+      {% if user_can_edit %}
+        <p>(Most visitors without editing permissions will be redirected from this page automatically)</p>
+      {% else %}
+        {# redirect non-authenticated users to the specified URL #}
+        {{ content.field_ucb_article_external_url }}
+      {% endif %}
+    </div>
   </article>
 {% endif %}


### PR DESCRIPTION
This update:
- Removes margin at the top of articles with header image.
- Moves header image caption to immediately below header image.
- Removes options for black text or hiding the overlay on the header image, setting the white text on dark overlay as the default.
- Updates description of the article header image text field.

Resolves CuBoulder/tiamat-theme#791
Resolves CuBoulder/tiamat-theme#790

Sister PR in: [tiamat-custom-entities](https://github.com/CuBoulder/tiamat-custom-entities/pull/117)