### PR TITLE
Article Blocks: A11y fixes, External Article Handling

### DIFF
--- a/css/block/ucb-article-feature-block.css
+++ b/css/block/ucb-article-feature-block.css
@@ -98,6 +98,10 @@
   padding: 0px;
 }
 
+.ucb-article-feature-container .ucb-article-img-link{
+  margin-right: 10px;
+}
+
 @media screen and (max-width: 767px) {
   .ucb-stacked-secondary-container > .ucb-article-card {
     margin-bottom: 10px;

--- a/css/block/ucb-article-list-block.css
+++ b/css/block/ucb-article-list-block.css
@@ -1,3 +1,7 @@
+.ucb-article-list-block{
+  padding: 0;
+}
+
 .ucb-article-list-block-button-container {
   text-align: right;
 }

--- a/js/ucb-article-feature-block.js
+++ b/js/ucb-article-feature-block.js
@@ -187,7 +187,8 @@ class ArticleFeatureBlockElement extends HTMLElement {
             }
       
             const data = await response.json();
-            
+            if (!data.data.attributes.field_article_text) return ""; //  needed for external articles
+
             let htmlStrip = data.data.attributes.field_article_text.processed.replace(
                 /<\/?[^>]+(>|$)/g,
                 ""

--- a/js/ucb-article-feature-block.js
+++ b/js/ucb-article-feature-block.js
@@ -1,558 +1,628 @@
 class ArticleFeatureBlockElement extends HTMLElement {
-	constructor() {
-		super();
-        // Image Size, display and JSON API Endpoint
-        var display = this.getAttribute('display');
-        var imgSize = this.getAttribute('imgSize');
-        var API = this.getAttribute('jsonapi');
-        var count = display === "stacked" ? 4 : 5;
-        // Exclusions are done on the JS side, get into arrays. Blank if no exclusions
-        var excludeCatArray = this.getAttribute('exCats').split(",").map(Number);
-        var excludeTagArray = this.getAttribute('exTags').split(",").map(Number);
+  constructor() {
+    super();
+    // Image Size, display and JSON API Endpoint
+    var display = this.getAttribute("display");
+    var imgSize = this.getAttribute("imgSize");
+    var API = this.getAttribute("jsonapi");
+    var count = display === "stacked" ? 4 : 5;
+    // Exclusions are done on the JS side, get into arrays. Blank if no exclusions
+    var excludeCatArray = this.getAttribute("exCats").split(",").map(Number);
+    var excludeTagArray = this.getAttribute("exTags").split(",").map(Number);
 
-        fetch(API)
-            .then(this.handleError)
-            .then((data) => this.build(data, display, count, imgSize, excludeCatArray, excludeTagArray))
-            .catch(Error=> {
-              console.error('There was an error fetching data from the API - Please try again later.')
-              console.error(Error)
-              this.toggleMessage('ucb-al-loading')
-              this.toggleMessage('ucb-al-api-error', "block")
-            });
+    fetch(API)
+      .then(this.handleError)
+      .then((data) =>
+        this.build(
+          data,
+          display,
+          count,
+          imgSize,
+          excludeCatArray,
+          excludeTagArray
+        )
+      )
+      .catch((Error) => {
+        console.error(
+          "There was an error fetching data from the API - Please try again later."
+        );
+        console.error(Error);
+        this.toggleMessage("ucb-al-loading");
+        this.toggleMessage("ucb-al-api-error", "block");
+      });
+  }
+
+  // This is the article list filtering function that assembles the article javascript object array from the JSON response. Handles exclusions of categories and tags.
+  async build(
+    data,
+    display,
+    count,
+    imgSize,
+    excludeCatArray,
+    excludeTagArray,
+    finalArticles = []
+  ) {
+    // More than 10 articles? This sets up the next call if there's more articles to be retrieved but not enough post-filters
+    let NEXTJSONURL = "";
+    if (data.links.next) {
+      let nextURL = data.links.next.href.split("/jsonapi/");
+      NEXTJSONURL = `/jsonapi/${nextURL[1]}`;
+    } else {
+      NEXTJSONURL = "";
     }
 
-    // This is the article list filtering function that assembles the article javascript object array from the JSON response. Handles exclusions of categories and tags.
-    async build(data, display, count, imgSize, excludeCatArray, excludeTagArray, finalArticles = []){
-      // More than 10 articles? This sets up the next call if there's more articles to be retrieved but not enough post-filters
-        let NEXTJSONURL = "";
-        if(data.links.next) {
-            let nextURL = data.links.next.href.split("/jsonapi/");
-            NEXTJSONURL = `/jsonapi/${nextURL[1]}`;
+    // If no Articles retrieved...
+    if (data.data.length == 0) {
+      this.toggleMessage("ucb-al-loading");
+      this.toggleMessage("ucb-al-error", "block");
+      console.warn(
+        "No Articles retrieved - please check your inclusion filters and try again"
+      );
+    } else {
+      // Below objects are needed to match images with their corresponding articles. There are two endpoints => data.data (article) and data.included (incl. media), both needed to associate a media library image with its respective article
+      let idObj = {};
+      let altObj = {};
+      let wideObj = {};
+      // Remove any blanks from our articles before map
+      if (data.included) {
+        // removes all other included data besides images in our included media
+        let idFilterData = data.included.filter((item) => {
+          return item.type == "media--image";
+        });
+
+        let altFilterData = data.included.filter((item) => {
+          return item.type == "file--file";
+        });
+        // finds the focial point version of the thumbnail
+        altFilterData.map((item) => {
+          // checks if consumer is working, else default to standard image instead of focal image
+          if (
+            item.links.focal_image_square != undefined &&
+            item.links.focal_image_wide != undefined
+          ) {
+            altObj[item.id] = item.links.focal_image_square.href;
+            // This is used if a user selects the "Wide" image style
+            wideObj[item.id] = item.links.focal_image_wide.href;
           } else {
-            NEXTJSONURL = "";
+            altObj[item.id] = item.attributes.uri.url;
           }
+        });
 
-          // If no Articles retrieved...
-        if(data.data.length == 0){
-            this.toggleMessage('ucb-al-loading')
-            this.toggleMessage('ucb-al-error',"block")
-            console.warn('No Articles retrieved - please check your inclusion filters and try again')
-        } else {
-        // Below objects are needed to match images with their corresponding articles. There are two endpoints => data.data (article) and data.included (incl. media), both needed to associate a media library image with its respective article
-        let idObj = {};
-        let altObj = {};
-        let wideObj = {};
-        // Remove any blanks from our articles before map
-        if (data.included) {
-          // removes all other included data besides images in our included media
-          let idFilterData = data.included.filter((item) => {
-            return item.type == "media--image";
-          })
+        // using the image-only data, creates the idObj =>  key: thumbnail id, value : data id
+        idFilterData.map((pair) => {
+          idObj[pair.id] = pair.relationships.thumbnail.data.id;
+        });
+      }
+      // Iterate over each Article
+      await Promise.all(
+        data.data.map(async (item) => {
+          // Article must have a thumbnail
+          if (item.relationships.field_ucb_article_thumbnail.data) {
+            let thisArticleCats = [];
+            let thisArticleTags = [];
 
-          let altFilterData = data.included.filter((item) => {
-            return item.type == 'file--file';
-          });
-          // finds the focial point version of the thumbnail
-          altFilterData.map((item)=>{
-            // checks if consumer is working, else default to standard image instead of focal image
-            if(item.links.focal_image_square != undefined && item.links.focal_image_wide != undefined){
-              altObj[item.id] = item.links.focal_image_square.href
-              // This is used if a user selects the "Wide" image style
-              wideObj[item.id] = item.links.focal_image_wide.href
-            } else {
-              altObj[item.id] = item.attributes.uri.url
-            }
-        })
-
-          // using the image-only data, creates the idObj =>  key: thumbnail id, value : data id
-          idFilterData.map((pair) => {
-            idObj[pair.id] = pair.relationships.thumbnail.data.id;
-          })
-        }
-    // Iterate over each Article
-    await Promise.all (data.data.map(async(item)=>{
-            // Article must have a thumbnail
-            if(item.relationships.field_ucb_article_thumbnail.data){
-                let thisArticleCats = [];
-                let thisArticleTags = [];
-
-                // // loop through and grab all of the categories
-                if (item.relationships.field_ucb_article_categories) {
-                for (let i = 0; i < item.relationships.field_ucb_article_categories.data.length; i++) {
-                    thisArticleCats.push(
-                    item.relationships.field_ucb_article_categories.data[i].meta
-                        .drupal_internal__target_id
-                    )
-                }
-                }  
-                // // loop through and grab all of the tags
-                if (item.relationships.field_ucb_article_tags) {
-                for (var i = 0; i < item.relationships.field_ucb_article_tags.data.length; i++) {
-                    thisArticleTags.push(item.relationships.field_ucb_article_tags.data[i].meta.drupal_internal__target_id)
-                }
-                }
-
-                let doesIncludeCat = thisArticleCats;
-                let doesIncludeTag = thisArticleTags;
-
-                // check to see if we need to filter on categories
-                if (excludeCatArray.length && thisArticleCats.length) {
-                doesIncludeCat = thisArticleCats.filter((element) =>
-                    excludeCatArray.includes(element)
-                )
-                }
-                // check to see if we need to filter on tags
-                if (excludeTagArray.length && thisArticleTags.length) {
-                doesIncludeTag = thisArticleTags.filter((element) =>
-                    excludeTagArray.includes(element)
-                )
-                }
-
-                // If there's no categories or tags that are in the exclusions, proceed
-                if (doesIncludeCat.length == 0 && doesIncludeTag.length == 0) {
-                    // okay to render
-                    let bodyAndImageId = item.relationships.field_ucb_article_content.data.length ? item.relationships.field_ucb_article_content.data[0].id : "";
-                    let body = item.attributes.field_ucb_article_summary ? item.attributes.field_ucb_article_summary : "";
-                    body = body.trim();
-                    let imageSrc = "";
-                    let imageSrcWide = "";
-
-                    if (!body.length && bodyAndImageId != "") {
-                        body = await this.getArticleParagraph(bodyAndImageId);
-                    }
-                    //Use the idObj as a memo to add the corresponding image url
-                    let thumbId = item.relationships.field_ucb_article_thumbnail.data.id;
-                        imageSrc = altObj[idObj[thumbId]];
-                    imageSrcWide = wideObj[idObj[thumbId]]
-
-                    //Date - make human readable
-                    const options = { year: 'numeric', month: 'short', day: 'numeric' };
-                    let date = new Date(item.attributes.created).toLocaleDateString('en-us', options);
-                    let title = item.attributes.title;
-                    let link = item.attributes.path.alias;
-
-                    // Create an Article Object for programatic rendering
-                    const article = {
-                        title,
-                        link,
-                        imageSquare: imageSrc,
-                        imageWide: imageSrcWide,
-                        date,
-                        body,
-                    }
-                    // Adds the article object to the final array of articles chosen
-                    finalArticles.push(article)
-                }
-        }
-    }));
-        // Case for not enough articles selected and extra articles available
-        if(finalArticles.length < count && NEXTJSONURL){
-            fetch(NEXTJSONURL).then(this.handleError)
-            .then((data) => this.build(data, display, count, imgSize, excludeCatArray, excludeTagArray, finalArticles))
-            .catch(Error=> {
-              console.error('There was an error fetching data from the API - Please try again later.')
-              console.error(Error)
-              this.toggleMessage('ucb-al-loading')
-              this.toggleMessage('ucb-al-api-error', "block")
-            });
-        }
-
-        // If no chosen articles and no other options, provide error
-        if(finalArticles.length === 0 && !NEXTJSONURL){
-          console.error('There are no available Articles that match the selected filters. Please adjust your filters and try again.')
-          this.toggleMessage('ucb-al-loading')
-          this.toggleMessage('ucb-al-error', "block")
-        }
-
-        // Case for Too many articles, proceed
-        if(finalArticles.length >= count || (finalArticles.length >= count && NEXTJSONURL)){
-            finalArticles.length = count
-        }
-
-        // Have articles and want to proceed
-        if(finalArticles.length > 0 && !NEXTJSONURL){
-          this.renderDisplay(finalArticles, display, imgSize)
-        }
-    }
-}
-        // Responsible for fetching & processing the body of the Article if no summary provided
-        async getArticleParagraph(id) {
-            if (!id) {
-                return "";
-            }
-            
-            const response = await fetch(`/jsonapi/paragraph/article_content/${id}`);
-            if (!response.ok) {
-                throw new Error('Failed to fetch article paragraph');
-            }
-      
-            const data = await response.json();
-            if (!data.data.attributes.field_article_text) return ""; //  needed for external articles
-
-            let htmlStrip = data.data.attributes.field_article_text.processed.replace(
-                /<\/?[^>]+(>|$)/g,
-                ""
-            );
-            let lineBreakStrip = htmlStrip.replace(/(\r\n|\n|\r)/gm, "");
-            let trimmedString = lineBreakStrip.substr(0, 250);
-            
-            if (trimmedString.length > 100) {
-                trimmedString = trimmedString.substr(
-                    0,
-                    Math.min(
-                        trimmedString.length,
-                        trimmedString.lastIndexOf(" ")
-                    )
+            // // loop through and grab all of the categories
+            if (item.relationships.field_ucb_article_categories) {
+              for (
+                let i = 0;
+                i < item.relationships.field_ucb_article_categories.data.length;
+                i++
+              ) {
+                thisArticleCats.push(
+                  item.relationships.field_ucb_article_categories.data[i].meta
+                    .drupal_internal__target_id
                 );
+              }
             }
-      
-            return trimmedString + "...";
+            // // loop through and grab all of the tags
+            if (item.relationships.field_ucb_article_tags) {
+              for (
+                var i = 0;
+                i < item.relationships.field_ucb_article_tags.data.length;
+                i++
+              ) {
+                thisArticleTags.push(
+                  item.relationships.field_ucb_article_tags.data[i].meta
+                    .drupal_internal__target_id
+                );
+              }
+            }
+
+            let doesIncludeCat = thisArticleCats;
+            let doesIncludeTag = thisArticleTags;
+
+            // check to see if we need to filter on categories
+            if (excludeCatArray.length && thisArticleCats.length) {
+              doesIncludeCat = thisArticleCats.filter((element) =>
+                excludeCatArray.includes(element)
+              );
+            }
+            // check to see if we need to filter on tags
+            if (excludeTagArray.length && thisArticleTags.length) {
+              doesIncludeTag = thisArticleTags.filter((element) =>
+                excludeTagArray.includes(element)
+              );
+            }
+
+            // If there's no categories or tags that are in the exclusions, proceed
+            if (doesIncludeCat.length == 0 && doesIncludeTag.length == 0) {
+              // okay to render
+              let bodyAndImageId = item.relationships.field_ucb_article_content
+                .data.length
+                ? item.relationships.field_ucb_article_content.data[0].id
+                : "";
+              let body = item.attributes.field_ucb_article_summary
+                ? item.attributes.field_ucb_article_summary
+                : "";
+              body = body.trim();
+              let imageSrc = "";
+              let imageSrcWide = "";
+
+              if (!body.length && bodyAndImageId != "") {
+                body = await this.getArticleParagraph(bodyAndImageId);
+              }
+              //Use the idObj as a memo to add the corresponding image url
+              let thumbId =
+                item.relationships.field_ucb_article_thumbnail.data.id;
+              imageSrc = altObj[idObj[thumbId]];
+              imageSrcWide = wideObj[idObj[thumbId]];
+
+              //Date - make human readable
+              const options = {
+                year: "numeric",
+                month: "short",
+                day: "numeric",
+              };
+              let date = new Date(item.attributes.created).toLocaleDateString(
+                "en-us",
+                options
+              );
+              let title = item.attributes.title;
+              let link = item.attributes.path.alias;
+
+              // Create an Article Object for programatic rendering
+              const article = {
+                title,
+                link,
+                imageSquare: imageSrc,
+                imageWide: imageSrcWide,
+                date,
+                body,
+              };
+              // Adds the article object to the final array of articles chosen
+              finalArticles.push(article);
+            }
           }
-
-    // Responsible for calling the render function of the appropriate display
-    renderDisplay(articleArray, display, imgSize){        
-        switch (display) {
-            case 'inline-large':
-                this.renderInlineLarge(articleArray, imgSize)
-                break;
-            case 'inline-half':
-                this.renderInlineHalf(articleArray, imgSize)
-                break;
-            case 'stacked':
-                this.renderStacked(articleArray, imgSize)
-                break;
-            default:
-                this.renderStacked(articleArray, imgSize)
-                break;
-        }
-    }
-    // The below functions are used to render the appropriate display
-    // Render Inline 50/50
-    renderInlineHalf(articleArray, imgSize){
-                // Container
-                var articleFeatureContainer = document.createElement('div')
-                articleFeatureContainer.className = 'ucb-article-feature-container row'
-        
-                // This is the list of 'secondary' articles
-                var secondaryContainer = document.createElement('div')
-                secondaryContainer.className = 'ucb-inline-half-secondary-container col-lg-6 col-md-6 col-sm-12 col-sm-12'
-        
-                articleArray.map(article =>{
-                    // First article (feature)
-                    if(articleFeatureContainer.children.length == 0){
-                        // This is the large feature article
-                        var featureContainer = document.createElement('article')
-                        featureContainer.className = 'ucb-inline-half-feature-container col-lg-6 col-md-6 col-sm-12 col-xs-12'
-        
-                        // Image
-                        var featureImg = document.createElement('img')
-                        if(imgSize === 'wide'){
-                            featureImg.src = article.imageWide
-                            featureImg.className = 'ucb-feature-article-img feature-img-wide'
-                        } else {
-                            featureImg.src = article.imageSquare
-                            featureImg.className = 'ucb-feature-article-img feature-img-square'
-                        }
-                        // Image Link
-                        var featureImgLink = document.createElement('a')
-                        featureImgLink.className = 'ucb-feature-article-img-link'
-                        featureImgLink.href = article.link;
-                        featureImgLink.appendChild(featureImg)
-        
-                        // Title
-                        var featureTitle = document.createElement('h2')
-                        featureTitle.className = 'ucb-feature-article-header'
-                        // Title Link
-                        var featureTitleLink = document.createElement('a')
-                        featureTitleLink.href = article.link;
-                        featureTitleLink.innerText = article.title;
-                        featureTitle.appendChild(featureTitleLink)
-        
-                        // Body
-                        var featureSummary = document.createElement('p')
-                        featureSummary.className = 'ucb-feature-article-summary'
-                        featureSummary.innerText = article.body;
-        
-                        // Read More
-                        var featureReadMore = document.createElement('a')
-                        featureReadMore.className = 'ucb-article-read-more'
-                        featureReadMore.href = article.link;
-                        featureReadMore.innerText = 'Read More'
-                        //Screen Reader text
-                        var srOnly = document.createElement('span')
-                        srOnly.className = 'sr-only'
-                        srOnly.innerText = ` about ${article.title}`
-                        featureReadMore.appendChild(srOnly)
-        
-                        // Append
-                        featureContainer.appendChild(featureImgLink)
-                        featureContainer.appendChild(featureTitle)
-                        featureContainer.appendChild(featureSummary)
-                        featureContainer.appendChild(featureReadMore)
-        
-                        articleFeatureContainer.appendChild(featureContainer)
-                    } else {
-                    // The non features
-        
-                    // Row
-                    var articleContainer = document.createElement('article')
-                    articleContainer.className = 'ucb-article-card row'
-        
-                    //Img
-                    var articleImg = document.createElement('img')
-                    articleImg.className = 'ucb-article-feature-secondary-img'
-                    articleImg.src = article.imageSquare;
-        
-                    // Img Link
-                    var articleImgLink = document.createElement('a')
-                    articleImgLink.className = 'ucb-article-img-link'
-                    articleImgLink.href = article.link;
-                    articleImgLink.appendChild(articleImg)
-        
-                    // Title
-                    var articleTitle = document.createElement('h3')
-                    articleTitle.className = 'ucb-article-feature-secondary-title'
-                    //Title Link 
-                    var articleTitleLink = document.createElement('a')
-                    articleTitleLink.href = article.link;
-                    articleTitleLink.innerText = article.title;
-                    articleTitle.appendChild(articleTitleLink)
-        
-                    articleContainer.appendChild(articleImgLink)
-                    articleContainer.appendChild(articleTitle)
-                    secondaryContainer.appendChild(articleContainer)
-                    }
-                })
-                // Hide loader, append final container
-                this.toggleMessage('ucb-al-loading')
-                articleFeatureContainer.appendChild(secondaryContainer)
-                this.appendChild(articleFeatureContainer)
-    }
-    // Render Inline 66/33
-    renderInlineLarge(articleArray, imgSize){
-        // Container
-        var articleFeatureContainer = document.createElement('div')
-        articleFeatureContainer.className = 'ucb-article-feature-container row'
-
-        // This is the list of 'secondary' articles
-        var secondaryContainer = document.createElement('div')
-        secondaryContainer.className = 'ucb-inline-large-secondary-container col-lg-4 col-md-4 col-sm-4 col-sm-12'
-
-        articleArray.map(article =>{
-            // First article (feature)
-            if(articleFeatureContainer.children.length == 0){
-                // This is the large feature article
-                var featureContainer = document.createElement('article')
-                featureContainer.className = 'ucb-inline-large-feature-container col-lg-8 col-md-8 col-sm-12 col-xs-12'
-
-                // Image
-                var featureImg = document.createElement('img')
-                if(imgSize === 'wide'){
-                    featureImg.src = article.imageWide
-                    featureImg.className = 'ucb-feature-article-img feature-img-wide'
-                } else {
-                    featureImg.src =article.imageSquare
-                    featureImg.className = 'ucb-feature-article-img feature-img-square'
-                }
-                // Image Link
-                var featureImgLink = document.createElement('a')
-                featureImgLink.className = 'ucb-feature-article-img-link'
-                featureImgLink.href = article.link;
-                featureImgLink.appendChild(featureImg)
-
-                // Title
-                var featureTitle = document.createElement('h3')
-                featureTitle.className = 'ucb-feature-article-header'
-                // Title Link
-                var featureTitleLink = document.createElement('a')
-                featureTitleLink.href = article.link;
-                featureTitleLink.innerText = article.title;
-                featureTitle.appendChild(featureTitleLink)
-
-                // Body
-                var featureSummary = document.createElement('p')
-                featureSummary.className = 'ucb-feature-article-summary'
-                featureSummary.innerText = article.body;
-
-                // Read More
-                var featureReadMore = document.createElement('a')
-                featureReadMore.className = 'ucb-article-read-more'
-                featureReadMore.href = article.link;
-                featureReadMore.innerText = 'Read More'
-                //Screen Reader text
-                var srOnly = document.createElement('span')
-                srOnly.className = 'sr-only'
-                srOnly.innerText = ` about ${article.title}`
-                featureReadMore.appendChild(srOnly)
-
-                // Append
-                featureContainer.appendChild(featureImgLink)
-                featureContainer.appendChild(featureTitle)
-                featureContainer.appendChild(featureSummary)
-                featureContainer.appendChild(featureReadMore)
-
-                articleFeatureContainer.appendChild(featureContainer)
-            } else {
-            // The non features
-
-            // Row
-            var articleContainer = document.createElement('article')
-            articleContainer.className = 'ucb-article-card row'
-
-            //Img
-            var articleImg = document.createElement('img')
-            articleImg.className = 'ucb-article-feature-secondary-img'
-            articleImg.src = article.imageSquare;
-
-            // Img Link
-            var articleImgLink = document.createElement('a')
-            articleImgLink.className = 'ucb-article-img-link'
-            articleImgLink.href = article.link;
-            articleImgLink.appendChild(articleImg)
-
-            // Title
-            var articleTitle = document.createElement('h3')
-            articleTitle.className = 'ucb-article-feature-secondary-title'
-            //Title Link 
-            var articleTitleLink = document.createElement('a')
-            articleTitleLink.href = article.link;
-            articleTitleLink.innerText = article.title;
-            articleTitle.appendChild(articleTitleLink)
-
-            articleContainer.appendChild(articleImgLink)
-            articleContainer.appendChild(articleTitle)
-            secondaryContainer.appendChild(articleContainer)
-            }
         })
-        // Hide loader, append final container
-        this.toggleMessage('ucb-al-loading')
-        articleFeatureContainer.appendChild(secondaryContainer)
-        this.appendChild(articleFeatureContainer)
-    }
-    // Render Stacked
-    renderStacked(articleArray, imgSize){
-                // Container
-                var articleFeatureContainer = document.createElement('div')
-                articleFeatureContainer.className = 'ucb-article-feature-container row'
-        
-                // This is the list of 'secondary' articles
-                var secondaryContainer = document.createElement('div')
-                secondaryContainer.className = 'ucb-stacked-secondary-container row col-sm-12'
-        
-                articleArray.map(article =>{
-                    // First article (feature)
-                    if(articleFeatureContainer.children.length == 0){
-                        // This is the large feature article
-                        var featureContainer = document.createElement('article')
-                        featureContainer.className = 'ucb-stacked-primary-container col-xs-12'
-        
-                        // Image
-                        var featureImg = document.createElement('img')
-                        if(imgSize === 'wide'){
-                            featureImg.src = article.imageWide
-                            featureImg.className = 'ucb-feature-article-img feature-img-wide'
-                        } else {
-                            featureImg.src =article.imageSquare
-                            featureImg.className = 'ucb-feature-article-img feature-img-square'
-                        }
-                        // Image Link
-                        var featureImgLink = document.createElement('a')
-                        featureImgLink.className = 'ucb-feature-article-img-link'
-                        featureImgLink.href = article.link;
-                        featureImgLink.appendChild(featureImg)
-        
-                        // Title
-                        var featureTitle = document.createElement('h2')
-                        featureTitle.className = 'ucb-feature-article-header'
-                        // Title Link
-                        var featureTitleLink = document.createElement('a')
-                        featureTitleLink.href = article.link;
-                        featureTitleLink.innerText = article.title;
-                        featureTitle.appendChild(featureTitleLink)
-        
-                        // Body
-                        var featureSummary = document.createElement('p')
-                        featureSummary.className = 'ucb-feature-article-summary'
-                        featureSummary.innerText = article.body;
-        
-                        // Read More
-                        var featureReadMore = document.createElement('a')
-                        featureReadMore.className = 'ucb-article-read-more'
-                        featureReadMore.href = article.link;
-                        featureReadMore.innerText = 'Read More'
-                        //Screen Reader text
-                        var srOnly = document.createElement('span')
-                        srOnly.className = 'sr-only'
-                        srOnly.innerText = ` about ${article.title}`
-                        featureReadMore.appendChild(srOnly)
+      );
+      // Case for not enough articles selected and extra articles available
+      if (finalArticles.length < count && NEXTJSONURL) {
+        fetch(NEXTJSONURL)
+          .then(this.handleError)
+          .then((data) =>
+            this.build(
+              data,
+              display,
+              count,
+              imgSize,
+              excludeCatArray,
+              excludeTagArray,
+              finalArticles
+            )
+          )
+          .catch((Error) => {
+            console.error(
+              "There was an error fetching data from the API - Please try again later."
+            );
+            console.error(Error);
+            this.toggleMessage("ucb-al-loading");
+            this.toggleMessage("ucb-al-api-error", "block");
+          });
+      }
 
-                        // Append
-                        featureContainer.appendChild(featureImgLink)
-                        featureContainer.appendChild(featureTitle)
-                        featureContainer.appendChild(featureSummary)
-                        featureContainer.appendChild(featureReadMore)
-        
-                        articleFeatureContainer.appendChild(featureContainer)
-                    } else {
-                    // The non features
-        
-                    // Row
-                    var articleContainer = document.createElement('article')
-                    articleContainer.className = 'ucb-article-card col-md-4 col-sm-12 row'
-        
-                    //Img
-                    var articleImg = document.createElement('img')
-                    articleImg.className = 'ucb-article-feature-secondary-img'
-                    articleImg.src = article.imageSquare;
-        
-                    // Img Link
-                    var articleImgLink = document.createElement('a')
-                    articleImgLink.className = 'ucb-article-img-link'
-                    articleImgLink.href = article.link;
-                    articleImgLink.appendChild(articleImg)
-        
-                    // Title
-                    var articleTitle = document.createElement('h3')
-                    articleTitle.className = 'ucb-article-feature-secondary-title'
-                    //Title Link 
-                    var articleTitleLink = document.createElement('a')
-                    articleTitleLink.href = article.link;
-                    articleTitleLink.innerText = article.title;
-                    articleTitle.appendChild(articleTitleLink)
-        
-                    articleContainer.appendChild(articleImgLink)
-                    articleContainer.appendChild(articleTitle)
-                    secondaryContainer.appendChild(articleContainer)
-                    }
-                })
-                // Hide loader, append final container
-                this.toggleMessage('ucb-al-loading')
-                articleFeatureContainer.appendChild(secondaryContainer)
-                this.appendChild(articleFeatureContainer)
+      // If no chosen articles and no other options, provide error
+      if (finalArticles.length === 0 && !NEXTJSONURL) {
+        console.error(
+          "There are no available Articles that match the selected filters. Please adjust your filters and try again."
+        );
+        this.toggleMessage("ucb-al-loading");
+        this.toggleMessage("ucb-al-error", "block");
+      }
+
+      // Case for Too many articles, proceed
+      if (
+        finalArticles.length >= count ||
+        (finalArticles.length >= count && NEXTJSONURL)
+      ) {
+        finalArticles.length = count;
+      }
+
+      // Have articles and want to proceed
+      if (finalArticles.length > 0 && !NEXTJSONURL) {
+        this.renderDisplay(finalArticles, display, imgSize);
+      }
+    }
+  }
+  // Responsible for fetching & processing the body of the Article if no summary provided
+  async getArticleParagraph(id) {
+    if (!id) {
+      return "";
     }
 
-    // Used to toggle error messages and loader
-    toggleMessage(id, display = "none") {
-        if (id) {
-          var toggle = this.querySelector(`#${id}`);
-          if (toggle) {
-            if (display === "block") {
-              toggle.style.display = "block";
-            } else {
-              toggle.style.display = "none";
-            }
-          }
-        }
+    const response = await fetch(`/jsonapi/paragraph/article_content/${id}`);
+    if (!response.ok) {
+      throw new Error("Failed to fetch article paragraph");
     }
 
-    // Used for error handling within the API response
-    handleError = response => {
-        if (!response.ok) { 
-           throw new Error;
+    const data = await response.json();
+    if (!data.data.attributes.field_article_text) return ""; //  needed for external articles
+
+    let htmlStrip = data.data.attributes.field_article_text.processed.replace(
+      /<\/?[^>]+(>|$)/g,
+      ""
+    );
+    let lineBreakStrip = htmlStrip.replace(/(\r\n|\n|\r)/gm, "");
+    let trimmedString = lineBreakStrip.substr(0, 250);
+
+    if (trimmedString.length > 100) {
+      trimmedString = trimmedString.substr(
+        0,
+        Math.min(trimmedString.length, trimmedString.lastIndexOf(" "))
+      );
+    }
+
+    return trimmedString + "...";
+  }
+
+  // Responsible for calling the render function of the appropriate display
+  renderDisplay(articleArray, display, imgSize) {
+    switch (display) {
+      case "inline-large":
+        this.renderInlineLarge(articleArray, imgSize);
+        break;
+      case "inline-half":
+        this.renderInlineHalf(articleArray, imgSize);
+        break;
+      case "stacked":
+        this.renderStacked(articleArray, imgSize);
+        break;
+      default:
+        this.renderStacked(articleArray, imgSize);
+        break;
+    }
+  }
+  // The below functions are used to render the appropriate display
+  // Render Inline 50/50
+  renderInlineHalf(articleArray, imgSize) {
+    // Container
+    var articleFeatureContainer = document.createElement("div");
+    articleFeatureContainer.className = "ucb-article-feature-container row";
+
+    // This is the list of 'secondary' articles
+    var secondaryContainer = document.createElement("div");
+    secondaryContainer.className =
+      "ucb-inline-half-secondary-container col-lg-6 col-md-6 col-sm-12 col-sm-12";
+
+    articleArray.map((article) => {
+      // First article (feature)
+      if (articleFeatureContainer.children.length == 0) {
+        // This is the large feature article
+        var featureContainer = document.createElement("article");
+        featureContainer.className =
+          "ucb-inline-half-feature-container col-lg-6 col-md-6 col-sm-12 col-xs-12";
+
+        // Image
+        var featureImg = document.createElement("img");
+        if (imgSize === "wide") {
+          featureImg.src = article.imageWide;
+          featureImg.className = "ucb-feature-article-img feature-img-wide";
         } else {
-           return response.json();
+          featureImg.src = article.imageSquare;
+          featureImg.className = "ucb-feature-article-img feature-img-square";
         }
-    };
+        // Image Link
+        var featureImgLink = document.createElement("a");
+        featureImgLink.className = "ucb-feature-article-img-link";
+        featureImgLink.href = article.link;
+        featureImgLink.setAttribute("role", "presentation");
+        featureImgLink.setAttribute("aria-hidden", "true");
+        featureImgLink.appendChild(featureImg);
+
+        // Title
+        var featureTitle = document.createElement("h2");
+        featureTitle.className = "ucb-feature-article-header";
+        // Title Link
+        var featureTitleLink = document.createElement("a");
+        featureTitleLink.href = article.link;
+        featureTitleLink.innerText = article.title;
+        featureTitle.appendChild(featureTitleLink);
+
+        // Body
+        var featureSummary = document.createElement("p");
+        featureSummary.className = "ucb-feature-article-summary";
+        featureSummary.innerText = article.body;
+
+        // Read More
+        var featureReadMore = document.createElement("a");
+        featureReadMore.className = "ucb-article-read-more";
+        featureReadMore.setAttribute("aria-hidden", "true");
+        featureReadMore.href = article.link;
+        featureReadMore.innerText = "Read More";
+
+        // Append
+        featureContainer.appendChild(featureImgLink);
+        featureContainer.appendChild(featureTitle);
+        featureContainer.appendChild(featureSummary);
+        featureContainer.appendChild(featureReadMore);
+
+        articleFeatureContainer.appendChild(featureContainer);
+      } else {
+        // The non features
+
+        // Row
+        var articleContainer = document.createElement("article");
+        articleContainer.className = "ucb-article-card row";
+
+        //Img
+        var articleImg = document.createElement("img");
+        articleImg.className = "ucb-article-feature-secondary-img";
+        articleImg.src = article.imageSquare;
+
+        // Img Link
+        var articleImgLink = document.createElement("a");
+        articleImgLink.className = "ucb-article-img-link";
+        articleImgLink.href = article.link;
+        articleImgLink.setAttribute("role", "presentation");
+        articleImgLink.setAttribute("aria-hidden", "true");
+        articleImgLink.appendChild(articleImg);
+
+        // Title
+        var articleTitle = document.createElement("h3");
+        articleTitle.className = "ucb-article-feature-secondary-title";
+        //Title Link
+        var articleTitleLink = document.createElement("a");
+        articleTitleLink.href = article.link;
+        articleTitleLink.innerText = article.title;
+        articleTitle.appendChild(articleTitleLink);
+
+        articleContainer.appendChild(articleImgLink);
+        articleContainer.appendChild(articleTitle);
+        secondaryContainer.appendChild(articleContainer);
+      }
+    });
+    // Hide loader, append final container
+    this.toggleMessage("ucb-al-loading");
+    articleFeatureContainer.appendChild(secondaryContainer);
+    this.appendChild(articleFeatureContainer);
+  }
+  // Render Inline 66/33
+  renderInlineLarge(articleArray, imgSize) {
+    // Container
+    var articleFeatureContainer = document.createElement("div");
+    articleFeatureContainer.className = "ucb-article-feature-container row";
+
+    // This is the list of 'secondary' articles
+    var secondaryContainer = document.createElement("div");
+    secondaryContainer.className =
+      "ucb-inline-large-secondary-container col-lg-4 col-md-4 col-sm-4 col-sm-12";
+
+    articleArray.map((article) => {
+      // First article (feature)
+      if (articleFeatureContainer.children.length == 0) {
+        // This is the large feature article
+        var featureContainer = document.createElement("article");
+        featureContainer.className =
+          "ucb-inline-large-feature-container col-lg-8 col-md-8 col-sm-12 col-xs-12";
+
+        // Image
+        var featureImg = document.createElement("img");
+        if (imgSize === "wide") {
+          featureImg.src = article.imageWide;
+          featureImg.className = "ucb-feature-article-img feature-img-wide";
+        } else {
+          featureImg.src = article.imageSquare;
+          featureImg.className = "ucb-feature-article-img feature-img-square";
+        }
+        // Image Link
+        var featureImgLink = document.createElement("a");
+        featureImgLink.className = "ucb-feature-article-img-link";
+        featureImgLink.href = article.link;
+        featureImgLink.appendChild(featureImg);
+
+        // Title
+        var featureTitle = document.createElement("h3");
+        featureTitle.className = "ucb-feature-article-header";
+        // Title Link
+        var featureTitleLink = document.createElement("a");
+        featureTitleLink.href = article.link;
+        featureTitleLink.innerText = article.title;
+        featureTitle.appendChild(featureTitleLink);
+
+        // Body
+        var featureSummary = document.createElement("p");
+        featureSummary.className = "ucb-feature-article-summary";
+        featureSummary.innerText = article.body;
+
+        // Read More
+        var featureReadMore = document.createElement("a");
+        featureReadMore.className = "ucb-article-read-more";
+        featureReadMore.href = article.link;
+        featureReadMore.innerText = "Read More";
+        //Screen Reader text
+        var srOnly = document.createElement("span");
+        srOnly.className = "sr-only";
+        srOnly.innerText = ` about ${article.title}`;
+        featureReadMore.appendChild(srOnly);
+
+        // Append
+        featureContainer.appendChild(featureImgLink);
+        featureContainer.appendChild(featureTitle);
+        featureContainer.appendChild(featureSummary);
+        featureContainer.appendChild(featureReadMore);
+
+        articleFeatureContainer.appendChild(featureContainer);
+      } else {
+        // The non features
+
+        // Row
+        var articleContainer = document.createElement("article");
+        articleContainer.className = "ucb-article-card row";
+
+        //Img
+        var articleImg = document.createElement("img");
+        articleImg.className = "ucb-article-feature-secondary-img";
+        articleImg.src = article.imageSquare;
+
+        // Img Link
+        var articleImgLink = document.createElement("a");
+        articleImgLink.className = "ucb-article-img-link";
+        articleImgLink.href = article.link;
+        articleImgLink.appendChild(articleImg);
+
+        // Title
+        var articleTitle = document.createElement("h3");
+        articleTitle.className = "ucb-article-feature-secondary-title";
+        //Title Link
+        var articleTitleLink = document.createElement("a");
+        articleTitleLink.href = article.link;
+        articleTitleLink.innerText = article.title;
+        articleTitle.appendChild(articleTitleLink);
+
+        articleContainer.appendChild(articleImgLink);
+        articleContainer.appendChild(articleTitle);
+        secondaryContainer.appendChild(articleContainer);
+      }
+    });
+    // Hide loader, append final container
+    this.toggleMessage("ucb-al-loading");
+    articleFeatureContainer.appendChild(secondaryContainer);
+    this.appendChild(articleFeatureContainer);
+  }
+  // Render Stacked
+  renderStacked(articleArray, imgSize) {
+    // Container
+    var articleFeatureContainer = document.createElement("div");
+    articleFeatureContainer.className = "ucb-article-feature-container row";
+
+    // This is the list of 'secondary' articles
+    var secondaryContainer = document.createElement("div");
+    secondaryContainer.className =
+      "ucb-stacked-secondary-container row col-sm-12";
+
+    articleArray.map((article) => {
+      // First article (feature)
+      if (articleFeatureContainer.children.length == 0) {
+        // This is the large feature article
+        var featureContainer = document.createElement("article");
+        featureContainer.className = "ucb-stacked-primary-container col-xs-12";
+
+        // Image
+        var featureImg = document.createElement("img");
+        if (imgSize === "wide") {
+          featureImg.src = article.imageWide;
+          featureImg.className = "ucb-feature-article-img feature-img-wide";
+        } else {
+          featureImg.src = article.imageSquare;
+          featureImg.className = "ucb-feature-article-img feature-img-square";
+        }
+        // Image Link
+        var featureImgLink = document.createElement("a");
+        featureImgLink.className = "ucb-feature-article-img-link";
+        featureImgLink.href = article.link;
+        featureImgLink.appendChild(featureImg);
+
+        // Title
+        var featureTitle = document.createElement("h2");
+        featureTitle.className = "ucb-feature-article-header";
+        // Title Link
+        var featureTitleLink = document.createElement("a");
+        featureTitleLink.href = article.link;
+        featureTitleLink.innerText = article.title;
+        featureTitle.appendChild(featureTitleLink);
+
+        // Body
+        var featureSummary = document.createElement("p");
+        featureSummary.className = "ucb-feature-article-summary";
+        featureSummary.innerText = article.body;
+
+        // Read More
+        var featureReadMore = document.createElement("a");
+        featureReadMore.className = "ucb-article-read-more";
+        featureReadMore.href = article.link;
+        featureReadMore.innerText = "Read More";
+        //Screen Reader text
+        var srOnly = document.createElement("span");
+        srOnly.className = "sr-only";
+        srOnly.innerText = ` about ${article.title}`;
+        featureReadMore.appendChild(srOnly);
+
+        // Append
+        featureContainer.appendChild(featureImgLink);
+        featureContainer.appendChild(featureTitle);
+        featureContainer.appendChild(featureSummary);
+        featureContainer.appendChild(featureReadMore);
+
+        articleFeatureContainer.appendChild(featureContainer);
+      } else {
+        // The non features
+
+        // Row
+        var articleContainer = document.createElement("article");
+        articleContainer.className = "ucb-article-card col-md-4 col-sm-12 row";
+
+        //Img
+        var articleImg = document.createElement("img");
+        articleImg.className = "ucb-article-feature-secondary-img";
+        articleImg.src = article.imageSquare;
+
+        // Img Link
+        var articleImgLink = document.createElement("a");
+        articleImgLink.className = "ucb-article-img-link";
+        articleImgLink.href = article.link;
+        articleImgLink.appendChild(articleImg);
+
+        // Title
+        var articleTitle = document.createElement("h3");
+        articleTitle.className = "ucb-article-feature-secondary-title";
+        //Title Link
+        var articleTitleLink = document.createElement("a");
+        articleTitleLink.href = article.link;
+        articleTitleLink.innerText = article.title;
+        articleTitle.appendChild(articleTitleLink);
+
+        articleContainer.appendChild(articleImgLink);
+        articleContainer.appendChild(articleTitle);
+        secondaryContainer.appendChild(articleContainer);
+      }
+    });
+    // Hide loader, append final container
+    this.toggleMessage("ucb-al-loading");
+    articleFeatureContainer.appendChild(secondaryContainer);
+    this.appendChild(articleFeatureContainer);
+  }
+
+  // Used to toggle error messages and loader
+  toggleMessage(id, display = "none") {
+    if (id) {
+      var toggle = this.querySelector(`#${id}`);
+      if (toggle) {
+        if (display === "block") {
+          toggle.style.display = "block";
+        } else {
+          toggle.style.display = "none";
+        }
+      }
+    }
+  }
+
+  // Used for error handling within the API response
+  handleError = (response) => {
+    if (!response.ok) {
+      throw new Error();
+    } else {
+      return response.json();
+    }
+  };
 }
 
-customElements.define('article-feature-block', ArticleFeatureBlockElement);
+customElements.define("article-feature-block", ArticleFeatureBlockElement);

--- a/js/ucb-article-grid-block.js
+++ b/js/ucb-article-grid-block.js
@@ -1,293 +1,355 @@
 class ArticleGridBlockElement extends HTMLElement {
-	constructor() {
-		super();
-        // Count, display and JSON API Endpoint
-        var count = this.getAttribute('count');
-        var includeSummary = this.getAttribute('includeSummary');
-        var API = this.getAttribute('jsonapi');
-        // Exclusions are done on the JS side, get into arrays. Blank if no exclusions
-        var excludeCatArray = this.getAttribute('exCats').split(",").map(Number);
-        var excludeTagArray = this.getAttribute('exTags').split(",").map(Number);
+  constructor() {
+    super();
+    // Count, display and JSON API Endpoint
+    var count = this.getAttribute("count");
+    var includeSummary = this.getAttribute("includeSummary");
+    var API = this.getAttribute("jsonapi");
+    // Exclusions are done on the JS side, get into arrays. Blank if no exclusions
+    var excludeCatArray = this.getAttribute("exCats").split(",").map(Number);
+    var excludeTagArray = this.getAttribute("exTags").split(",").map(Number);
 
-        fetch(API)
-            .then(this.handleError)
-            .then((data) => this.build(data, count, includeSummary, excludeCatArray, excludeTagArray))
-            .catch(Error=> {
-              console.error('There was an error fetching data from the API - Please try again later.')
-              console.error(Error)
-              this.toggleMessage('ucb-al-loading')
-              this.toggleMessage('ucb-al-api-error', "block")
-            });
+    fetch(API)
+      .then(this.handleError)
+      .then((data) =>
+        this.build(
+          data,
+          count,
+          includeSummary,
+          excludeCatArray,
+          excludeTagArray
+        )
+      )
+      .catch((Error) => {
+        console.error(
+          "There was an error fetching data from the API - Please try again later."
+        );
+        console.error(Error);
+        this.toggleMessage("ucb-al-loading");
+        this.toggleMessage("ucb-al-api-error", "block");
+      });
+  }
+
+  async build(
+    data,
+    count,
+    includeSummary,
+    excludeCatArray,
+    excludeTagArray,
+    finalArticles = []
+  ) {
+    // More than 10 articles? This sets up the next call if there's more articles to be retrieved but not enough post-filters
+    let NEXTJSONURL = "";
+    if (data.links.next) {
+      let nextURL = data.links.next.href.split("/jsonapi/");
+      NEXTJSONURL = `/jsonapi/${nextURL[1]}`;
+    } else {
+      NEXTJSONURL = "";
     }
 
-    async build(data, count, includeSummary, excludeCatArray, excludeTagArray, finalArticles = []){
-      // More than 10 articles? This sets up the next call if there's more articles to be retrieved but not enough post-filters
-        let NEXTJSONURL = "";
-        if(data.links.next) {
-            let nextURL = data.links.next.href.split("/jsonapi/");
-            NEXTJSONURL = `/jsonapi/${nextURL[1]}`;
-          } else {
-            NEXTJSONURL = "";
-          }
-
-          // If no Articles retrieved...
-        if(data.data.length == 0){
-            this.toggleMessage('ucb-al-loading')
-            this.toggleMessage('ucb-al-error',"block")
-            console.warn('No Articles retrieved - please check your inclusion filters and try again')
-        } else {
-        // Below objects are needed to match images with their corresponding articles. There are two endpoints => data.data (article) and data.included (incl. media), both needed to associate a media library image with its respective article
-        let idObj = {};
-        let altObj = {};
-        // Remove any blanks from our articles before map
-        if (data.included) {
-          // removes all other included data besides images in our included media
-          let idFilterData = data.included.filter((item) => {
-            return item.type == "media--image";
-          })
-
-          let altFilterData = data.included.filter((item) => {
-            return item.type == 'file--file';
-          });
-          // finds the focial point version of the thumbnail
-          altFilterData.map((item)=>{
-            // checks if consumer is working, else default to standard image instead of focal image
-            if(item.links.focal_image_square != undefined){
-              altObj[item.id] = item.links.focal_image_square.href
-            } else {
-              altObj[item.id] = item.attributes.uri.url
-            }
-        })
-
-          // using the image-only data, creates the idObj =>  key: thumbnail id, value : data id
-          idFilterData.map((pair) => {
-            idObj[pair.id] = pair.relationships.thumbnail.data.id;
-          })
-        }
-    // Iterate over each Article
-    await Promise.all(data.data.map(async (item)=>{
-            // Article must have a thumbnail
-            if(item.relationships.field_ucb_article_thumbnail.data){
-                let thisArticleCats = [];
-                let thisArticleTags = [];
-                
-                // // loop through and grab all of the categories
-                if (item.relationships.field_ucb_article_categories) {
-                for (let i = 0; i < item.relationships.field_ucb_article_categories.data.length; i++) {
-                    thisArticleCats.push(
-                    item.relationships.field_ucb_article_categories.data[i].meta
-                        .drupal_internal__target_id
-                    )
-                }
-                }  
-                // // loop through and grab all of the tags
-                if (item.relationships.field_ucb_article_tags) {
-                for (var i = 0; i < item.relationships.field_ucb_article_tags.data.length; i++) {
-                    thisArticleTags.push(item.relationships.field_ucb_article_tags.data[i].meta.drupal_internal__target_id)
-                }
-                }
-
-                let doesIncludeCat = thisArticleCats;
-                let doesIncludeTag = thisArticleTags;
-
-                // check to see if we need to filter on categories
-                if (excludeCatArray.length && thisArticleCats.length) {
-                doesIncludeCat = thisArticleCats.filter((element) =>
-                    excludeCatArray.includes(element)
-                )
-                }
-                // check to see if we need to filter on tags
-                if (excludeTagArray.length && thisArticleTags.length) {
-                doesIncludeTag = thisArticleTags.filter((element) =>
-                    excludeTagArray.includes(element)
-                )
-                }
-
-                // If there's no categories or tags that are in the exclusions, proceed
-                if (doesIncludeCat.length == 0 && doesIncludeTag.length == 0) {
-                    // okay to render
-                    let bodyAndImageId = item.relationships.field_ucb_article_content.data.length ? item.relationships.field_ucb_article_content.data[0].id : "";
-                    let body = item.attributes.field_ucb_article_summary ? item.attributes.field_ucb_article_summary : "";
-                    body = body.trim();
-                    let imageSrc = "";
-
-                    if (!body.length && bodyAndImageId != "") {
-                      body = await this.getArticleParagraph(bodyAndImageId);
-                    }
-
-                    // if no thumbnail, show no image
-                    if (!item.relationships.field_ucb_article_thumbnail.data) {
-                        imageSrc = "";
-                    } else {
-                        //Use the idObj as a memo to add the corresponding image url
-                        let thumbId = item.relationships.field_ucb_article_thumbnail.data.id;
-                        imageSrc = altObj[idObj[thumbId]];
-                    }
-
-                    //Date - make human readable
-                    const options = { year: 'numeric', month: 'short', day: 'numeric' };
-                    let date = new Date(item.attributes.created).toLocaleDateString('en-us', options);
-                    let title = item.attributes.title;
-                    let link = item.attributes.path.alias;
-
-                    // Create an Article Object for programatic rendering
-                    const article = {
-                        title,
-                        link,
-                        image: imageSrc,
-                        date,
-                        body,
-                    }
-                    // Adds the article object to the final array of articles chosen
-                    finalArticles.push(article)
-                }
-        }
-    }));
-        // Case for not enough articles selected and extra articles available
-        if(finalArticles.length < count && NEXTJSONURL){
-            fetch(NEXTJSONURL).then(this.handleError)
-            .then((data) => this.build(data, count, includeSummary, excludeCatArray, excludeTagArray, finalArticles))
-            .catch(Error=> {
-              console.error('There was an error fetching data from the API - Please try again later.')
-              console.error(Error)
-              this.toggleMessage('ucb-al-loading')
-              this.toggleMessage('ucb-al-api-error', "block")
-            });
-        }
-
-        // If no chosen articles and no other options, provide error
-        if(finalArticles.length === 0 && !NEXTJSONURL){
-          console.error('There are no available Articles that match the selected filters. Please adjust your filters and try again.')
-          this.toggleMessage('ucb-al-loading')
-          this.toggleMessage('ucb-al-error', "block")
-        }
-
-        // Case for Too many articles
-        if(finalArticles.length >= count || (finalArticles.length >= count && NEXTJSONURL)){
-          finalArticles.length = count
-      }
-
-        // Have articles and want to proceed
-        if((finalArticles.length >= 0 && !NEXTJSONURL) || (finalArticles.length == count && NEXTJSONURL)){
-          finalArticles.length = count
-          this.renderDisplay(finalArticles, includeSummary)
-        }
-    }
-}
-
-    // Responsible for fetching & processing the body of the Article if no summary provided
-    async getArticleParagraph(id) {
-          if (!id) {
-              return "";
-          }
-          
-          const response = await fetch(`/jsonapi/paragraph/article_content/${id}`);
-          if (!response.ok) {
-              throw new Error('Failed to fetch article paragraph');
-          }
-    
-          const data = await response.json();
-          if (!data.data.attributes.field_article_text) return ""; //  needed for external articles
-
-          let htmlStrip = data.data.attributes.field_article_text.processed.replace(
-              /<\/?[^>]+(>|$)/g,
-              ""
-          );
-          let lineBreakStrip = htmlStrip.replace(/(\r\n|\n|\r)/gm, "");
-          let trimmedString = lineBreakStrip.substr(0, 250);
-          
-          if (trimmedString.length > 100) {
-              trimmedString = trimmedString.substr(
-                  0,
-                  Math.min(
-                      trimmedString.length,
-                      trimmedString.lastIndexOf(" ")
-                  )
-              );
-          }
-    
-          return trimmedString + "...";
-    }
-
-    // Responsible for calling the render function of the appropriate display
-    renderDisplay(articleArray, includeSummary){
-        var articleGridContainer = document.createElement('div')
-        articleGridContainer.className = 'row ucb-article-grid-container';
-
-        articleArray.forEach(article => {
-          var articleCard = document.createElement('div')
-          articleCard.className = 'ucb-article-grid-card col-sm-12 col-md-6 col-lg-4'
-
-          // Image
-          var articleImgContainer = document.createElement('div')
-          articleImgContainer.className = 'ucb-article-grid-card-img-container'
-
-          var articleImg = document.createElement('img')
-          articleImg.className = 'ucb-article-grid-card-img'
-          articleImg.src = article.image;
-
-          var articleImgLink = document.createElement('a')
-          articleImgLink.className = 'ucb-article-grid-card-img-link'
-          articleImgLink.href = article.link;
-          articleImgLink.setAttribute('role', 'presentation');
-          articleImgLink.setAttribute('aria-hidden', 'true');
-
-          // Image append
-          articleImgLink.appendChild(articleImg)
-          articleImgContainer.appendChild(articleImgLink)
-          articleCard.appendChild(articleImgContainer)
-
-          // Header
-          var articleCardTitle = document.createElement('h3')
-          articleCardTitle.className = 'ucb-article-grid-header'
-          articleCardTitle.innerText = article.title
-          var articleCardTitleLink = document.createElement('a')
-          articleCardTitleLink.className = 'ucb-article-grid-header-link'
-          articleCardTitleLink.href = article.link;
-
-          articleCardTitleLink.appendChild(articleCardTitle)
-          articleCard.appendChild(articleCardTitleLink)
-
-          // Summary - optional
-          if(includeSummary === 'True'){
-            var articleCardSummary = document.createElement('p')
-            articleCardSummary.className = 'ucb-article-grid-summary'
-            articleCardSummary.innerText = article.body;
-            articleCard.appendChild(articleCardSummary)
-          }
-
-          // Append final article card to div
-          articleGridContainer.appendChild(articleCard)
+    // If no Articles retrieved...
+    if (data.data.length == 0) {
+      this.toggleMessage("ucb-al-loading");
+      this.toggleMessage("ucb-al-error", "block");
+      console.warn(
+        "No Articles retrieved - please check your inclusion filters and try again"
+      );
+    } else {
+      // Below objects are needed to match images with their corresponding articles. There are two endpoints => data.data (article) and data.included (incl. media), both needed to associate a media library image with its respective article
+      let idObj = {};
+      let altObj = {};
+      // Remove any blanks from our articles before map
+      if (data.included) {
+        // removes all other included data besides images in our included media
+        let idFilterData = data.included.filter((item) => {
+          return item.type == "media--image";
         });
 
-        // Hide loader, append final container
-        this.toggleMessage('ucb-al-loading')
-        this.appendChild(articleGridContainer)
+        let altFilterData = data.included.filter((item) => {
+          return item.type == "file--file";
+        });
+        // finds the focial point version of the thumbnail
+        altFilterData.map((item) => {
+          // checks if consumer is working, else default to standard image instead of focal image
+          if (item.links.focal_image_square != undefined) {
+            altObj[item.id] = item.links.focal_image_square.href;
+          } else {
+            altObj[item.id] = item.attributes.uri.url;
+          }
+        });
 
-    }
+        // using the image-only data, creates the idObj =>  key: thumbnail id, value : data id
+        idFilterData.map((pair) => {
+          idObj[pair.id] = pair.relationships.thumbnail.data.id;
+        });
+      }
+      // Iterate over each Article
+      await Promise.all(
+        data.data.map(async (item) => {
+          // Article must have a thumbnail
+          if (item.relationships.field_ucb_article_thumbnail.data) {
+            let thisArticleCats = [];
+            let thisArticleTags = [];
 
-    // Used to toggle error messages and loader
-    toggleMessage(id, display = "none") {
-        if (id) {
-          var toggle = this.querySelector(`#${id}`);
-          if (toggle) {
-            if (display === "block") {
-              toggle.style.display = "block";
-            } else {
-              toggle.style.display = "none";
+            // // loop through and grab all of the categories
+            if (item.relationships.field_ucb_article_categories) {
+              for (
+                let i = 0;
+                i < item.relationships.field_ucb_article_categories.data.length;
+                i++
+              ) {
+                thisArticleCats.push(
+                  item.relationships.field_ucb_article_categories.data[i].meta
+                    .drupal_internal__target_id
+                );
+              }
+            }
+            // // loop through and grab all of the tags
+            if (item.relationships.field_ucb_article_tags) {
+              for (
+                var i = 0;
+                i < item.relationships.field_ucb_article_tags.data.length;
+                i++
+              ) {
+                thisArticleTags.push(
+                  item.relationships.field_ucb_article_tags.data[i].meta
+                    .drupal_internal__target_id
+                );
+              }
+            }
+
+            let doesIncludeCat = thisArticleCats;
+            let doesIncludeTag = thisArticleTags;
+
+            // check to see if we need to filter on categories
+            if (excludeCatArray.length && thisArticleCats.length) {
+              doesIncludeCat = thisArticleCats.filter((element) =>
+                excludeCatArray.includes(element)
+              );
+            }
+            // check to see if we need to filter on tags
+            if (excludeTagArray.length && thisArticleTags.length) {
+              doesIncludeTag = thisArticleTags.filter((element) =>
+                excludeTagArray.includes(element)
+              );
+            }
+
+            // If there's no categories or tags that are in the exclusions, proceed
+            if (doesIncludeCat.length == 0 && doesIncludeTag.length == 0) {
+              // okay to render
+              let bodyAndImageId = item.relationships.field_ucb_article_content
+                .data.length
+                ? item.relationships.field_ucb_article_content.data[0].id
+                : "";
+              let body = item.attributes.field_ucb_article_summary
+                ? item.attributes.field_ucb_article_summary
+                : "";
+              body = body.trim();
+              let imageSrc = "";
+
+              if (!body.length && bodyAndImageId != "") {
+                body = await this.getArticleParagraph(bodyAndImageId);
+              }
+
+              // if no thumbnail, show no image
+              if (!item.relationships.field_ucb_article_thumbnail.data) {
+                imageSrc = "";
+              } else {
+                //Use the idObj as a memo to add the corresponding image url
+                let thumbId =
+                  item.relationships.field_ucb_article_thumbnail.data.id;
+                imageSrc = altObj[idObj[thumbId]];
+              }
+
+              //Date - make human readable
+              const options = {
+                year: "numeric",
+                month: "short",
+                day: "numeric",
+              };
+              let date = new Date(item.attributes.created).toLocaleDateString(
+                "en-us",
+                options
+              );
+              let title = item.attributes.title;
+              let link = item.attributes.path.alias;
+
+              // Create an Article Object for programatic rendering
+              const article = {
+                title,
+                link,
+                image: imageSrc,
+                date,
+                body,
+              };
+              // Adds the article object to the final array of articles chosen
+              finalArticles.push(article);
             }
           }
-        }
+        })
+      );
+      // Case for not enough articles selected and extra articles available
+      if (finalArticles.length < count && NEXTJSONURL) {
+        fetch(NEXTJSONURL)
+          .then(this.handleError)
+          .then((data) =>
+            this.build(
+              data,
+              count,
+              includeSummary,
+              excludeCatArray,
+              excludeTagArray,
+              finalArticles
+            )
+          )
+          .catch((Error) => {
+            console.error(
+              "There was an error fetching data from the API - Please try again later."
+            );
+            console.error(Error);
+            this.toggleMessage("ucb-al-loading");
+            this.toggleMessage("ucb-al-api-error", "block");
+          });
+      }
+
+      // If no chosen articles and no other options, provide error
+      if (finalArticles.length === 0 && !NEXTJSONURL) {
+        console.error(
+          "There are no available Articles that match the selected filters. Please adjust your filters and try again."
+        );
+        this.toggleMessage("ucb-al-loading");
+        this.toggleMessage("ucb-al-error", "block");
+      }
+
+      // Case for Too many articles
+      if (
+        finalArticles.length >= count ||
+        (finalArticles.length >= count && NEXTJSONURL)
+      ) {
+        finalArticles.length = count;
+      }
+
+      // Have articles and want to proceed
+      if (
+        (finalArticles.length >= 0 && !NEXTJSONURL) ||
+        (finalArticles.length == count && NEXTJSONURL)
+      ) {
+        finalArticles.length = count;
+        this.renderDisplay(finalArticles, includeSummary);
+      }
+    }
+  }
+
+  // Responsible for fetching & processing the body of the Article if no summary provided
+  async getArticleParagraph(id) {
+    if (!id) {
+      return "";
     }
 
-    // Used for error handling within the API response
-    handleError = response => {
-        if (!response.ok) { 
-           throw new Error;
+    const response = await fetch(`/jsonapi/paragraph/article_content/${id}`);
+    if (!response.ok) {
+      throw new Error("Failed to fetch article paragraph");
+    }
+
+    const data = await response.json();
+    if (!data.data.attributes.field_article_text) return ""; //  needed for external articles
+
+    let htmlStrip = data.data.attributes.field_article_text.processed.replace(
+      /<\/?[^>]+(>|$)/g,
+      ""
+    );
+    let lineBreakStrip = htmlStrip.replace(/(\r\n|\n|\r)/gm, "");
+    let trimmedString = lineBreakStrip.substr(0, 250);
+
+    if (trimmedString.length > 100) {
+      trimmedString = trimmedString.substr(
+        0,
+        Math.min(trimmedString.length, trimmedString.lastIndexOf(" "))
+      );
+    }
+
+    return trimmedString + "...";
+  }
+
+  // Responsible for calling the render function of the appropriate display
+  renderDisplay(articleArray, includeSummary) {
+    var articleGridContainer = document.createElement("div");
+    articleGridContainer.className = "row ucb-article-grid-container";
+
+    articleArray.forEach((article) => {
+      var articleCard = document.createElement("div");
+      articleCard.className =
+        "ucb-article-grid-card col-sm-12 col-md-6 col-lg-4";
+
+      // Image
+      var articleImgContainer = document.createElement("div");
+      articleImgContainer.className = "ucb-article-grid-card-img-container";
+
+      var articleImg = document.createElement("img");
+      articleImg.className = "ucb-article-grid-card-img";
+      articleImg.src = article.image;
+
+      var articleImgLink = document.createElement("a");
+      articleImgLink.className = "ucb-article-grid-card-img-link";
+      articleImgLink.href = article.link;
+      articleImgLink.setAttribute("role", "presentation");
+      articleImgLink.setAttribute("aria-hidden", "true");
+
+      // Image append
+      articleImgLink.appendChild(articleImg);
+      articleImgContainer.appendChild(articleImgLink);
+      articleCard.appendChild(articleImgContainer);
+
+      // Header
+      var articleCardTitle = document.createElement("h3");
+      articleCardTitle.className = "ucb-article-grid-header";
+      articleCardTitle.innerText = article.title;
+      var articleCardTitleLink = document.createElement("a");
+      articleCardTitleLink.className = "ucb-article-grid-header-link";
+      articleCardTitleLink.href = article.link;
+
+      articleCardTitleLink.appendChild(articleCardTitle);
+      articleCard.appendChild(articleCardTitleLink);
+
+      // Summary - optional
+      if (includeSummary === "True") {
+        var articleCardSummary = document.createElement("p");
+        articleCardSummary.className = "ucb-article-grid-summary";
+        articleCardSummary.innerText = article.body;
+        articleCard.appendChild(articleCardSummary);
+      }
+
+      // Append final article card to div
+      articleGridContainer.appendChild(articleCard);
+    });
+
+    // Hide loader, append final container
+    this.toggleMessage("ucb-al-loading");
+    this.appendChild(articleGridContainer);
+  }
+
+  // Used to toggle error messages and loader
+  toggleMessage(id, display = "none") {
+    if (id) {
+      var toggle = this.querySelector(`#${id}`);
+      if (toggle) {
+        if (display === "block") {
+          toggle.style.display = "block";
         } else {
-           return response.json();
+          toggle.style.display = "none";
         }
-    };
+      }
+    }
+  }
+
+  // Used for error handling within the API response
+  handleError = (response) => {
+    if (!response.ok) {
+      throw new Error();
+    } else {
+      return response.json();
+    }
+  };
 }
 
-customElements.define('article-grid-block', ArticleGridBlockElement);
+customElements.define("article-grid-block", ArticleGridBlockElement);

--- a/js/ucb-article-grid-block.js
+++ b/js/ucb-article-grid-block.js
@@ -187,7 +187,8 @@ class ArticleGridBlockElement extends HTMLElement {
           }
     
           const data = await response.json();
-          
+          if (!data.data.attributes.field_article_text) return ""; //  needed for external articles
+
           let htmlStrip = data.data.attributes.field_article_text.processed.replace(
               /<\/?[^>]+(>|$)/g,
               ""

--- a/js/ucb-article-list-block.js
+++ b/js/ucb-article-list-block.js
@@ -112,7 +112,7 @@ class ArticleListBlockElement extends HTMLElement {
           body = body.trim();
           let imageSrc = "";
           let imageSrcWide = "";
-          if (!body.length && bodyAndImageId != "" && !item.attributes.field_ucb_article_external_url) {
+          if (!body.length && bodyAndImageId != "") {
             body = await this.getArticleParagraph(bodyAndImageId);
           }
 

--- a/js/ucb-article-list-block.js
+++ b/js/ucb-article-list-block.js
@@ -112,8 +112,7 @@ class ArticleListBlockElement extends HTMLElement {
           body = body.trim();
           let imageSrc = "";
           let imageSrcWide = "";
-
-          if (!body.length && bodyAndImageId != "") {
+          if (!body.length && bodyAndImageId != "" && !item.attributes.field_ucb_article_external_url) {
             body = await this.getArticleParagraph(bodyAndImageId);
           }
 
@@ -188,6 +187,7 @@ class ArticleListBlockElement extends HTMLElement {
     }
 
     const data = await response.json();
+    if (!data.data.attributes.field_article_text) return ""; //  needed for external articles
 
     let htmlStrip = data.data.attributes.field_article_text.processed.replace(
       /<\/?[^>]+(>|$)/g,

--- a/js/ucb-article-slider-block.js
+++ b/js/ucb-article-slider-block.js
@@ -155,17 +155,7 @@ class ArticleSliderBlockElement extends HTMLElement {
         }
     }
 }
-    
-    async getArticleParagraph(id) {
-        if(id) {
-          const response = await fetch(
-            `/jsonapi/paragraph/article_content/${id}`
-          );
-          return response;
-        } else {
-            return "";
-        }
-    }
+
     renderDisplay(articleArray){
       var fliktyInit = document.getElementsByClassName('ucb-article-slider')[0]
       articleArray.map(article=>{


### PR DESCRIPTION
### Article List Blocks: External Article Handling ( "Article Grid Block", "Article List Block", "Article Feature Block" )

- Adds edge case to handle Article pages displaying in the "Teaser" style `Article List Block` that may not have an Article body or summary field added, such as an external article reference with no summary added.

#### Article Grid + Article Feature Accessibility Changes
- Adjusts to accessibility standards for repeated links on the "Article Grid" and "Article Feature" blocks, all links other than the title have been set to `aria-hidden = "true"`. Images with links set to `role="presentation"` to prevent screen readers from repeating link information two or three times.
- Some JavaScript code formatting, no functionality changes.

#### CSS Fixes
- Article Feature: The secondary Articles needed additional margin between the thumbnail and the title/link of the Article
- Article List Block: The entire element had left/right padding preventing alignment with other blocks.

Resolves #971 