### PR TITLE
Newsletter: One Article or One Custom Content in a Section

### DIFF
--- a/templates/paragraphs/paragraph--newsletter-section.html.twig
+++ b/templates/paragraphs/paragraph--newsletter-section.html.twig
@@ -109,8 +109,7 @@
 			<div class="row row-content">
 				{% for key, item in paragraph.field_newsletter_section_select %}
 					{%  if key|first != '#' %}
-						<div class="col-lg-6 col-12 pb-4">
-
+						<div class="{{paragraph.field_newsletter_section_select|length > 1 ? 'col-lg-6' : '' }} col-12 pb-4">
 							<div
 							class="teaser-article-img px-2">
 							{# Code to render selected article content (thumbnail) #}


### PR DESCRIPTION
### Newsletters
There is a special case for if a Newsletter Section set to "Teaser" display has only one Article or one item of Section Custom Content, then it should span the full width of the web newsletter. This is only the case for a single item in a Newsletter section, odd numbered counts are still 50%. The email version of the Newsletter is unaffected.

Resolves #895 