### PR TITLE
Update hero-unit.css

### DIFF
--- a/css/block/hero-unit.css
+++ b/css/block/hero-unit.css
@@ -153,3 +153,10 @@
   padding-top: 0;
   padding-bottom: 0;
 }
+
+/* Block Styles CSS */
+
+/* Fix for icon breaking hero */
+.block-hero-unit .bs-icon-position-default {
+  display: block;
+}


### PR DESCRIPTION
The main part of this is found in PR: 

Added css for fixing default block style icon display It would cause the hero units to shrink like the contextual links would. This is mainly a fix for the layout builder view.

Closes #840 
Closes #777 
Closes #745