### PR TITLE
Fixes error thrown by Social Media Icons block email field

### DIFF
--- a/templates/field/field--field-social-media-email-link.html.twig
+++ b/templates/field/field--field-social-media-email-link.html.twig
@@ -10,7 +10,7 @@
   <ul>
     {% for item in items %}
       <li>
-        {{ socialMediaMenu.link('Email', 'mailto:' ~ item|render, 'fa-solid fa-envelope', 'email') }}
+        {{ socialMediaMenu.link('Email', 'mailto:' ~ item.content|render, 'fa-solid fa-envelope', 'email') }}
       </li>
     {% endfor %}
   </ul>


### PR DESCRIPTION
It throws a console error despite working just fine. This update removes the error.

Resolves CuBoulder/tiamat-theme#862