### PR TITLE
Newsletter: Adds Optional URL to Newsletter Custom Content

### DIFF
--- a/css/ucb-newsletter.css
+++ b/css/ucb-newsletter.css
@@ -72,3 +72,8 @@
 .newsletter-social-lightbox a{
   color: black;
 }
+
+a.ucb-newsletter-content-title{
+  color:inherit;
+  text-decoration: none;
+}

--- a/templates/content/node--newsletter--email-html.html.twig
+++ b/templates/content/node--newsletter--email-html.html.twig
@@ -203,10 +203,10 @@ h1,h2,h3,h4,h5,h6,.h1,.h2,.h3,.h4,.h5,.h6 {
    font-family: Roboto,"Helvetica Neue",Helvetica,Arial,sans-serif;
 }
 
-td>h3>a{
+/* td>h3>a{
     text-decoration: none;
     color: #0277BD;
-}
+} */
 
 .ucb-article-categories{
     padding: 0;

--- a/templates/paragraphs/paragraph--newsletter-section--email-html.html.twig
+++ b/templates/paragraphs/paragraph--newsletter-section--email-html.html.twig
@@ -68,13 +68,29 @@
 					</tr>
 						{# Code to render user made content (title) #}
 					{% elseif item.entity.field_newsletter_content_title.value|render %}
-					<tr id="feature-article-user-title-email-{{key}}">
-						<td align="center" style="text-align: left; padding-right:10px; padding-left:10px">
-							<h3>
-								{{ item.entity.field_newsletter_content_title|view }}
-							</h3>
-						</td>
-					</tr>
+						{% if item.entity.field_newsletter_content_url.0.url %}
+							{% set actual_url = item.entity.field_newsletter_content_url.0.url.toString() %}
+							{% set is_absolute = (actual_url starts with 'http://' or actual_url starts with 'https://') %}
+							{% set final_url = is_absolute ? actual_url : (base_url ~ actual_url) %}
+
+							<tr id="feature-article-user-title-email-{{ key }}">
+								<td align="center" style="text-align: left; padding-right:10px; padding-left:10px">
+									<a href="{{ final_url }}">
+										<h3>
+											{{ item.entity.field_newsletter_content_title|view }}
+										</h3>
+									</a>
+								</td>
+							</tr>
+						{% else %}
+							<tr id="feature-article-user-title-email-{{ key }}">
+								<td align="center" style="text-align: left; padding-right:10px; padding-left:10px">
+									<h3>
+										{{ item.entity.field_newsletter_content_title|view }}
+									</h3>
+								</td>
+							</tr>
+						{% endif %}
 					{% endif %}
 				{# Code to render selected article content (categories) #}
 				{% if item.entity.field_newsletter_article_select.entity.field_ucb_article_categories is not empty %}
@@ -169,11 +185,22 @@
 	
 													{# Code to render user made content (title) #}
 												{% elseif item.entity.field_newsletter_content_title.value|render %}
+													{% if item.entity.field_newsletter_content_url.0.url %}
+														{% set actual_url = item.entity.field_newsletter_content_url.0.url.toString() %}
+														{% set is_absolute = (actual_url starts with 'http://' or actual_url starts with 'https://') %}
+														{% set final_url = is_absolute ? actual_url : (base_url ~ actual_url) %}
+														<a href="{{ final_url }}">
+															<h3 style="font-size: 18px;">
+															{{ item.entity.field_newsletter_content_title|view }}
+															</h3>
+														</a>
+													{% else %}
 												<td>
 													<h3 style="font-size: 18px;">
 														{{ item.entity.field_newsletter_content_title|view }}
 													</h3>
 												</td>
+													{% endif %}
 												{% endif %}
 												</tr>											
 												{# Categories #}
@@ -208,7 +235,7 @@
 								{# Code to render user made content (content text) #}
 							{% elseif item.entity.field_newsletter_content_text.value|render %}
 								<tr>
-									<td>{{ item.entity.field_newsletter_content_text|view }}</td>
+									<td style="padding-left: 0px;">{{ item.entity.field_newsletter_content_text|view }}</td>
 								</tr>
 							{% endif %}
 											</tbody>

--- a/templates/paragraphs/paragraph--newsletter-section--email-html.html.twig
+++ b/templates/paragraphs/paragraph--newsletter-section--email-html.html.twig
@@ -75,11 +75,11 @@
 
 							<tr id="feature-article-user-title-email-{{ key }}">
 								<td align="center" style="text-align: left; padding-right:10px; padding-left:10px">
-									<a href="{{ final_url }}">
-										<h3>
+									<h3>
+										<a class="ucb-newsletter-content-title" href="{{ final_url }}">
 											{{ item.entity.field_newsletter_content_title|view }}
-										</h3>
-									</a>
+										</a>
+									</h3>
 								</td>
 							</tr>
 						{% else %}
@@ -189,11 +189,11 @@
 														{% set actual_url = item.entity.field_newsletter_content_url.0.url.toString() %}
 														{% set is_absolute = (actual_url starts with 'http://' or actual_url starts with 'https://') %}
 														{% set final_url = is_absolute ? actual_url : (base_url ~ actual_url) %}
-														<a href="{{ final_url }}">
-															<h3 style="font-size: 18px;">
-															{{ item.entity.field_newsletter_content_title|view }}
-															</h3>
-														</a>
+														<h3 style="font-size: 18px;">
+															<a class="ucb-newsletter-content-title" href="{{ final_url }}">
+																{{ item.entity.field_newsletter_content_title|view }}
+															</a>
+														</h3>
 													{% else %}
 												<td>
 													<h3 style="font-size: 18px;">

--- a/templates/paragraphs/paragraph--newsletter-section--email-html.html.twig
+++ b/templates/paragraphs/paragraph--newsletter-section--email-html.html.twig
@@ -26,7 +26,10 @@
 			{% for key, item in paragraph.field_newsletter_section_select %}
 				{%  if key|first != '#' %}
 				{# Unpublished check #}
- 					{% if item.entity.field_newsletter_article_select.entity.isPublished() %}
+				{% if (item.entity.field_newsletter_article_select.entity and 
+					item.entity.field_newsletter_article_select.entity.isPublished()) or 
+					(item.entity.field_newsletter_content_title and 
+					item.entity.field_newsletter_content_title.value|render) %}					
 					{# Code to render selected article content (thumbnail) #}
 					<!--Feature Article-->
 					<table role="presentation" style="padding-bottom: 20px;">
@@ -48,9 +51,7 @@
 									{# Code to render user made content #}
 								{% elseif item.entity.field_newsletter_content_image.entity.field_media_image.alt|render %}
 								<td align="center" style="text-align: left; padding-right:10px; padding-left:10px;padding-bottom:20px;">
-									<a href="{{base_url}}{{ path('entity.node.canonical', {'node': item.entity.field_newsletter_article_select.target_id}) }}">
 									<img width="100%" style="aspect-ratio:2/1;object-fit:cover;" src="{{base_url}}{{file_url(item.entity.field_newsletter_content_image.entity.field_media_image.entity.fileuri|image_style('focal_image_wide'))}}"/>
-									</a>
 								</td>
 								{% endif %}
 							</tr>
@@ -120,8 +121,11 @@
 				{% for key, item in paragraph.field_newsletter_section_select %}
 					{%  if key|first != '#' %}
 					{# Unpublished check #}
- 					{% if item.entity.field_newsletter_article_select.entity.isPublished() %}
-					<!--Teaser Article-->
+					{% if (item.entity.field_newsletter_article_select.entity and 
+						item.entity.field_newsletter_article_select.entity.isPublished()) or 
+						(item.entity.field_newsletter_content_title and 
+						item.entity.field_newsletter_content_title.value|render) %}
+	  					<!--Teaser Article-->
 					<center align="left">
 						<table role="presentation" width="100%" style="padding-bottom: 20px;">
 							<tbody>

--- a/templates/paragraphs/paragraph--newsletter-section.html.twig
+++ b/templates/paragraphs/paragraph--newsletter-section.html.twig
@@ -63,9 +63,17 @@
 						{# Code to render user made content (title) #}
 					{% elseif item.entity.field_newsletter_content_title.value|render %}
 					<div id="feature-article-user-title-{{key}}">
+						{% if item.entity.field_newsletter_content_url.0.url %}
+						<a href="{{item.entity.field_newsletter_content_url.0.url}}">
+							<h3>
+								{{ item.entity.field_newsletter_content_title|view }}
+							</h3>
+						</a>
+						{% else %}
 						<h3>
 							{{ item.entity.field_newsletter_content_title|view }}
 						</h3>
+						{% endif %}
 					</div>
 					{% endif %}
 
@@ -131,9 +139,17 @@
 
 								{# Code to render user made content (title) #}
 							{% elseif item.entity.field_newsletter_content_title.value|render %}
+								{% if item.entity.field_newsletter_content_url.0.url %}
+								<a href="{{item.entity.field_newsletter_content_url.0.url}}">
+									<h3>
+										{{ item.entity.field_newsletter_content_title|view }}
+									</h3>
+								</a>
+								{% else %}
 								<h3>
 									{{ item.entity.field_newsletter_content_title|view }}
 								</h3>
+								{% endif %}
 							{% endif %}
 
 							{# Code to render selected article content (categories) #}

--- a/templates/paragraphs/paragraph--newsletter-section.html.twig
+++ b/templates/paragraphs/paragraph--newsletter-section.html.twig
@@ -64,11 +64,11 @@
 					{% elseif item.entity.field_newsletter_content_title.value|render %}
 					<div id="feature-article-user-title-{{key}}">
 						{% if item.entity.field_newsletter_content_url.0.url %}
-						<a href="{{item.entity.field_newsletter_content_url.0.url}}">
-							<h3>
+						<h3>
+							<a href="{{item.entity.field_newsletter_content_url.0.url}}">
 								{{ item.entity.field_newsletter_content_title|view }}
-							</h3>
-						</a>
+							</a>
+						</h3>
 						{% else %}
 						<h3>
 							{{ item.entity.field_newsletter_content_title|view }}
@@ -140,11 +140,11 @@
 								{# Code to render user made content (title) #}
 							{% elseif item.entity.field_newsletter_content_title.value|render %}
 								{% if item.entity.field_newsletter_content_url.0.url %}
-								<a href="{{item.entity.field_newsletter_content_url.0.url}}">
 									<h3>
-										{{ item.entity.field_newsletter_content_title|view }}
+										<a href="{{item.entity.field_newsletter_content_url.0.url}}">
+											{{ item.entity.field_newsletter_content_title|view }}
+										</a>
 									</h3>
-								</a>
 								{% else %}
 								<h3>
 									{{ item.entity.field_newsletter_content_title|view }}


### PR DESCRIPTION
Adds the optional URL field for Newsletter Section's Custom Content.

Includes:
- `tiamat-theme` => https://github.com/CuBoulder/tiamat-theme/pull/882
- `custom-entities` => https://github.com/CuBoulder/tiamat-custom-entities/pull/131

Resolves #872 

