### PR TITLE
Form Block: Fixes bug preventing editing in Layout Builder

### DIFF
--- a/templates/block/block--ucb-form.html.twig
+++ b/templates/block/block--ucb-form.html.twig
@@ -1,23 +1,24 @@
 {{ attach_library('boulder_base/ucb-form-page') }}
 
-{%
-  set classes = [
-  'block',
-  'block-' ~ configuration.provider|clean_class,
-  'block-' ~ plugin_id|clean_class,
-  bundle ? 'block--type-' ~ bundle|clean_class,
-  view_mode ? 'block--view-mode-' ~ view_mode|clean_class
-]
-%}
+{% set classes = [
+	'container',
+	'block',
+	'block-' ~ configuration.provider|clean_class,
+	'block-' ~ plugin_id|clean_class,
+	bundle ? 'block--type-' ~ bundle|clean_class,
+	view_mode ? 'block--view-mode-' ~ view_mode|clean_class,
+	''
+] %}
 
-<article{{attributes.addClass(classes)}}>
-
+{% block content %}
+<div{{attributes.addClass(classes)}}>
+			{{ title_prefix }}
 	<div class="container">
 		<h1{{title_attributes}}>
 			{{ label }}
 		</h1>
 	</div>
-
+		{{ title_suffix }}
 	<div class="container mb-4">
 		<div class="row">
 			<div class="col-sm-8">
@@ -28,4 +29,5 @@
 			</div>
 		</div>
 	</div>
-</article>
+</div>
+{% endblock %}


### PR DESCRIPTION
Form block was missing template markup required to allow editing in Layout Builder. This has been corrected.

Resolves #789 