### PR TITLE
Adjusts style of Links in Content Grid - Cards

### DIFF
--- a/css/block/content-grid.css
+++ b/css/block/content-grid.css
@@ -52,9 +52,11 @@
 /* Override for Card links color to maintain accessibility (white on blue) */
 .grid-card .grid-text-container a {
   color: var(--ucb-link);
+  text-decoration: none;
 }
 .grid-card .grid-text-container a:hover{
   color: var(--ucb-link-visited);
+  text-decoration: none;
 }
 
 /* Card Layout CSS */

--- a/css/block/content-grid.css
+++ b/css/block/content-grid.css
@@ -49,6 +49,14 @@
   width: 100%;
 }
 
+/* Override for Card links color to maintain accessibility (white on blue) */
+.grid-card .grid-text-container a {
+  color: var(--ucb-link);
+}
+.grid-card .grid-text-container a:hover{
+  color: var(--ucb-link-visited);
+}
+
 /* Card Layout CSS */
 .grid-card {
   -webkit-box-shadow: 0 0 10px rgb(0, 0, 0, 10%);
@@ -85,7 +93,6 @@
   width: 100%;
   font-size: 100%
 }
-
 
 /*** Offest Grid Layout ***/
 .grid-image-container-large .grid-fill {


### PR DESCRIPTION
Since Content Grids with a "Cards" layout selection always have a white background, the link colors are a consistent blue following the established white background link style, rather than adopting whatever the block background's link styles are.

Resolves #776 