### PR TITLE
Slider: Right-side Content Breakpoint

### DIFF
--- a/css/block/slider.css
+++ b/css/block/slider.css
@@ -228,6 +228,9 @@ a.slide-link i.fab {
   .carousel-caption {
     width: 100%;
   }
+}
+
+@media screen and (max-width:576px) {
   .right-content .carousel-item-structure {
     display: flex;
     flex-direction: column !important;


### PR DESCRIPTION
Previously the D10 breakpoint for the `Right-Side Content` style `Slider` block would stack the content under the image at a Tablet breakpoint. 

This has been updated to stack under the image at a Mobile-sized breakpoint, while the 75% text size reduction will continue to apply earlier at the Tablet breakpoint to mirror D7.

Resolves #917 
