### PR TITLE
Change collection categories revision id to tid

### DIFF
--- a/js/ucb-collections-block.js
+++ b/js/ucb-collections-block.js
@@ -42,7 +42,7 @@
             }
 
             data.data.map((item) => {
-              let currentDataID = item.attributes.drupal_internal__revision_id;
+              let currentDataID = item.attributes.drupal_internal__tid;
               let currentClassName =
                 "category-label-" + currentDataID + "-" + blockID;
               let categoryLabels =


### PR DESCRIPTION
Closes #997.
Changes the search from collection category revision id to tid to solve an issue in migration.