### PR TITLE
Removes white margins from Dark Mode Article

### DIFF
--- a/css/ucb-article-dark.css
+++ b/css/ucb-article-dark.css
@@ -30,8 +30,14 @@ main {
 }
 
 article.ucb-page-style-dark {
-	padding-top: 0.5em;
-	padding-bottom: 0.5em;
+	padding-top: 1.75em;
+	padding-bottom: 1.75em;
+}
+
+/* Override for the content wrapper on Dark Mode Articles to maintain background color */
+article.ucb-page-style-dark.ucb-content-wrapper{
+  margin-top: 0px;
+  margin-bottom: 0px;
 }
 
 /* div#block-boulderd9-base-content::after {


### PR DESCRIPTION
Previously, a margin wrapper would apply white top and bottom margins to a dark mode article creating horizontal white bars surrounding content. This has been adjusted so the dark background color spans the entire article.

Resolves #946 