### PR TITLE
Removes unused `sr-only` element from article lists

### DIFF
--- a/js/ucb-article-list-block.js
+++ b/js/ucb-article-list-block.js
@@ -1,580 +1,564 @@
 class ArticleListBlockElement extends HTMLElement {
-	constructor() {
-		super();
-        // Count, display and JSON API Endpoint
-        var count = this.getAttribute('count');
-        var display = this.getAttribute('display');
-        var API = this.getAttribute('jsonapi');
-        // Exclusions are done on the JS side, get into arrays. Blank if no exclusions
-        var excludeCatArray = this.getAttribute('exCats').split(",").map(Number);
-        var excludeTagArray = this.getAttribute('exTags').split(",").map(Number);
+  constructor() {
+    super();
+    // Count, display and JSON API Endpoint
+    var count = this.getAttribute('count');
+    var display = this.getAttribute('display');
+    var API = this.getAttribute('jsonapi');
+    // Exclusions are done on the JS side, get into arrays. Blank if no exclusions
+    var excludeCatArray = this.getAttribute('exCats').split(",").map(Number);
+    var excludeTagArray = this.getAttribute('exTags').split(",").map(Number);
 
-        fetch(API)
-            .then(this.handleError)
-            .then((data) => this.build(data, count, display, excludeCatArray,excludeTagArray))
-            .catch(Error=> {
-              console.error('There was an error fetching data from the API - Please try again later.')
-              console.error(Error)
-              this.toggleMessage('ucb-al-loading')
-              this.toggleMessage('ucb-al-api-error', "block")
-            });
+    fetch(API)
+      .then(this.handleError)
+      .then((data) => this.build(data, count, display, excludeCatArray, excludeTagArray))
+      .catch(Error => {
+        console.error('There was an error fetching data from the API - Please try again later.');
+        console.error(Error);
+        this.toggleMessage('ucb-al-loading');
+        this.toggleMessage('ucb-al-api-error', "block");
+      });
+  }
+
+  async build(data, count, display, excludeCatArray, excludeTagArray, finalArticles = []) {
+    // More than 10 articles? This sets up the next call if there's more articles to be retrieved but not enough post-filters
+    let NEXTJSONURL = "";
+    if (data.links.next) {
+      let nextURL = data.links.next.href.split("/jsonapi/");
+      NEXTJSONURL = `/jsonapi/${nextURL[1]}`;
+    } else {
+      NEXTJSONURL = "";
     }
 
-   async build(data, count, display, excludeCatArray, excludeTagArray, finalArticles = []){
-      // More than 10 articles? This sets up the next call if there's more articles to be retrieved but not enough post-filters
-        let NEXTJSONURL = "";
-        if(data.links.next) {
-            let nextURL = data.links.next.href.split("/jsonapi/");
-            NEXTJSONURL = `/jsonapi/${nextURL[1]}`;
+    // If no Articles retrieved...
+    if (data.data.length == 0) {
+      this.toggleMessage('ucb-al-loading');
+      this.toggleMessage('ucb-al-error', "block");
+      console.warn('No Articles retrieved - please check your inclusion filters and try again');
+    } else {
+      // Below objects are needed to match images with their corresponding articles. There are two endpoints => data.data (article) and data.included (incl. media), both needed to associate a media library image with its respective article
+      let idObj = {};
+      let altObj = {};
+      let wideObj = {};
+      // Remove any blanks from our articles before map
+      if (data.included) {
+        // removes all other included data besides images in our included media
+        let idFilterData = data.included.filter((item) => {
+          return item.type == "media--image";
+        });
+
+        let altFilterData = data.included.filter((item) => {
+          return item.type == 'file--file';
+        });
+        // finds the focial point version of the thumbnail
+        altFilterData.map((item) => {
+          // checks if consumer is working, else default to standard image instead of focal image
+          if (item.links.focal_image_square != undefined) {
+            altObj[item.id] = item.links.focal_image_square.href
+            // This is used if a user selects the "Wide" image style
+            wideObj[item.id] = item.links.focal_image_wide.href
           } else {
-            NEXTJSONURL = "";
+            altObj[item.id] = item.attributes.uri.url
           }
+        });
 
-          // If no Articles retrieved...
-        if(data.data.length == 0){
-            this.toggleMessage('ucb-al-loading')
-            this.toggleMessage('ucb-al-error',"block")
-            console.warn('No Articles retrieved - please check your inclusion filters and try again')
-        } else {
-        // Below objects are needed to match images with their corresponding articles. There are two endpoints => data.data (article) and data.included (incl. media), both needed to associate a media library image with its respective article
-        let idObj = {};
-        let altObj = {};
-        let wideObj = {};
-        // Remove any blanks from our articles before map
-        if (data.included) {
-          // removes all other included data besides images in our included media
-          let idFilterData = data.included.filter((item) => {
-            return item.type == "media--image";
-          })
-
-          let altFilterData = data.included.filter((item) => {
-            return item.type == 'file--file';
-          });
-          // finds the focial point version of the thumbnail
-          altFilterData.map((item)=>{
-            // checks if consumer is working, else default to standard image instead of focal image
-            if(item.links.focal_image_square != undefined){
-              altObj[item.id] = item.links.focal_image_square.href
-              // This is used if a user selects the "Wide" image style
-              wideObj[item.id] = item.links.focal_image_wide.href
-            } else {
-              altObj[item.id] = item.attributes.uri.url
-            }
-        })
-
-          // using the image-only data, creates the idObj =>  key: thumbnail id, value : data id
-          idFilterData.map((pair) => {
-            idObj[pair.id] = pair.relationships.thumbnail.data.id;
-          })
-        }
-
-        // Iterate over each Article
-        await Promise.all(data.data.map(async (item) => {
-          let thisArticleCats = [];
-            let thisArticleTags = [];
-            // // loop through and grab all of the categories
-            if (item.relationships.field_ucb_article_categories) {
-              for (let i = 0; i < item.relationships.field_ucb_article_categories.data.length; i++) {
-                thisArticleCats.push(
-                  item.relationships.field_ucb_article_categories.data[i].meta
-                    .drupal_internal__target_id
-                )
-              }
-            }  
-            // // loop through and grab all of the tags
-            if (item.relationships.field_ucb_article_tags) {
-              for (var i = 0; i < item.relationships.field_ucb_article_tags.data.length; i++) {
-                thisArticleTags.push(item.relationships.field_ucb_article_tags.data[i].meta.drupal_internal__target_id)
-              }
-            }
-
-            let doesIncludeCat = thisArticleCats;
-            let doesIncludeTag = thisArticleTags;
-  
-            // check to see if we need to filter on categories
-            if (excludeCatArray.length && thisArticleCats.length) {
-              doesIncludeCat = thisArticleCats.filter((element) =>
-                excludeCatArray.includes(element)
-              )
-            }
-            // check to see if we need to filter on tags
-            if (excludeTagArray.length && thisArticleTags.length) {
-              doesIncludeTag = thisArticleTags.filter((element) =>
-                excludeTagArray.includes(element)
-              )
-            }
-
-            // If there's no categories or tags that are in the exclusions, proceed
-            if (doesIncludeCat.length == 0 && doesIncludeTag.length == 0) {
-                // okay to render
-                let bodyAndImageId = item.relationships.field_ucb_article_content.data.length ? item.relationships.field_ucb_article_content.data[0].id : "";
-                let body = item.attributes.field_ucb_article_summary ? item.attributes.field_ucb_article_summary : "";
-                body = body.trim();
-                let imageSrc = "";
-                let imageSrcWide = "";
-
-                if (!body.length && bodyAndImageId != "") {
-                  body = await this.getArticleParagraph(bodyAndImageId);
-                }
-      
-                  // if no thumbnail, show no image
-                  if (!item.relationships.field_ucb_article_thumbnail.data) {
-                    imageSrc = "";
-                  } else {
-                    //Use the idObj as a memo to add the corresponding image url
-                    let thumbId = item.relationships.field_ucb_article_thumbnail.data.id;
-                    imageSrc = altObj[idObj[thumbId]];
-                    imageSrcWide = wideObj[idObj[thumbId]]
-                  }
-      
-                  //Date - make human readable
-                  const options = { year: 'numeric', month: 'short', day: 'numeric' };
-                  let date = new Date(item.attributes.created).toLocaleDateString('en-us', options);
-                  let title = item.attributes.title;
-                  let link = item.attributes.path.alias;
-
-                  // Create an Article Object for programatic rendering
-                  const article = {
-                    title,
-                    link,
-                    image: imageSrc,
-                    imageWide: imageSrcWide,
-                    date,
-                    body,
-                  }
-                  // Adds the article object to the final array of articles chosen
-                  finalArticles.push(article)
-            }
-        }));
-        // Case for not enough articles selected and extra articles available
-        if(finalArticles.length < count && NEXTJSONURL){
-            fetch(NEXTJSONURL).then(this.handleError)
-            .then((data) => this.build(data, count, display, excludeCatArray, excludeTagArray, finalArticles))
-            .catch(Error=> {
-              console.error('There was an error fetching data from the API - Please try again later.')
-              console.error(Error)
-              this.toggleMessage('ucb-al-loading')
-              this.toggleMessage('ucb-al-api-error', "block")
-            });
-        }
-
-        // If no chosen articles and no other options, provide error
-        if(finalArticles.length === 0 && !NEXTJSONURL){
-          console.error('There are no available Articles that match the selected filters. Please adjust your filters and try again.')
-          this.toggleMessage('ucb-al-loading')
-          this.toggleMessage('ucb-al-error', "block")
-        }
-
-        // Case for Too many articles
-        if(finalArticles.length >= count || (finalArticles.length >= count && NEXTJSONURL)){
-          finalArticles.length = count
+        // using the image-only data, creates the idObj =>  key: thumbnail id, value : data id
+        idFilterData.map((pair) => {
+          idObj[pair.id] = pair.relationships.thumbnail.data.id;
+        });
       }
 
-        // Have articles and want to proceed
-        if((finalArticles.length >= 0 && !NEXTJSONURL) || (finalArticles.length == count && NEXTJSONURL)){
-          this.renderDisplay(display, finalArticles)
+      // Iterate over each Article
+      await Promise.all(data.data.map(async (item) => {
+        let thisArticleCats = [];
+        let thisArticleTags = [];
+        // // loop through and grab all of the categories
+        if (item.relationships.field_ucb_article_categories) {
+          for (let i = 0; i < item.relationships.field_ucb_article_categories.data.length; i++) {
+            thisArticleCats.push(
+              item.relationships.field_ucb_article_categories.data[i].meta
+                .drupal_internal__target_id
+            );
+          }
         }
-    }
-}
-    // Responsible for fetching & processing the body of the Article if no summary provided
-    async getArticleParagraph(id) {
-      if (!id) {
-          return "";
-      }
-      
-      const response = await fetch(`/jsonapi/paragraph/article_content/${id}`);
-      if (!response.ok) {
-          throw new Error('Failed to fetch article paragraph');
-      }
+        // // loop through and grab all of the tags
+        if (item.relationships.field_ucb_article_tags) {
+          for (var i = 0; i < item.relationships.field_ucb_article_tags.data.length; i++) {
+            thisArticleTags.push(item.relationships.field_ucb_article_tags.data[i].meta.drupal_internal__target_id);
+          }
+        }
 
-      const data = await response.json();
-      
-      let htmlStrip = data.data.attributes.field_article_text.processed.replace(
-          /<\/?[^>]+(>|$)/g,
-          ""
-      );
-      let lineBreakStrip = htmlStrip.replace(/(\r\n|\n|\r)/gm, "");
-      let trimmedString = lineBreakStrip.substr(0, 250);
-      
-      if (trimmedString.length > 100) {
-          trimmedString = trimmedString.substr(
-              0,
-              Math.min(
-                  trimmedString.length,
-                  trimmedString.lastIndexOf(" ")
-              )
+        let doesIncludeCat = thisArticleCats;
+        let doesIncludeTag = thisArticleTags;
+
+        // check to see if we need to filter on categories
+        if (excludeCatArray.length && thisArticleCats.length) {
+          doesIncludeCat = thisArticleCats.filter((element) =>
+            excludeCatArray.includes(element)
           );
+        }
+        // check to see if we need to filter on tags
+        if (excludeTagArray.length && thisArticleTags.length) {
+          doesIncludeTag = thisArticleTags.filter((element) =>
+            excludeTagArray.includes(element)
+          );
+        }
+
+        // If there's no categories or tags that are in the exclusions, proceed
+        if (doesIncludeCat.length == 0 && doesIncludeTag.length == 0) {
+          // okay to render
+          let bodyAndImageId = item.relationships.field_ucb_article_content.data.length ? item.relationships.field_ucb_article_content.data[0].id : "";
+          let body = item.attributes.field_ucb_article_summary ? item.attributes.field_ucb_article_summary : "";
+          body = body.trim();
+          let imageSrc = "";
+          let imageSrcWide = "";
+
+          if (!body.length && bodyAndImageId != "") {
+            body = await this.getArticleParagraph(bodyAndImageId);
+          }
+
+          // if no thumbnail, show no image
+          if (!item.relationships.field_ucb_article_thumbnail.data) {
+            imageSrc = "";
+          } else {
+            //Use the idObj as a memo to add the corresponding image url
+            let thumbId = item.relationships.field_ucb_article_thumbnail.data.id;
+            imageSrc = altObj[idObj[thumbId]];
+            imageSrcWide = wideObj[idObj[thumbId]]
+          }
+
+          //Date - make human readable
+          const options = { year: 'numeric', month: 'short', day: 'numeric' };
+          let date = new Date(item.attributes.created).toLocaleDateString('en-us', options);
+          let title = item.attributes.title;
+          let link = item.attributes.path.alias;
+
+          // Create an Article Object for programatic rendering
+          const article = {
+            title,
+            link,
+            image: imageSrc,
+            imageWide: imageSrcWide,
+            date,
+            body,
+          }
+          // Adds the article object to the final array of articles chosen
+          finalArticles.push(article);
+        }
+      }));
+      // Case for not enough articles selected and extra articles available
+      if (finalArticles.length < count && NEXTJSONURL) {
+        fetch(NEXTJSONURL).then(this.handleError)
+          .then((data) => this.build(data, count, display, excludeCatArray, excludeTagArray, finalArticles))
+          .catch(Error => {
+            console.error('There was an error fetching data from the API - Please try again later.');
+            console.error(Error);
+            this.toggleMessage('ucb-al-loading');
+            this.toggleMessage('ucb-al-api-error', "block");
+          });
       }
 
-      return trimmedString + "...";
+      // If no chosen articles and no other options, provide error
+      if (finalArticles.length === 0 && !NEXTJSONURL) {
+        console.error('There are no available Articles that match the selected filters. Please adjust your filters and try again.');
+        this.toggleMessage('ucb-al-loading');
+        this.toggleMessage('ucb-al-error', "block");
+      }
+
+      // Case for Too many articles
+      if (finalArticles.length >= count || (finalArticles.length >= count && NEXTJSONURL)) {
+        finalArticles.length = count
+      }
+
+      // Have articles and want to proceed
+      if ((finalArticles.length >= 0 && !NEXTJSONURL) || (finalArticles.length == count && NEXTJSONURL)) {
+        this.renderDisplay(display, finalArticles);
+      }
+    }
+  }
+  // Responsible for fetching & processing the body of the Article if no summary provided
+  async getArticleParagraph(id) {
+    if (!id) {
+      return "";
     }
 
-
-    // Responsible for calling the render function of the appropriate display
-    renderDisplay(display, articleArray){
-          switch (display) {
-              case 'feature-wide':
-                  this.renderFeatureWide(articleArray)
-                  break;
-              case 'feature-large':
-                  this.renderFeatureFull(articleArray)
-                  break;
-              case 'teaser':
-                  this.renderTeaser(articleArray)
-                  break;
-              case 'title-thumbnail':
-                  this.renderTitleThumb(articleArray)
-                  break;
-              case 'title-only':
-                  this.renderTitleOnly(articleArray)
-                  break;
-              default:
-                  this.renderTeaser(articleArray)
-                  break;
-          }
-
+    const response = await fetch(`/jsonapi/paragraph/article_content/${id}`);
+    if (!response.ok) {
+      throw new Error('Failed to fetch article paragraph');
     }
 
-    // renderX functions are responsible for taking the final array of Articles and displaying them appropriately
-    renderFeatureFull(articleArray){
-      var container = document.createElement('div')
-      container.classList = 'ucb-article-list-block'
+    const data = await response.json();
 
-      articleArray.forEach(article=>{
-          // Article Data
-          var articleDate = article.date;
-          var articleLink = article.link;
-          var articleImgSrc = article.image;
-          var articleTitle = article.title;
-          var articleSumm = article.body;
+    let htmlStrip = data.data.attributes.field_article_text.processed.replace(
+      /<\/?[^>]+(>|$)/g,
+      ""
+    );
+    let lineBreakStrip = htmlStrip.replace(/(\r\n|\n|\r)/gm, "");
+    let trimmedString = lineBreakStrip.substr(0, 250);
 
-          // Create and Append Elements
-          var article = document.createElement('article');
-          article.classList = 'ucb-article-card';
-
-
-          if(articleImgSrc){
-            var imgDiv = document.createElement('div');
-            var imgLink = document.createElement('a');
-            imgLink.href = articleLink;
-            imgLink.setAttribute('role', 'presentation');
-            imgLink.setAttribute('aria-hidden', 'true');
-            
-            var articleImg = document.createElement('img')
-            articleImg.classList = 'col-sm-12 ucb-article-card-img-full'
-            articleImg.src = articleImgSrc;
-  
-            imgLink.appendChild(articleImg);
-            imgDiv.appendChild(imgLink);
-  
-            article.appendChild(imgDiv);
-          }
-
-          var articleBody = document.createElement('div');
-          articleBody.classList = 'col-sm-12 ucb-article-card-data';
-
-          var headerLink = document.createElement('a');
-          headerLink.href = articleLink;
-
-          var articleHeader = document.createElement('h3');
-          articleHeader.classList = 'ucb-article-card-title-feature'
-          articleHeader.innerText = articleTitle;
-
-          headerLink.appendChild(articleHeader);
-
-          var date = document.createElement('span');
-          date.classList = 'ucb-article-card-date'
-          date.innerText = articleDate;
-
-          var articleSummary = document.createElement('p');
-          articleSummary.innerText = articleSumm;
-          articleSummary.classList = 'ucb-article-card-summary'
-
-          var readMore = document.createElement('a');
-          readMore.href = articleLink;
-          readMore.classList = 'ucb-article-card-read-more'
-          readMore.innerText = `Read More`;
-          readMore.setAttribute('aria-hidden', 'true');
-
-          // Sr-only text
-          var srOnly = document.createElement('span')
-          srOnly.className = 'sr-only'
-          srOnly.innerText = ` about ${articleTitle}`
-          readMore.appendChild(srOnly)
-
-          articleBody.appendChild(headerLink)
-          articleBody.appendChild(date)
-          articleBody.appendChild(articleSummary)
-          articleBody.appendChild(readMore)
-
-          article.appendChild(articleBody)
-
-          this.toggleMessage('ucb-al-loading')
-          container.appendChild(article)
-      })
-      this.appendChild(container)
-    }
-    renderFeatureWide(articleArray){
-      var container = document.createElement('div')
-      container.classList = 'ucb-article-list-block'
-
-      articleArray.forEach(article=>{
-          // Article Data
-          var articleDate = article.date;
-          var articleLink = article.link;
-          var articleImgSrc = article.imageWide;
-          var articleTitle = article.title;
-          var articleSumm = article.body;
-
-          // Create and Append Elements
-          var article = document.createElement('article');
-          article.classList = 'ucb-article-card';
-          
-          if(articleImgSrc){
-            var imgDiv = document.createElement('div');
-            var imgLink = document.createElement('a');
-            imgLink.href = articleLink;
-            imgLink.setAttribute('role', 'presentation');
-            imgLink.setAttribute('aria-hidden', 'true');
-            
-            var articleImg = document.createElement('img')
-            articleImg.classList = 'ucb-article-card-img-wide'
-            articleImg.src = articleImgSrc;
-  
-            imgLink.appendChild(articleImg);
-            imgDiv.appendChild(imgLink);
-  
-            article.appendChild(imgDiv);
-          }
-
-          var articleBody = document.createElement('div');
-          articleBody.classList = 'col-sm-12 ucb-article-card-data';
-
-          var headerLink = document.createElement('a');
-          headerLink.href = articleLink;
-
-          var articleHeader = document.createElement('h3');
-          articleHeader.classList = 'ucb-article-card-title-feature'
-          articleHeader.innerText = articleTitle;
-
-          headerLink.appendChild(articleHeader);
-
-          var date = document.createElement('span');
-          date.classList = 'ucb-article-card-date'
-          date.innerText = articleDate;
-
-          var articleSummary = document.createElement('p');
-          articleSummary.innerText = articleSumm;
-          articleSummary.classList = 'ucb-article-card-summary'
-
-          var readMore = document.createElement('a');
-          readMore.href = articleLink;
-          readMore.classList = 'ucb-article-card-read-more'
-          readMore.innerText = `Read More`;
-          readMore.setAttribute('aria-hidden', 'true');
-          // Sr-only text
-          var srOnly = document.createElement('span')
-          srOnly.className = 'sr-only'
-          srOnly.innerText = ` about ${articleTitle}`
-          readMore.appendChild(srOnly)
-
-          articleBody.appendChild(headerLink)
-          articleBody.appendChild(date)
-          articleBody.appendChild(articleSummary)
-          articleBody.appendChild(readMore)
-
-          article.appendChild(articleBody)
-
-          this.toggleMessage('ucb-al-loading')
-          container.appendChild(article)
-      })
-      this.appendChild(container)
-    }
-    renderTitleThumb(articleArray){
-        var container = document.createElement('div')
-        container.classList = 'ucb-article-list-block container'
-
-        articleArray.forEach(article=>{
-            // Article Data
-            var articleLink = article.link;
-            var articleImgSrc = article.image;
-            var articleTitle = article.title;
-
-            // Create and Append Elements
-            var article = document.createElement('article');
-            article.classList = 'ucb-article-card row';
-            if(articleImgSrc){
-              var imgDiv = document.createElement('div');
-              imgDiv.classList = 'ucb-article-card-img title-thumbnail-img';
-  
-              var imgLink = document.createElement('a');
-              imgLink.href = articleLink;
-              imgLink.setAttribute('role', 'presentation');
-              imgLink.setAttribute('aria-hidden', 'true');
-
-              var articleImg = document.createElement('img')
-              articleImg.src = articleImgSrc;
-  
-              imgLink.appendChild(articleImg);
-              imgDiv.appendChild(imgLink);
-  
-              article.appendChild(imgDiv);
-            }
-
-            var articleBody = document.createElement('div');
-            if(articleImgSrc){
-              articleBody.classList = 'col px-3 ucb-article-card-data';
-            } else {
-              articleBody.classList = 'col ucb-article-card-data';
-            }
-
-            var headerLink = document.createElement('a');
-            headerLink.href = articleLink;
-            headerLink.innerText = articleTitle
-
-            articleBody.appendChild(headerLink)
-
-            article.appendChild(articleBody)
-
-            this.toggleMessage('ucb-al-loading')
-            container.appendChild(article)
-        })
-        this.appendChild(container)
-    }
-    renderTitleOnly(articleArray){
-      var container = document.createElement('div')
-      container.classList = 'ucb-article-list-block'
-
-      articleArray.forEach(article=>{
-          // Article Data
-          var articleLink = article.link;
-          var articleTitle = article.title;
-
-          // Create and Append Elements
-          var article = document.createElement('article');
-          article.classList = 'ucb-article-card-title-only';
-    
-          var articleBody = document.createElement('div');
-          articleBody.classList = 'col-sm-12 ucb-article-card-data';
-
-          var headerLink = document.createElement('a');
-          headerLink.href = articleLink;
-          headerLink.innerText = articleTitle
-
-          articleBody.appendChild(headerLink)
-
-          article.appendChild(articleBody)
-
-          this.toggleMessage('ucb-al-loading')
-          container.appendChild(article)
-      })
-      this.appendChild(container)
-    }
-    renderTeaser(articleArray){
-        var container = document.createElement('div')
-        container.classList = 'ucb-article-list-block container'
-
-        articleArray.forEach(article=>{
-            // Article Data
-            var articleDate = article.date;
-            var articleLink = article.link;
-            var articleImgSrc = article.image;
-            var articleTitle = article.title;
-            var articleSumm = article.body;
-
-            // Create and Append Elements
-            var article = document.createElement('article');
-            article.classList = 'ucb-article-card row';
-
-            if(articleImgSrc){
-              var imgDiv = document.createElement('div');
-              imgDiv.classList = 'ucb-article-card-img';
-  
-              var imgLink = document.createElement('a');
-              imgLink.href = articleLink;
-              imgLink.setAttribute('role', 'presentation');
-              imgLink.setAttribute('aria-hidden', 'true');
-              
-              var articleImg = document.createElement('img')
-              articleImg.src = articleImgSrc;
-  
-              imgLink.appendChild(articleImg);
-              imgDiv.appendChild(imgLink);
-  
-              article.appendChild(imgDiv);
-            } 
-
-            var articleBody = document.createElement('div');
-            if(articleImgSrc){
-              articleBody.classList = 'col px-3 ucb-article-card-data';
-            } else {
-              articleBody.classList = 'col ucb-article-card-data';
-            }
-
-            var headerStrong = document.createElement('strong');
-
-            var articleHeader = document.createElement('a');
-            articleHeader.classList = 'ucb-article-card-title-teaser'
-            articleHeader.href = articleLink;
-            articleHeader.innerText = articleTitle;
-
-            headerStrong.appendChild(articleHeader);
-
-            var date = document.createElement('span');
-            date.classList = 'ucb-article-card-date'
-            date.innerText = articleDate;
-
-            var articleSummary = document.createElement('p');
-            articleSummary.innerText = articleSumm;
-            articleSummary.classList = 'ucb-article-card-summary'
-
-            var readMore = document.createElement('a');
-            readMore.href = articleLink;
-            readMore.classList = 'ucb-article-card-read-more'
-            readMore.innerText = `Read More`;
-            readMore.setAttribute('aria-hidden', 'true');
-            // Sr-only text
-            var srOnly = document.createElement('span')
-            srOnly.className = 'sr-only'
-            srOnly.innerText = ` about ${articleTitle}`
-            readMore.appendChild(srOnly)
-
-            articleBody.appendChild(headerStrong)
-            articleBody.appendChild(date)
-            articleBody.appendChild(articleSummary)
-            articleBody.appendChild(readMore)
-
-            article.appendChild(articleBody)
-
-            this.toggleMessage('ucb-al-loading')
-            container.appendChild(article)
-        })
-        this.appendChild(container)
-
+    if (trimmedString.length > 100) {
+      trimmedString = trimmedString.substr(
+        0,
+        Math.min(
+          trimmedString.length,
+          trimmedString.lastIndexOf(" ")
+        )
+      );
     }
 
-    // Used to toggle error messages and loader
-    toggleMessage(id, display = "none") {
-        if (id) {
-          var toggle = this.querySelector(`#${id}`);
-          if (toggle) {
-            if (display === "block") {
-              toggle.style.display = "block";
-            } else {
-              toggle.style.display = "none";
-            }
-          }
-        }
+    return trimmedString + "...";
+  }
+
+
+  // Responsible for calling the render function of the appropriate display
+  renderDisplay(display, articleArray) {
+    switch (display) {
+      case 'feature-wide':
+        this.renderFeatureWide(articleArray);
+        break;
+      case 'feature-large':
+        this.renderFeatureFull(articleArray);
+        break;
+      case 'teaser':
+        this.renderTeaser(articleArray);
+        break;
+      case 'title-thumbnail':
+        this.renderTitleThumb(articleArray);
+        break;
+      case 'title-only':
+        this.renderTitleOnly(articleArray);
+        break;
+      default:
+        this.renderTeaser(articleArray);
+        break;
     }
 
-    // Used for error handling within the API response
-    handleError = response => {
-        if (!response.ok) { 
-           throw new Error;
+  }
+
+  // renderX functions are responsible for taking the final array of Articles and displaying them appropriately
+  renderFeatureFull(articleArray) {
+    var container = document.createElement('div');
+    container.classList = 'ucb-article-list-block';
+
+    articleArray.forEach(article => {
+      // Article Data
+      var articleDate = article.date;
+      var articleLink = article.link;
+      var articleImgSrc = article.image;
+      var articleTitle = article.title;
+      var articleSumm = article.body;
+
+      // Create and Append Elements
+      var article = document.createElement('article');
+      article.classList = 'ucb-article-card';
+
+
+      if (articleImgSrc) {
+        var imgDiv = document.createElement('div');
+        var imgLink = document.createElement('a');
+        imgLink.href = articleLink;
+        imgLink.setAttribute('role', 'presentation');
+        imgLink.setAttribute('aria-hidden', 'true');
+
+        var articleImg = document.createElement('img');
+        articleImg.classList = 'col-sm-12 ucb-article-card-img-full';
+        articleImg.src = articleImgSrc;
+
+        imgLink.appendChild(articleImg);
+        imgDiv.appendChild(imgLink);
+
+        article.appendChild(imgDiv);
+      }
+
+      var articleBody = document.createElement('div');
+      articleBody.classList = 'col-sm-12 ucb-article-card-data';
+
+      var headerLink = document.createElement('a');
+      headerLink.href = articleLink;
+
+      var articleHeader = document.createElement('h3');
+      articleHeader.classList = 'ucb-article-card-title-feature';
+      articleHeader.innerText = articleTitle;
+
+      headerLink.appendChild(articleHeader);
+
+      var date = document.createElement('span');
+      date.classList = 'ucb-article-card-date';
+      date.innerText = articleDate;
+
+      var articleSummary = document.createElement('p');
+      articleSummary.innerText = articleSumm;
+      articleSummary.classList = 'ucb-article-card-summary';
+
+      var readMore = document.createElement('a');
+      readMore.href = articleLink;
+      readMore.classList = 'ucb-article-card-read-more';
+      readMore.innerText = 'Read More';
+      readMore.setAttribute('aria-hidden', 'true');
+
+      articleBody.appendChild(headerLink);
+      articleBody.appendChild(date);
+      articleBody.appendChild(articleSummary);
+      articleBody.appendChild(readMore);
+
+      article.appendChild(articleBody);
+
+      this.toggleMessage('ucb-al-loading');
+      container.appendChild(article);
+    });
+    this.appendChild(container);
+  }
+  renderFeatureWide(articleArray) {
+    var container = document.createElement('div');
+    container.classList = 'ucb-article-list-block';
+
+    articleArray.forEach(article => {
+      // Article Data
+      var articleDate = article.date;
+      var articleLink = article.link;
+      var articleImgSrc = article.imageWide;
+      var articleTitle = article.title;
+      var articleSumm = article.body;
+
+      // Create and Append Elements
+      var article = document.createElement('article');
+      article.classList = 'ucb-article-card';
+
+      if (articleImgSrc) {
+        var imgDiv = document.createElement('div');
+        var imgLink = document.createElement('a');
+        imgLink.href = articleLink;
+        imgLink.setAttribute('role', 'presentation');
+        imgLink.setAttribute('aria-hidden', 'true');
+
+        var articleImg = document.createElement('img');
+        articleImg.classList = 'ucb-article-card-img-wide';
+        articleImg.src = articleImgSrc;
+
+        imgLink.appendChild(articleImg);
+        imgDiv.appendChild(imgLink);
+
+        article.appendChild(imgDiv);
+      }
+
+      var articleBody = document.createElement('div');
+      articleBody.classList = 'col-sm-12 ucb-article-card-data';
+
+      var headerLink = document.createElement('a');
+      headerLink.href = articleLink;
+
+      var articleHeader = document.createElement('h3');
+      articleHeader.classList = 'ucb-article-card-title-feature';
+      articleHeader.innerText = articleTitle;
+
+      headerLink.appendChild(articleHeader);
+
+      var date = document.createElement('span');
+      date.classList = 'ucb-article-card-date';
+      date.innerText = articleDate;
+
+      var articleSummary = document.createElement('p');
+      articleSummary.innerText = articleSumm;
+      articleSummary.classList = 'ucb-article-card-summary';
+
+      var readMore = document.createElement('a');
+      readMore.href = articleLink;
+      readMore.classList = 'ucb-article-card-read-more';
+      readMore.innerText = 'Read More';
+      readMore.setAttribute('aria-hidden', 'true');
+
+      articleBody.appendChild(headerLink);
+      articleBody.appendChild(date);
+      articleBody.appendChild(articleSummary);
+      articleBody.appendChild(readMore);
+
+      article.appendChild(articleBody);
+
+      this.toggleMessage('ucb-al-loading');
+      container.appendChild(article);
+    });
+    this.appendChild(container);
+  }
+  renderTitleThumb(articleArray) {
+    var container = document.createElement('div');
+    container.classList = 'ucb-article-list-block container';
+
+    articleArray.forEach(article => {
+      // Article Data
+      var articleLink = article.link;
+      var articleImgSrc = article.image;
+      var articleTitle = article.title;
+
+      // Create and Append Elements
+      var article = document.createElement('article');
+      article.classList = 'ucb-article-card row';
+      if (articleImgSrc) {
+        var imgDiv = document.createElement('div');
+        imgDiv.classList = 'ucb-article-card-img title-thumbnail-img';
+
+        var imgLink = document.createElement('a');
+        imgLink.href = articleLink;
+        imgLink.setAttribute('role', 'presentation');
+        imgLink.setAttribute('aria-hidden', 'true');
+
+        var articleImg = document.createElement('img');
+        articleImg.src = articleImgSrc;
+
+        imgLink.appendChild(articleImg);
+        imgDiv.appendChild(imgLink);
+
+        article.appendChild(imgDiv);
+      }
+
+      var articleBody = document.createElement('div');
+      if (articleImgSrc) {
+        articleBody.classList = 'col px-3 ucb-article-card-data';
+      } else {
+        articleBody.classList = 'col ucb-article-card-data';
+      }
+
+      var headerLink = document.createElement('a');
+      headerLink.href = articleLink;
+      headerLink.innerText = articleTitle
+
+      articleBody.appendChild(headerLink);
+
+      article.appendChild(articleBody);
+
+      this.toggleMessage('ucb-al-loading');
+      container.appendChild(article);
+    });
+    this.appendChild(container);
+  }
+  renderTitleOnly(articleArray) {
+    var container = document.createElement('div');
+    container.classList = 'ucb-article-list-block';
+
+    articleArray.forEach(article => {
+      // Article Data
+      var articleLink = article.link;
+      var articleTitle = article.title;
+
+      // Create and Append Elements
+      var article = document.createElement('article');
+      article.classList = 'ucb-article-card-title-only';
+
+      var articleBody = document.createElement('div');
+      articleBody.classList = 'col-sm-12 ucb-article-card-data';
+
+      var headerLink = document.createElement('a');
+      headerLink.href = articleLink;
+      headerLink.innerText = articleTitle
+
+      articleBody.appendChild(headerLink);
+
+      article.appendChild(articleBody);
+
+      this.toggleMessage('ucb-al-loading');
+      container.appendChild(article);
+    });
+    this.appendChild(container);
+  }
+  renderTeaser(articleArray) {
+    var container = document.createElement('div');
+    container.classList = 'ucb-article-list-block container';
+
+    articleArray.forEach(article => {
+      // Article Data
+      var articleDate = article.date;
+      var articleLink = article.link;
+      var articleImgSrc = article.image;
+      var articleTitle = article.title;
+      var articleSumm = article.body;
+
+      // Create and Append Elements
+      var article = document.createElement('article');
+      article.classList = 'ucb-article-card row';
+
+      if (articleImgSrc) {
+        var imgDiv = document.createElement('div');
+        imgDiv.classList = 'ucb-article-card-img';
+
+        var imgLink = document.createElement('a');
+        imgLink.href = articleLink;
+        imgLink.setAttribute('role', 'presentation');
+        imgLink.setAttribute('aria-hidden', 'true');
+
+        var articleImg = document.createElement('img');
+        articleImg.src = articleImgSrc;
+
+        imgLink.appendChild(articleImg);
+        imgDiv.appendChild(imgLink);
+
+        article.appendChild(imgDiv);
+      }
+
+      var articleBody = document.createElement('div');
+      if (articleImgSrc) {
+        articleBody.classList = 'col px-3 ucb-article-card-data';
+      } else {
+        articleBody.classList = 'col ucb-article-card-data';
+      }
+
+      var headerStrong = document.createElement('strong');
+
+      var articleHeader = document.createElement('a');
+      articleHeader.classList = 'ucb-article-card-title-teaser';
+      articleHeader.href = articleLink;
+      articleHeader.innerText = articleTitle;
+
+      headerStrong.appendChild(articleHeader);
+
+      var date = document.createElement('span');
+      date.classList = 'ucb-article-card-date';
+      date.innerText = articleDate;
+
+      var articleSummary = document.createElement('p');
+      articleSummary.innerText = articleSumm;
+      articleSummary.classList = 'ucb-article-card-summary';
+
+      var readMore = document.createElement('a');
+      readMore.href = articleLink;
+      readMore.classList = 'ucb-article-card-read-more';
+      readMore.innerText = 'Read More';
+      readMore.setAttribute('aria-hidden', 'true');
+
+      articleBody.appendChild(headerStrong);
+      articleBody.appendChild(date);
+      articleBody.appendChild(articleSummary);
+      articleBody.appendChild(readMore);
+
+      article.appendChild(articleBody);
+
+      this.toggleMessage('ucb-al-loading');
+      container.appendChild(article);
+    });
+    this.appendChild(container);
+
+  }
+
+  // Used to toggle error messages and loader
+  toggleMessage(id, display = "none") {
+    if (id) {
+      var toggle = this.querySelector(`#${id}`);
+      if (toggle) {
+        if (display === "block") {
+          toggle.style.display = "block";
         } else {
-           return response.json();
+          toggle.style.display = "none";
         }
-    };
+      }
+    }
+  }
+
+  // Used for error handling within the API response
+  handleError = response => {
+    if (!response.ok) {
+      throw new Error;
+    } else {
+      return response.json();
+    }
+  };
 }
 
 customElements.define('article-list-block', ArticleListBlockElement);

--- a/js/ucb-article-list.js
+++ b/js/ucb-article-list.js
@@ -1,337 +1,331 @@
-/**  
- * Get additional data from the paragraph content attached to the Article node
- * @param {string} id - internal id used by Drupal to get the specific paragraph
- */
-async function getArticleParagraph(id) {
-  if (id) {
-    const response = await fetch(
-      `/jsonapi/paragraph/article_content/${id}`
-    );
-    return response;
-  } else {
-    return "";
+(function () {
+  /**  
+   * Get additional data from the paragraph content attached to the Article node
+   * @param {string} id - internal id used by Drupal to get the specific paragraph
+   */
+  async function getArticleParagraph(id) {
+    if (id) {
+      const response = await fetch(
+        `/jsonapi/paragraph/article_content/${id}`
+      );
+      return response;
+    } else {
+      return "";
+    }
   }
-}
 
-/**
- * Helper function to show/hide elements in the DOM
- * @param {string} id - CSS ID of the element to target
- * @param {string} display - display mode for that element (block | none) 
- */
-function toggleMessage(id, display = "none") {
-  if (id) {
-    var toggle = document.getElementById(id);
+  /**
+   * Helper function to show/hide elements in the DOM
+   * @param {string} id - CSS ID of the element to target
+   * @param {string} display - display mode for that element (block | none) 
+   */
+  function toggleMessage(id, display = "none") {
+    if (id) {
+      var toggle = document.getElementById(id);
 
-    if (toggle) {
-      switch (display) {
-        case "block":
-          toggle.style.display = "block";
-          break;
-        case "inline-block":
-          toggle.style.display = "inline-block";
-          break;
-        case "none":
-          toggle.style.display = "none";
-          break;
-        default:
-          toggle.style.display = "none";
-          break;
+      if (toggle) {
+        switch (display) {
+          case "block":
+            toggle.style.display = "block";
+            break;
+          case "inline-block":
+            toggle.style.display = "inline-block";
+            break;
+          case "none":
+            toggle.style.display = "none";
+            break;
+          default:
+            toggle.style.display = "none";
+            break;
+        }
       }
     }
   }
-}
 
-/**
- * Main function that will load the initial data from the given URL and start processing it for display
- * @param {string} JSONURL - URL for the JSON:API endpoint with filters, sort and pagination 
- * @param {string} id - target DOM element to add the content to 
- * @param {string} ExcludeCategories - array of categories to filter out when rendering 
- * @param {string} ExcludeTags - array of tags to filter out when rendering
- * @returns - Promise with resolve or reject
- */
-function renderArticleList(JSONURL, ExcludeCategories = "", ExcludeTags = "") {
-  return new Promise(function (resolve, reject) {
-    let excludeCatArray = ExcludeCategories.split(",").map(Number);
-    let excludeTagArray = ExcludeTags.split(",").map(Number);
-    // next URL if there is one, will be returned by this funtion
-    let NEXTJSONURL = "";
+  /**
+   * Main function that will load the initial data from the given URL and start processing it for display
+   * @param {string} JSONURL - URL for the JSON:API endpoint with filters, sort and pagination 
+   * @param {string} id - target DOM element to add the content to 
+   * @param {string} ExcludeCategories - array of categories to filter out when rendering 
+   * @param {string} ExcludeTags - array of tags to filter out when rendering
+   * @returns - Promise with resolve or reject
+   */
+  function renderArticleList(JSONURL, ExcludeCategories = "", ExcludeTags = "") {
+    return new Promise(function (resolve, reject) {
+      let excludeCatArray = ExcludeCategories.split(",").map(Number);
+      let excludeTagArray = ExcludeTags.split(",").map(Number);
+      // next URL if there is one, will be returned by this funtion
+      let NEXTJSONURL = "";
 
-    if (JSONURL) {
-      //let el = document.getElementById(id);
+      if (JSONURL) {
+        //let el = document.getElementById(id);
 
-      // show the loading spinner while we load the data
-      toggleMessage("ucb-al-loading", "block");
+        // show the loading spinner while we load the data
+        toggleMessage("ucb-al-loading", "block");
 
-      fetch(JSONURL)
-        .then((reponse) => reponse.json())
-        .then((data) => {
-          // get the next URL and return that if there is one
-          if (data.links.next) {
-            let nextURL = data.links.next.href.split("/jsonapi/");
-            NEXTJSONURL = nextURL[1];
-          } else {
-            NEXTJSONURL = "";
-          }
+        fetch(JSONURL)
+          .then((reponse) => reponse.json())
+          .then((data) => {
+            // get the next URL and return that if there is one
+            if (data.links.next) {
+              let nextURL = data.links.next.href.split("/jsonapi/");
+              NEXTJSONURL = nextURL[1];
+            } else {
+              NEXTJSONURL = "";
+            }
 
-          //console.log("data obj", data);
+            //console.log("data obj", data);
 
-          // if no articles of returned, stop the loading spinner and let the user know we received no data that matches their query
-          if (!data.data.length) {
-            toggleMessage("ucb-al-loading", "none");
-            toggleMessage("ucb-al-no-results", "block");
-            reject;
-          }
+            // if no articles of returned, stop the loading spinner and let the user know we received no data that matches their query
+            if (!data.data.length) {
+              toggleMessage("ucb-al-loading", "none");
+              toggleMessage("ucb-al-no-results", "block");
+              reject;
+            }
 
-          // Below objects are needed to match images with their corresponding articles. There are two endpoints => data.data (article) and data.included (incl. media), both needed to associate a media library image with its respective article
-          let urlObj = {};
-          let idObj = {};
-          let altObj = {};
-          // Remove any blanks from our articles before map
-          if (data.included) {
-            // removes all other included data besides images in our included media
-            let idFilterData = data.included.filter((item) => {
-              return item.type == "media--image";
-            })
+            // Below objects are needed to match images with their corresponding articles. There are two endpoints => data.data (article) and data.included (incl. media), both needed to associate a media library image with its respective article
+            let urlObj = {};
+            let idObj = {};
+            let altObj = {};
+            // Remove any blanks from our articles before map
+            if (data.included) {
+              // removes all other included data besides images in our included media
+              let idFilterData = data.included.filter((item) => {
+                return item.type == "media--image";
+              });
 
-            let altFilterData = data.included.filter((item) => {
-              return item.type == 'file--file';
+              let altFilterData = data.included.filter((item) => {
+                return item.type == 'file--file';
+              });
+              // finds the focial point version of the thumbnail
+              altFilterData.map((item) => {
+                // checks if consumer is working, else default to standard image instead of focal image
+                if (item.links.focal_image_square != undefined) {
+                  altObj[item.id] = { src: item.links.focal_image_square.href }
+                } else {
+                  altObj[item.id] = { src: item.attributes.uri.url }
+                }
+              });
+
+              // using the image-only data, creates the idObj =>  key: thumbnail id, value : data id
+              idFilterData.map((pair) => {
+                const thumbnailId = pair.relationships.thumbnail.data.id;
+                idObj[pair.id] = pair.relationships.thumbnail.data.id;
+                altObj[thumbnailId].alt = pair.relationships.thumbnail.data.meta.alt;
+              });
+            }
+            // console.log("idObj", idObj);
+            // console.log("urlObj", urlObj);
+            // console.log('altObj', altObj);
+            //iterate over each item in the array
+            data.data.map((item) => {
+              let thisArticleCats = [];
+              let thisArticleTags = [];
+              // // loop through and grab all of the categories
+              if (item.relationships.field_ucb_article_categories) {
+                for (let i = 0; i < item.relationships.field_ucb_article_categories.data.length; i++) {
+                  thisArticleCats.push(
+                    item.relationships.field_ucb_article_categories.data[i].meta
+                      .drupal_internal__target_id
+                  );
+                }
+              }
+              // console.log("this article cats",thisArticleCats);
+
+              // // loop through and grab all of the tags
+              if (item.relationships.field_ucb_article_tags) {
+                for (var i = 0; i < item.relationships.field_ucb_article_tags.data.length; i++) {
+                  thisArticleTags.push(item.relationships.field_ucb_article_tags.data[i].meta.drupal_internal__target_id)
+                }
+              }
+              // console.log('this article tags',thisArticleTags);
+
+              // checks to see if the current article (item) contains a category or tag scheduled for exclusion
+              let doesIncludeCat = thisArticleCats;
+              let doesIncludeTag = thisArticleTags;
+
+              // check to see if we need to filter on categories
+              if (excludeCatArray.length && thisArticleCats.length) {
+                doesIncludeCat = thisArticleCats.filter((element) =>
+                  excludeCatArray.includes(element)
+                );
+              }
+              // check to see if we need to filter on tags
+              if (excludeTagArray.length && thisArticleTags.length) {
+                doesIncludeTag = thisArticleTags.filter((element) =>
+                  excludeTagArray.includes(element)
+                );
+              }
+
+              // if we didn't match any of the filtered tags or cats, then render the content
+              if (doesIncludeCat.length == 0 && doesIncludeTag.length == 0) {
+                // we need to render the Article Card view for this returned element
+                // **ADD DATA**
+                // this is my id of the article body paragraph type we need only if no thumbnail or summary provided
+                let bodyAndImageId = item.relationships.field_ucb_article_content.data.length ? item.relationships.field_ucb_article_content.data[0].id : "";
+                let body = item.attributes.field_ucb_article_summary ? item.attributes.field_ucb_article_summary : "";
+                body = body.trim();
+                let imageSrc = "";
+
+                // if no article summary, use a simplified article body
+                if (!body.length && bodyAndImageId != "") {
+                  getArticleParagraph(bodyAndImageId)
+                    .then((response) => response.json())
+                    .then((data) => {
+                      // Remove any html tags within the article
+                      let htmlStrip = data.data.attributes.field_article_text.processed.replace(
+                        /<\/?[^>]+(>|$)/g,
+                        ""
+                      );
+                      // Remove any line breaks if media is embedded in the body
+                      let lineBreakStrip = htmlStrip.replace(/(\r\n|\n|\r)/gm, "");
+                      // take only the first 100 words ~ 500 chars
+                      let trimmedString = lineBreakStrip.substr(0, 250);
+                      // if in the middle of the string, take the whole word
+                      if (trimmedString.length > 100) {
+                        trimmedString = trimmedString.substr(
+                          0,
+                          Math.min(
+                            trimmedString.length,
+                            trimmedString.lastIndexOf(" ")
+                          )
+                        );
+                        body = `${trimmedString}...`;
+                      }
+                      // set the contentBody of Article Summary card to the minified body instead
+                      body = `${trimmedString}`;
+                      document.getElementById(`body-${bodyAndImageId}`).innerText = body;
+                    });
+                }
+
+                // if no thumbnail, show no image
+                if (!item.relationships.field_ucb_article_thumbnail.data) {
+                  imageSrc = null;
+                } else {
+                  //Use the idObj as a memo to add the corresponding image url
+                  let thumbId = item.relationships.field_ucb_article_thumbnail.data.id;
+                  imageSrc = altObj[idObj[thumbId]];
+                }
+
+                //Date - make human readable
+                const options = { year: 'numeric', month: 'short', day: 'numeric' };
+                let date = new Date(item.attributes.created).toLocaleDateString('en-us', options);
+                let title = item.attributes.title;
+                let link = item.attributes.path.alias;
+                let image = "";
+                let articleSummarySize = "col-md-12";
+
+                var articleRow = document.createElement('div');
+                articleRow.className = 'ucb-article-card row';
+
+                if (link && imageSrc) {
+                  articleSummarySize = "col-md-10";
+
+                  var imgContainer = document.createElement('div');
+                  imgContainer.className = 'col-md-2 ucb-article-card-img';
+
+                  var imgLink = document.createElement('a');
+                  imgLink.href = link;
+                  imgLink.setAttribute('role', 'presentation');
+                  imgLink.setAttribute('aria-hidden', 'true');
+
+                  var articleImg = document.createElement('img');
+                  articleImg.src = imageSrc.src;
+                  articleImg.setAttribute('alt', imageSrc.alt);
+
+                  imgLink.appendChild(articleImg);
+                  imgContainer.appendChild(imgLink);
+
+                  // add to article row
+                  articleRow.appendChild(imgContainer);
+                }
+
+
+                // Container
+                var articleDataContainer = document.createElement('div');
+                articleDataContainer.className = `col-sm-12 ${articleSummarySize} ucb-article-card-data`;
+
+
+                // Header
+                var articleDataLink = document.createElement('a');
+                articleDataLink.href = link;
+
+                var articleDataHead = document.createElement('h2');
+                articleDataHead.className = "ucb-article-card-title";
+                articleDataHead.innerText = title;
+
+                articleDataLink.appendChild(articleDataHead);
+
+
+                // Date
+                var articleCardDate = document.createElement('span');
+                articleCardDate.className = 'ucb-article-card-date';
+                articleCardDate.innerText = date;
+
+                // Summary
+
+                var articleSummaryBody = document.createElement('p');
+                articleSummaryBody.className = 'ucb-article-card-body';
+                articleSummaryBody.id = `body-${bodyAndImageId}`;
+                articleSummaryBody.innerText = body;
+
+                // Read more & link
+                var articleSummaryReadMore = document.createElement('span');
+                articleSummaryReadMore.className = 'ucb-article-card-more';
+
+                var readMoreLink = document.createElement('a');
+                readMoreLink.href = link;
+                readMoreLink.setAttribute('aria-hidden', 'true');
+                readMoreLink.innerText = `Read more`;
+
+                articleSummaryReadMore.appendChild(readMoreLink);
+
+                //Appends
+
+                articleDataContainer.appendChild(articleDataLink);
+                articleDataContainer.appendChild(articleCardDate);
+                articleDataContainer.appendChild(articleSummaryBody);
+                articleDataContainer.appendChild(articleSummaryReadMore);
+
+                articleRow.appendChild(articleDataContainer);
+
+                let dataOutput = document.getElementById("ucb-al-data");
+                let thisArticle = document.createElement("article");
+                thisArticle.className = 'ucb-article-card-container';
+                thisArticle.appendChild(articleRow);
+                dataOutput.append(thisArticle);
+
+                if (NEXTJSONURL) {
+                  toggleMessage('ucb-el-load-more', 'inline-block');
+                }
+              }
             });
-            // finds the focial point version of the thumbnail
-            altFilterData.map((item) => {
-              // checks if consumer is working, else default to standard image instead of focal image
-              if (item.links.focal_image_square != undefined) {
-                altObj[item.id] = { src: item.links.focal_image_square.href }
-              } else {
-                altObj[item.id] = { src: item.attributes.uri.url }
-              }
-            })
 
-            // using the image-only data, creates the idObj =>  key: thumbnail id, value : data id
-            idFilterData.map((pair) => {
-              const thumbnailId = pair.relationships.thumbnail.data.id;
-              idObj[pair.id] = pair.relationships.thumbnail.data.id;
-              altObj[thumbnailId].alt = pair.relationships.thumbnail.data.meta.alt;
-            })
-          }
-          // console.log("idObj", idObj);
-          // console.log("urlObj", urlObj);
-          // console.log('altObj', altObj)
-          //iterate over each item in the array
-          data.data.map((item) => {
-            let thisArticleCats = [];
-            let thisArticleTags = [];
-            // // loop through and grab all of the categories
-            if (item.relationships.field_ucb_article_categories) {
-              for (let i = 0; i < item.relationships.field_ucb_article_categories.data.length; i++) {
-                thisArticleCats.push(
-                  item.relationships.field_ucb_article_categories.data[i].meta
-                    .drupal_internal__target_id
-                )
-              }
-            }
-            // console.log("this article cats",thisArticleCats)
+            // done loading -- hide the loading spinner graphic
+            toggleMessage("ucb-al-loading", "none");
+            resolve(NEXTJSONURL);
+          }).catch(function (error) {
+            // catch any fetch errors and let the user know so they're not endlessly watching the spinner
+            console.log("Fetch Error in URL : " + JSONURL);
+            console.log("Fetch Error is : " + error);
+            // turn off spinner
+            toggleMessage("ucb-al-loading", "none");
+            // turn on default error message
+            if (error) {
+              toggleMessage("ucb-al-error", "block");
 
-            // // loop through and grab all of the tags
-            if (item.relationships.field_ucb_article_tags) {
-              for (var i = 0; i < item.relationships.field_ucb_article_tags.data.length; i++) {
-                thisArticleTags.push(item.relationships.field_ucb_article_tags.data[i].meta.drupal_internal__target_id)
-              }
-            }
-            // console.log('this article tags',thisArticleTags)
-
-            // checks to see if the current article (item) contains a category or tag scheduled for exclusion
-            let doesIncludeCat = thisArticleCats;
-            let doesIncludeTag = thisArticleTags;
-
-            // check to see if we need to filter on categories
-            if (excludeCatArray.length && thisArticleCats.length) {
-              doesIncludeCat = thisArticleCats.filter((element) =>
-                excludeCatArray.includes(element)
-              )
-            }
-            // check to see if we need to filter on tags
-            if (excludeTagArray.length && thisArticleTags.length) {
-              doesIncludeTag = thisArticleTags.filter((element) =>
-                excludeTagArray.includes(element)
-              )
             }
 
-            // if we didn't match any of the filtered tags or cats, then render the content
-            if (doesIncludeCat.length == 0 && doesIncludeTag.length == 0) {
-              // we need to render the Article Card view for this returned element
-              // **ADD DATA**
-              // this is my id of the article body paragraph type we need only if no thumbnail or summary provided
-              let bodyAndImageId = item.relationships.field_ucb_article_content.data.length ? item.relationships.field_ucb_article_content.data[0].id : "";
-              let body = item.attributes.field_ucb_article_summary ? item.attributes.field_ucb_article_summary : "";
-              body = body.trim();
-              let imageSrc = "";
+          });
 
-              // if no article summary, use a simplified article body
-              if (!body.length && bodyAndImageId != "") {
-                getArticleParagraph(bodyAndImageId)
-                  .then((response) => response.json())
-                  .then((data) => {
-                    // Remove any html tags within the article
-                    let htmlStrip = data.data.attributes.field_article_text.processed.replace(
-                      /<\/?[^>]+(>|$)/g,
-                      ""
-                    )
-                    // Remove any line breaks if media is embedded in the body
-                    let lineBreakStrip = htmlStrip.replace(/(\r\n|\n|\r)/gm, "");
-                    // take only the first 100 words ~ 500 chars
-                    let trimmedString = lineBreakStrip.substr(0, 250);
-                    // if in the middle of the string, take the whole word
-                    if (trimmedString.length > 100) {
-                      trimmedString = trimmedString.substr(
-                        0,
-                        Math.min(
-                          trimmedString.length,
-                          trimmedString.lastIndexOf(" ")
-                        )
-                      )
-                      body = `${trimmedString}...`;
-                    }
-                    // set the contentBody of Article Summary card to the minified body instead
-                    body = `${trimmedString}`;
-                    document.getElementById(`body-${bodyAndImageId}`).innerText = body;
-                  })
-              }
+      }
+    });
+  }
 
-              // if no thumbnail, show no image
-              if (!item.relationships.field_ucb_article_thumbnail.data) {
-                imageSrc = null;
-              } else {
-                //Use the idObj as a memo to add the corresponding image url
-                let thumbId = item.relationships.field_ucb_article_thumbnail.data.id;
-                imageSrc = altObj[idObj[thumbId]];
-              }
+  /*
+   * Initilization and start of code 
+   */
 
-              //Date - make human readable
-              const options = { year: 'numeric', month: 'short', day: 'numeric' };
-              let date = new Date(item.attributes.created).toLocaleDateString('en-us', options);
-              let title = item.attributes.title;
-              let link = item.attributes.path.alias;
-              let image = "";
-              let articleSummarySize = "col-md-12";
-
-              var articleRow = document.createElement('div')
-              articleRow.className = 'ucb-article-card row'
-
-              if (link && imageSrc) {
-                articleSummarySize = "col-md-10"
-
-                var imgContainer = document.createElement('div')
-                imgContainer.className = 'col-md-2 ucb-article-card-img'
-
-                var imgLink = document.createElement('a')
-                imgLink.href = link;
-                imgLink.setAttribute('role', 'presentation');
-                imgLink.setAttribute('aria-hidden', 'true');
-
-                var articleImg = document.createElement('img')
-                articleImg.src = imageSrc.src;
-                articleImg.setAttribute('alt', imageSrc.alt);
-
-                imgLink.appendChild(articleImg)
-                imgContainer.appendChild(imgLink)
-
-                // add to article row
-                articleRow.appendChild(imgContainer)
-              }
-
-
-              // Container
-              var articleDataContainer = document.createElement('div')
-              articleDataContainer.className = `col-sm-12 ${articleSummarySize} ucb-article-card-data`
-
-
-              // Header
-              var articleDataLink = document.createElement('a')
-              articleDataLink.href = link;
-
-              var articleDataHead = document.createElement('h2')
-              articleDataHead.className = "ucb-article-card-title"
-              articleDataHead.innerText = title;
-
-              articleDataLink.appendChild(articleDataHead)
-
-
-              // Date
-              var articleCardDate = document.createElement('span')
-              articleCardDate.className = 'ucb-article-card-date'
-              articleCardDate.innerText = date;
-
-              // Summary
-
-              var articleSummaryBody = document.createElement('p')
-              articleSummaryBody.className = 'ucb-article-card-body'
-              articleSummaryBody.id = `body-${bodyAndImageId}`
-              articleSummaryBody.innerText = body;
-
-              // Read more & link
-              var articleSummaryReadMore = document.createElement('span')
-              articleSummaryReadMore.className = 'ucb-article-card-more'
-
-              var readMoreLink = document.createElement('a')
-              readMoreLink.href = link;
-              readMoreLink.setAttribute('aria-hidden', 'true')
-              readMoreLink.innerText = `Read more`
-              //Screen Reader text
-              var srOnly = document.createElement('span')
-              srOnly.className = 'sr-only'
-              srOnly.innerText = ` about ${title}`
-              readMoreLink.appendChild(srOnly)
-
-              articleSummaryReadMore.appendChild(readMoreLink)
-
-              //Appends
-
-              articleDataContainer.appendChild(articleDataLink)
-              articleDataContainer.appendChild(articleCardDate)
-              articleDataContainer.appendChild(articleSummaryBody)
-              articleDataContainer.appendChild(articleSummaryReadMore)
-
-              articleRow.appendChild(articleDataContainer)
-
-
-
-              let dataOutput = document.getElementById("ucb-al-data");
-              let thisArticle = document.createElement("article");
-              thisArticle.className = 'ucb-article-card-container';
-              thisArticle.appendChild(articleRow);
-              dataOutput.append(thisArticle);
-
-              if (NEXTJSONURL) {
-                toggleMessage('ucb-el-load-more', 'inline-block')
-              }
-            }
-          })
-
-          // done loading -- hide the loading spinner graphic
-          toggleMessage("ucb-al-loading", "none");
-          resolve(NEXTJSONURL);
-        }).catch(function (error) {
-          // catch any fetch errors and let the user know so they're not endlessly watching the spinner
-          console.log("Fetch Error in URL : " + JSONURL);
-          console.log("Fetch Error is : " + error);
-          // turn off spinner
-          toggleMessage("ucb-al-loading", "none");
-          // turn on default error message
-          if (error) {
-            toggleMessage("ucb-al-error", "block");
-
-          }
-
-        });
-
-    }
-  });
-}
-
-/**
- * Initilization and start of code 
- */
-(function () {
   // get the url from the data-jsonapi variable
   let el = document.getElementById("ucb-article-listing");
   let JSONURL = ""; // JSON:API URL 
@@ -354,7 +348,7 @@ function renderArticleList(JSONURL, ExcludeCategories = "", ExcludeTags = "") {
   });
 
   // watch for scrolling and determine if we're at the bottom of the content and need to request more
-  const button = document.getElementById('ucb-el-load-more')
+  const button = document.getElementById('ucb-el-load-more');
   button.addEventListener("click", function () {
     if (NEXTJSONURL) {
       renderArticleList(NEXTJSONURL, CategoryExclude, TagsExclude,).then((response) => {
@@ -364,9 +358,9 @@ function renderArticleList(JSONURL, ExcludeCategories = "", ExcludeTags = "") {
         } else {
           NEXTJSONURL = "";
           toggleMessage("ucb-al-end-of-data", "block");
-          toggleMessage('ucb-el-load-more')
+          toggleMessage('ucb-el-load-more');
         }
       });
     }
-  })
-})()
+  });
+})();


### PR DESCRIPTION
This update:
- [a11y, Remove] Removes unused `sr-only` elements from article list "read more" links. Resolves CuBoulder/tiamat-theme#932
- [Change] Improves the readability of article list JavaScript files (no changes in functionality should be observed).