### PR TITLE
Add in base font colors for collection grid

### DIFF
--- a/css/block/ucb-collections-block.css
+++ b/css/block/ucb-collections-block.css
@@ -212,12 +212,12 @@
   color: #fff;
 }
 
-.ucb-collection-card-container a {
+.collection-grid-container .ucb-collection-card-container a {
   color: #0277BD;
 }
-.ucb-collection-card-container a:hover {
+.collection-grid-container .ucb-collection-card-container a:hover {
   color: #E51C23;
 }
-.ucb-collection-card-container {
+.collection-grid-container .ucb-collection-card-container {
   color: #000;
 }

--- a/css/block/ucb-collections-block.css
+++ b/css/block/ucb-collections-block.css
@@ -211,3 +211,13 @@
   background-color: #424242;
   color: #fff;
 }
+
+.ucb-collection-card-container a {
+  color: #0277BD;
+}
+.ucb-collection-card-container a:hover {
+  color: #E51C23;
+}
+.ucb-collection-card-container {
+  color: #000;
+}


### PR DESCRIPTION
Resolves CuBoulder/tiamat-theme#929 and resolves CuBoulder/tiamat-theme#930.
Adds base font colors for links and text to fix bugs related to background styles.