### PR TITLE
Slider: "Right-side Content Overlay" styles

### DIFF
--- a/css/block/slider.css
+++ b/css/block/slider.css
@@ -236,7 +236,6 @@ a.slide-link i.fab {
   .right-overlay.ucb-slider-block .carousel-caption {
     height: 100%;
     width: auto;
-    font-size: inherit;
   }
 }
 

--- a/css/block/slider.css
+++ b/css/block/slider.css
@@ -199,6 +199,11 @@ a.slide-link i.fab {
   .carousel-caption {
     width: 100%;
   }
+  .right-overlay.ucb-slider-block .carousel-caption {
+    height: 100%;
+    width: auto;
+    font-size: 75%;
+  }
 }
 
 @media screen and (max-width: 768px) {
@@ -227,6 +232,11 @@ a.slide-link i.fab {
   }
   .carousel-caption {
     width: 100%;
+  }
+  .right-overlay.ucb-slider-block .carousel-caption {
+    height: 100%;
+    width: auto;
+    font-size: inherit;
   }
 }
 


### PR DESCRIPTION
### Slider: "Right-side Content Overlay"
Fixes some overlay issues on smaller screen sizes where the right side overlay wouldn't span the full height and longer strings of text was pushed into non-viewable areas of the slider due to a width setting. 

Resolves https://github.com/CuBoulder/tiamat-theme/issues/980