### PR TITLE
A11y for Content Rows

### DIFF
--- a/css/block/content-row.css
+++ b/css/block/content-row.css
@@ -145,6 +145,10 @@
   padding-bottom: 0px;
 }
 
+.row-content-tile-odd{
+  flex-direction: row-reverse;
+}
+
 @media screen and (max-width: 975px) {
   .small-feature-row {
     margin-top: 1em;

--- a/css/block/content-row.css
+++ b/css/block/content-row.css
@@ -112,6 +112,7 @@
 .ucb-teaser-lg-row{
   align-items: center;
   margin-bottom: 20px;
+  flex-direction: row-reverse;
 }
 
 .row-image-container{
@@ -147,6 +148,15 @@
 
   .small-feature:last-child {
     padding-right: 0;
+  }
+}
+
+@media screen and (max-width:767px) {
+  .ucb-teaser-lg-row{
+   flex-direction: column-reverse;
+  }
+  .row-image-container-lg{
+   margin-bottom: 10px;
   }
 }
 

--- a/css/block/content-row.css
+++ b/css/block/content-row.css
@@ -115,6 +115,16 @@
   flex-direction: row-reverse;
 }
 
+.ucb-teaser-lg-row.ucb-teaser-lg-alternate{
+  align-items: center;
+  margin-bottom: 20px;
+  flex-direction: inherit;
+}
+
+.ucb-teaser-lg-alternate.ucb-teaser-lg-row-odd{
+  flex-direction: row-reverse;
+}
+
 .row-image-container{
   width: calc(100px + var(--bs-gutter-x));
   height: auto;
@@ -166,8 +176,12 @@
   }
 }
 @media screen and (max-width: 576px) {
-  .ucb-teaser-lg-row-even{
+  .ucb-teaser-lg-alternate.ucb-teaser-lg-row-odd,
+  .ucb-teaser-lg-alternate.ucb-teaser-lg-row-even{
     flex-direction: column-reverse;
+  }
+  .ucb-teaser-lg-row.ucb-teaser-lg-alternate .row-image-container-lg{
+    margin-bottom: 10px;
   }
 }
 

--- a/css/block/content-row.css
+++ b/css/block/content-row.css
@@ -19,6 +19,12 @@
   border-bottom: 2px solid rgba(128, 128, 128, 0.333);
   margin-bottom: 20px;
 }
+
+.teaser-row{
+  flex-direction: row-reverse;
+  justify-content: flex-end;
+}
+
 .ucb-content-row-teaser{
   display: flex;
   flex-direction: column;
@@ -141,6 +147,12 @@
 
   .small-feature:last-child {
     padding-right: 0;
+  }
+}
+
+@media screen and (max-width: 975px) {
+  .teaser-row{
+    flex-direction: column-reverse;
   }
 }
 @media screen and (max-width: 576px) {

--- a/templates/block/block--content-row.html.twig
+++ b/templates/block/block--content-row.html.twig
@@ -58,11 +58,21 @@
 			{% for key, item in content['#block_content'].field_row_layout_content %}
 				{% set rowLink = item.entity.field_row_layout_content_link.0.url|render %}
 				<div class="row-content ucb-content-row-teaser">{% set image = item.entity.field_row_layout_content_image.0 %}
-					<div class="row">
+					<div class="row teaser-row">
+						<div class="{{ image ? 'col-sm-10 ' : 'col-sm-12' }} row-text-container">
+							{% if rowLink %}
+								<a href="{{ rowLink }} ">
+									<h3>{{ item.entity.field_row_layout_content_title.0.value }}</h3>
+								</a>
+							{% else %}
+								<h3>{{ item.entity.field_row_layout_content_title.0.value }}</h3>
+							{% endif %}
+							{{item.entity.field_row_layout_content_text|view}}
+						</div>
 					{% if image %}
 					<div class="col-sm-2 row-image-container">
 						{% if rowLink %}
-							<a href="{{ rowLink }} ">
+							<a role="presentation" aria-hidden="true" href="{{ rowLink }} ">
 								{{ image|view }}
 							</a>
 						{% else %}
@@ -70,16 +80,6 @@
 						{% endif %}
 					</div>
 					{% endif %}
-					<div class="{{ image ? 'col-sm-10 ' : 'col-sm-12' }} row-text-container">
-						{% if rowLink %}
-							<a href="{{ rowLink }} ">
-								<h3>{{ item.entity.field_row_layout_content_title.0.value }}</h3>
-							</a>
-						{% else %}
-							<h3>{{ item.entity.field_row_layout_content_title.0.value }}</h3>
-						{% endif %}
-						{{item.entity.field_row_layout_content_text|view}}
-					</div>
 					</div>
 				</div>
 			{% endfor %}
@@ -94,7 +94,7 @@
 						{% if image %}
 						<div class="col-sm-5 col-xs-12 row-image-container-lg">
 							{% if rowLink %}
-								<a href="{{ rowLink }} ">
+								<a role="presentation" aria-hidden="true" href="{{ rowLink }} ">
 									<img alt="{{item.entity.field_row_layout_content_image.entity.field_media_image.alt}}" class="ucb-content-row-img-lg" src="{{item.entity.field_row_layout_content_image.entity.field_media_image.entity.fileuri|image_style('focal_image_wide')}}"></img>
 								</a>
 							{% else %}

--- a/templates/block/block--content-row.html.twig
+++ b/templates/block/block--content-row.html.twig
@@ -263,17 +263,6 @@
 			{% set rowLink = item.entity.field_row_layout_content_link.0.url|render %}
 			<div class="row row-content ucb-teaser-lg-row">
 			{% set image = item.entity.field_row_layout_content_image.0 %}
-				{% if image %}
-				<div class="col-lg-4 col-md-6 col-sm-12 row-image-container-lg">
-					{% if rowLink %}
-						<a href="{{ rowLink }} ">
-							<img alt="{{item.entity.field_row_layout_content_image.entity.field_media_image.alt}}" class="ucb-content-row-img-lg" src="{{item.entity.field_row_layout_content_image.entity.field_media_image.entity.fileuri|image_style('focal_image_wide')}}"></img>
-						</a>
-					{% else %}
-						{{ image|view }}
-					{% endif %}
-				</div>
-				{% endif %}
 				<div class="{{ image ? 'col-lg-8 col-md-6 col-sm-12' : 'col-sm-12' }} row-text-container">
 					{% if rowLink %}
 						<a href="{{ rowLink }} ">
@@ -284,6 +273,17 @@
 					{% endif %}
 					{{item.entity.field_row_layout_content_text|view}}
 				</div>
+				{% if image %}
+				<div class="col-lg-4 col-md-6 col-sm-12 row-image-container-lg">
+					{% if rowLink %}
+						<a role="presentation" aria-hidden="true" href="{{ rowLink }} ">
+							<img alt="{{item.entity.field_row_layout_content_image.entity.field_media_image.alt}}" class="ucb-content-row-img-lg" src="{{item.entity.field_row_layout_content_image.entity.field_media_image.entity.fileuri|image_style('focal_image_wide')}}"></img>
+						</a>
+					{% else %}
+						{{ image|view }}
+					{% endif %}
+				</div>
+				{% endif %}
 			</div>
 		{% endfor %}
 		{% endif %}

--- a/templates/block/block--content-row.html.twig
+++ b/templates/block/block--content-row.html.twig
@@ -154,7 +154,7 @@
 						<div class="col-lg-7">
 							<div class="feature-row-image-container feature-row-fill">
 								{% if rowLink %}
-									<a href="{{ rowLink }} ">
+									<a role="presentation" aria-hidden="true" href="{{ rowLink }} ">
 										{{ item.entity.field_row_layout_content_image|view }}
 									</a>
 								{% else %}

--- a/templates/block/block--content-row.html.twig
+++ b/templates/block/block--content-row.html.twig
@@ -88,33 +88,8 @@
 			{% for key, item in content['#block_content'].field_row_layout_content %}
 				{% set oddOrEven = loop.index is odd ? 'odd' : 'even' %}
 				{% set rowLink = item.entity.field_row_layout_content_link.0.url|render %}
-				<div class="row d-flex row-content ucb-teaser-lg-row ucb-teaser-lg-row-{{oddOrEven}}">
+				<div class="row d-flex row-content ucb-teaser-lg-row ucb-teaser-lg-alternate ucb-teaser-lg-row-{{oddOrEven}}">
 					{% set image = item.entity.field_row_layout_content_image.0 %}
-					{% if (loop.index is odd) %}
-						{% if image %}
-						<div class="col-sm-5 col-xs-12 row-image-container-lg">
-							{% if rowLink %}
-								<a role="presentation" aria-hidden="true" href="{{ rowLink }} ">
-									<img alt="{{item.entity.field_row_layout_content_image.entity.field_media_image.alt}}" class="ucb-content-row-img-lg" src="{{item.entity.field_row_layout_content_image.entity.field_media_image.entity.fileuri|image_style('focal_image_wide')}}"></img>
-								</a>
-							{% else %}
-								{{ image|view }}
-							{% endif %}
-						</div>
-						<div class="col-sm-7 col-xs-12 row-text-container">
-						{% else %}
-						<div class="col-12 row-text-container">
-						{% endif %}
-							{% if rowLink %}
-								<a href="{{ rowLink }} ">
-									<h3>{{ item.entity.field_row_layout_content_title.0.value }}</h3>
-								</a>
-							{% else %}
-								<h3>{{ item.entity.field_row_layout_content_title.0.value }}</h3>
-							{% endif %}
-							{{item.entity.field_row_layout_content_text|view}}
-						</div>
-					{% else %}
 						<div class="{{ image ? 'col-sm-7 col-xs-12' : 'col-12' }} row-text-container">
 							{% if rowLink %}
 								<a href="{{ rowLink }} ">
@@ -128,7 +103,7 @@
 						{% if image %}
 						<div class="col-sm-5 col-xs-12 row-image-container-lg">
 							{% if rowLink %}
-								<a href="{{ rowLink }} ">
+								<a role="presentation" aria-hidden="true" href="{{ rowLink }} ">
 									<img alt="{{item.entity.field_row_layout_content_image.entity.field_media_image.alt}}" class="ucb-content-row-img-lg" src="{{item.entity.field_row_layout_content_image.entity.field_media_image.entity.fileuri|image_style('focal_image_wide')}}"></img>
 								</a>
 							{% else %}
@@ -136,7 +111,6 @@
 							{% endif %}
 						</div>
 						{% endif %}
-					{% endif %}
 				</div>
 			{% endfor %}
 			{# Tiles Row Layout #}

--- a/templates/block/block--content-row.html.twig
+++ b/templates/block/block--content-row.html.twig
@@ -118,21 +118,7 @@
 			{% for key, item in content['#block_content'].field_row_layout_content %}
 				{% set rowLink = item.entity.field_row_layout_content_link.0.url|render %}
 				{% set tileBackground = "height:100%;background-image:url('" ~ file_url(item.entity.field_row_layout_content_image.entity.field_media_image.entity.fileuri|image_style('focal_image_square')) ~ "');background-repeat:no-repeat;background-position:center;background-size:cover;" %}
-				<div class="row d-flex row-content-tiles">
-					{% if (loop.index is odd) %}
-						<div class="col-6 row-image-container-tile-odd">
-							{% if rowLink %}
-								<a href="{{ rowLink }} ">
-									{# TO DO -- Make this a DIV with background img #}
-									{# {{ item.entity.field_row_layout_content_image|view }} #}
-									<div class="ucb-content-row-left" style={{tileBackground}}></div>
-								</a>
-							{% else %}
-								{# TO DO -- Make this a DIV with background img #}
-								{# {{ item.entity.field_row_layout_content_image|view }} #}
-								<div style={{tileBackground}}></div>
-							{% endif %}
-						</div>
+				<div class="row d-flex row-content-tiles {{(loop.index is odd) ? 'row-content-tile-odd' : 'row-content-tile-even'}}">
 						<div class="col-6 row-text-container-tile">
 							{% if rowLink %}
 								<a href="{{ rowLink }} ">
@@ -143,20 +129,9 @@
 							{% endif %}
 							{{item.entity.field_row_layout_content_text|view}}
 						</div>
-					{% else %}
-						<div class="col-6 row-text-container-tile">
+						<div class="col-6 row-image-container-tile-{{(loop.index is odd) ? 'odd' : 'even'}}">
 							{% if rowLink %}
-								<a href="{{ rowLink }} ">
-									<h3>{{item.entity.field_row_layout_content_title.0.value }}</h3>
-								</a>
-							{% else %}
-								<h3>{{item.entity.field_row_layout_content_title.0.value }}</h3>
-							{% endif %}
-							{{item.entity.field_row_layout_content_text|view}}
-						</div>
-						<div class="col-6 row-image-container-tile-even">
-							{% if rowLink %}
-								<a href="{{ rowLink }} ">
+								<a role="presentation" aria-hidden="true" href="{{ rowLink }} ">
 									{# TO DO -- Make this a DIV with background img #}
 									{# {{ item.entity.field_row_layout_content_image|view }} #}
 									<div style="{{tileBackground}}"></div>
@@ -167,7 +142,6 @@
 								<div style="{{tileBackground}}"></div>
 							{% endif %}
 						</div>
-					{% endif %}
 				</div>
 			{% endfor %}
 			{# Features Row Layout #}


### PR DESCRIPTION
### Content Row: Accessibility Fixes
- Adjusts DOM order for consistent assistive readability on the `Content Row` display options and reorganizes using pure CSS where applicable
- Adds `role="presentation" and aria-hidden="true"` to links on images so only the title link is read with assistive technologies

Resolves #907 