### PR TITLE
Refactors block style field templates

### DIFF
--- a/templates/field/field--field-bs-background-style.html.twig
+++ b/templates/field/field--field-bs-background-style.html.twig
@@ -1,32 +1,29 @@
-{% for item in items %}
-  {% set backgroundChoice = element['#object'].get('field_bs_background_style').value %}
+{% set backgroundChoice = element['#object'].get('field_bs_background_style').value %}
 
-  {% if backgroundChoice == 'bs_background_style_white' %}
-    {% set blockBackground = 'bs-background-white' %}
-  {% elseif backgroundChoice == 'bs_background_style_gray' %}
-    {% set blockBackground = 'bs-background-gray' %}
-  {% elseif backgroundChoice == 'bs_background_style_dark_gray' %}
-    {% set blockBackground = 'bs-background-dark-gray' %}
-  {% elseif backgroundChoice == 'bs_background_style_tan' %}
-    {% set blockBackground = 'bs-background-tan' %}
-  {% elseif backgroundChoice == 'bs_background_style_light_blue' %}
-    {% set blockBackground = 'bs-background-light-blue' %}
-  {% elseif backgroundChoice == 'bs_background_style_medium_blue' %}
-    {% set blockBackground = 'bs-background-medium-blue' %}
-  {% elseif backgroundChoice == 'bs_background_style_dark_blue' %}
-    {% set blockBackground = 'bs-background-dark-blue' %}
-  {% elseif backgroundChoice == 'bs_background_style_light_green' %}
-    {% set blockBackground = 'bs-background-light-green' %}
-  {% elseif backgroundChoice == 'bs_background_style_brick' %}
-    {% set blockBackground = 'bs-background-brick' %}
-  {% elseif backgroundChoice == 'bs_background_style_outline' %}
-    {% set blockBackground = 'bs-background-outline' %}
-  {% elseif backgroundChoice == 'bs_background_style_underline' %}
-    {% set blockBackground = 'bs-background-underline' %}
-  {% else %}
-    {% set blockBackground = 'bs-background-none' %}
-  {% endif %}
+{% if backgroundChoice == 'bs_background_style_white' %}
+  {% set blockBackground = 'bs-background-white' %}
+{% elseif backgroundChoice == 'bs_background_style_gray' %}
+  {% set blockBackground = 'bs-background-gray' %}
+{% elseif backgroundChoice == 'bs_background_style_dark_gray' %}
+  {% set blockBackground = 'bs-background-dark-gray' %}
+{% elseif backgroundChoice == 'bs_background_style_tan' %}
+  {% set blockBackground = 'bs-background-tan' %}
+{% elseif backgroundChoice == 'bs_background_style_light_blue' %}
+  {% set blockBackground = 'bs-background-light-blue' %}
+{% elseif backgroundChoice == 'bs_background_style_medium_blue' %}
+  {% set blockBackground = 'bs-background-medium-blue' %}
+{% elseif backgroundChoice == 'bs_background_style_dark_blue' %}
+  {% set blockBackground = 'bs-background-dark-blue' %}
+{% elseif backgroundChoice == 'bs_background_style_light_green' %}
+  {% set blockBackground = 'bs-background-light-green' %}
+{% elseif backgroundChoice == 'bs_background_style_brick' %}
+  {% set blockBackground = 'bs-background-brick' %}
+{% elseif backgroundChoice == 'bs_background_style_outline' %}
+  {% set blockBackground = 'bs-background-outline' %}
+{% elseif backgroundChoice == 'bs_background_style_underline' %}
+  {% set blockBackground = 'bs-background-underline' %}
+{% else %}
+  {% set blockBackground = 'bs-background-none' %}
+{% endif %}
 
-  {{ blockBackground }}
-
-{% endfor %}
+{{ blockBackground }}

--- a/templates/field/field--field-bs-background-style.html.twig
+++ b/templates/field/field--field-bs-background-style.html.twig
@@ -1,31 +1,32 @@
 {% for item in items %}
+	{% set backgroundChoice = element['#object'].get('field_bs_background_style').value %}
 
-	{% if item.content|render|striptags|trim == 'White' %}
+	{% if backgroundChoice == 'bs_background_style_white' %}
 		{% set blockBackground = 'bs-background-white' %}
-	{% elseif item.content|render|striptags|trim == 'Gray' %}
+	{% elseif backgroundChoice == 'bs_background_style_gray' %}
 		{% set blockBackground = 'bs-background-gray' %}
-	{% elseif item.content|render|striptags|trim == 'Dark Gray' %}
+	{% elseif backgroundChoice == 'bs_background_style_dark_gray' %}
 		{% set blockBackground = 'bs-background-dark-gray' %}
-	{% elseif item.content|render|striptags|trim == 'Tan' %}
+	{% elseif backgroundChoice == 'bs_background_style_tan' %}
 		{% set blockBackground = 'bs-background-tan' %}
-	{% elseif item.content|render|striptags|trim == 'Light Blue' %}
+	{% elseif backgroundChoice == 'bs_background_style_light_blue' %}
 		{% set blockBackground = 'bs-background-light-blue' %}
-	{% elseif item.content|render|striptags|trim == 'Medium Blue' %}
+	{% elseif backgroundChoice == 'bs_background_style_medium_blue' %}
 		{% set blockBackground = 'bs-background-medium-blue' %}
-	{% elseif item.content|render|striptags|trim == 'Dark Blue' %}
+	{% elseif backgroundChoice == 'bs_background_style_dark_blue' %}
 		{% set blockBackground = 'bs-background-dark-blue' %}
-	{% elseif item.content|render|striptags|trim == 'Light Green' %}
+	{% elseif backgroundChoice == 'bs_background_style_light_green' %}
 		{% set blockBackground = 'bs-background-light-green' %}
-	{% elseif item.content|render|striptags|trim == 'Brick' %}
+	{% elseif backgroundChoice == 'bs_background_style_brick' %}
 		{% set blockBackground = 'bs-background-brick' %}
-	{% elseif item.content|render|striptags|trim == 'Outline' %}
+	{% elseif backgroundChoice == 'bs_background_style_outline' %}
 		{% set blockBackground = 'bs-background-outline' %}
-	{% elseif item.content|render|striptags|trim == 'Underline' %}
+	{% elseif backgroundChoice == 'bs_background_style_underline' %}
 		{% set blockBackground = 'bs-background-underline' %}
 	{% else %}
 		{% set blockBackground = 'bs-background-none' %}
 	{% endif %}
 
-	{{ blockBackground }}
+{{ blockBackground }}
 
 {% endfor %}

--- a/templates/field/field--field-bs-background-style.html.twig
+++ b/templates/field/field--field-bs-background-style.html.twig
@@ -1,32 +1,32 @@
 {% for item in items %}
-	{% set backgroundChoice = element['#object'].get('field_bs_background_style').value %}
+  {% set backgroundChoice = element['#object'].get('field_bs_background_style').value %}
 
-	{% if backgroundChoice == 'bs_background_style_white' %}
-		{% set blockBackground = 'bs-background-white' %}
-	{% elseif backgroundChoice == 'bs_background_style_gray' %}
-		{% set blockBackground = 'bs-background-gray' %}
-	{% elseif backgroundChoice == 'bs_background_style_dark_gray' %}
-		{% set blockBackground = 'bs-background-dark-gray' %}
-	{% elseif backgroundChoice == 'bs_background_style_tan' %}
-		{% set blockBackground = 'bs-background-tan' %}
-	{% elseif backgroundChoice == 'bs_background_style_light_blue' %}
-		{% set blockBackground = 'bs-background-light-blue' %}
-	{% elseif backgroundChoice == 'bs_background_style_medium_blue' %}
-		{% set blockBackground = 'bs-background-medium-blue' %}
-	{% elseif backgroundChoice == 'bs_background_style_dark_blue' %}
-		{% set blockBackground = 'bs-background-dark-blue' %}
-	{% elseif backgroundChoice == 'bs_background_style_light_green' %}
-		{% set blockBackground = 'bs-background-light-green' %}
-	{% elseif backgroundChoice == 'bs_background_style_brick' %}
-		{% set blockBackground = 'bs-background-brick' %}
-	{% elseif backgroundChoice == 'bs_background_style_outline' %}
-		{% set blockBackground = 'bs-background-outline' %}
-	{% elseif backgroundChoice == 'bs_background_style_underline' %}
-		{% set blockBackground = 'bs-background-underline' %}
-	{% else %}
-		{% set blockBackground = 'bs-background-none' %}
-	{% endif %}
+  {% if backgroundChoice == 'bs_background_style_white' %}
+    {% set blockBackground = 'bs-background-white' %}
+  {% elseif backgroundChoice == 'bs_background_style_gray' %}
+    {% set blockBackground = 'bs-background-gray' %}
+  {% elseif backgroundChoice == 'bs_background_style_dark_gray' %}
+    {% set blockBackground = 'bs-background-dark-gray' %}
+  {% elseif backgroundChoice == 'bs_background_style_tan' %}
+    {% set blockBackground = 'bs-background-tan' %}
+  {% elseif backgroundChoice == 'bs_background_style_light_blue' %}
+    {% set blockBackground = 'bs-background-light-blue' %}
+  {% elseif backgroundChoice == 'bs_background_style_medium_blue' %}
+    {% set blockBackground = 'bs-background-medium-blue' %}
+  {% elseif backgroundChoice == 'bs_background_style_dark_blue' %}
+    {% set blockBackground = 'bs-background-dark-blue' %}
+  {% elseif backgroundChoice == 'bs_background_style_light_green' %}
+    {% set blockBackground = 'bs-background-light-green' %}
+  {% elseif backgroundChoice == 'bs_background_style_brick' %}
+    {% set blockBackground = 'bs-background-brick' %}
+  {% elseif backgroundChoice == 'bs_background_style_outline' %}
+    {% set blockBackground = 'bs-background-outline' %}
+  {% elseif backgroundChoice == 'bs_background_style_underline' %}
+    {% set blockBackground = 'bs-background-underline' %}
+  {% else %}
+    {% set blockBackground = 'bs-background-none' %}
+  {% endif %}
 
-{{ blockBackground }}
+  {{ blockBackground }}
 
 {% endfor %}

--- a/templates/field/field--field-bs-content-font-scale.html.twig
+++ b/templates/field/field--field-bs-content-font-scale.html.twig
@@ -1,7 +1,10 @@
 {% for item in items %}
-	{% if item.content|render|striptags|trim == 'Increase' %}
+	{% set scaleChoice = element['#object'].get('field_bs_content_font_scale').value %}
+
+
+	{% if scaleChoice == 'bs_content_font_scale_increase' %}
 		{% set blockContentScale = 'bs-content-scale-increase' %}
-	{% elseif item.content|render|striptags|trim == 'Decrease' %}
+	{% elseif scaleChoice == 'bs_content_font_scale_decrease' %}
 		{% set blockContentScale = 'bs-content-scale-decrease' %}
 	{% else %}
 		{% set blockContentScale = 'bs-content-scale-default' %}

--- a/templates/field/field--field-bs-content-font-scale.html.twig
+++ b/templates/field/field--field-bs-content-font-scale.html.twig
@@ -1,14 +1,12 @@
-{% for item in items %}
-  {% set scaleChoice = element['#object'].get('field_bs_content_font_scale').value %}
+{% set scaleChoice = element['#object'].get('field_bs_content_font_scale').value %}
 
 
-  {% if scaleChoice == 'bs_content_font_scale_increase' %}
-    {% set blockContentScale = 'bs-content-scale-increase' %}
-  {% elseif scaleChoice == 'bs_content_font_scale_decrease' %}
-    {% set blockContentScale = 'bs-content-scale-decrease' %}
-  {% else %}
-    {% set blockContentScale = 'bs-content-scale-default' %}
-  {% endif %}
+{% if scaleChoice == 'bs_content_font_scale_increase' %}
+  {% set blockContentScale = 'bs-content-scale-increase' %}
+{% elseif scaleChoice == 'bs_content_font_scale_decrease' %}
+  {% set blockContentScale = 'bs-content-scale-decrease' %}
+{% else %}
+  {% set blockContentScale = 'bs-content-scale-default' %}
+{% endif %}
 
-  {{ blockContentScale }}
-{% endfor %}
+{{ blockContentScale }}

--- a/templates/field/field--field-bs-content-font-scale.html.twig
+++ b/templates/field/field--field-bs-content-font-scale.html.twig
@@ -1,14 +1,14 @@
 {% for item in items %}
-	{% set scaleChoice = element['#object'].get('field_bs_content_font_scale').value %}
+  {% set scaleChoice = element['#object'].get('field_bs_content_font_scale').value %}
 
 
-	{% if scaleChoice == 'bs_content_font_scale_increase' %}
-		{% set blockContentScale = 'bs-content-scale-increase' %}
-	{% elseif scaleChoice == 'bs_content_font_scale_decrease' %}
-		{% set blockContentScale = 'bs-content-scale-decrease' %}
-	{% else %}
-		{% set blockContentScale = 'bs-content-scale-default' %}
-	{% endif %}
+  {% if scaleChoice == 'bs_content_font_scale_increase' %}
+    {% set blockContentScale = 'bs-content-scale-increase' %}
+  {% elseif scaleChoice == 'bs_content_font_scale_decrease' %}
+    {% set blockContentScale = 'bs-content-scale-decrease' %}
+  {% else %}
+    {% set blockContentScale = 'bs-content-scale-default' %}
+  {% endif %}
 
-	{{ blockContentScale }}
+  {{ blockContentScale }}
 {% endfor %}

--- a/templates/field/field--field-bs-heading-alignment.html.twig
+++ b/templates/field/field--field-bs-heading-alignment.html.twig
@@ -1,6 +1,8 @@
 {% for item in items %}
+	{% set headingAlignmentChoice = element['#object'].get('field_bs_heading_alignment').value %}
 
-	{% if item.content|render|striptags|trim == 'Centered' %}
+
+	{% if headingAlignmentChoice == 'bs_heading_align_centered' %}
 		{% set blockHeadingAlignment = 'bs-heading-align-centered' %}
 	{% else %}
 		{% set blockHeadingAlignment = 'bs-heading-align-default' %}

--- a/templates/field/field--field-bs-heading-alignment.html.twig
+++ b/templates/field/field--field-bs-heading-alignment.html.twig
@@ -1,12 +1,12 @@
 {% for item in items %}
-	{% set headingAlignmentChoice = element['#object'].get('field_bs_heading_alignment').value %}
+  {% set headingAlignmentChoice = element['#object'].get('field_bs_heading_alignment').value %}
 
 
-	{% if headingAlignmentChoice == 'bs_heading_align_centered' %}
-		{% set blockHeadingAlignment = 'bs-heading-align-centered' %}
-	{% else %}
-		{% set blockHeadingAlignment = 'bs-heading-align-default' %}
-	{% endif %}
+  {% if headingAlignmentChoice == 'bs_heading_align_centered' %}
+    {% set blockHeadingAlignment = 'bs-heading-align-centered' %}
+  {% else %}
+    {% set blockHeadingAlignment = 'bs-heading-align-default' %}
+  {% endif %}
 
-	{{ blockHeadingAlignment }}
+  {{ blockHeadingAlignment }}
 {% endfor %}

--- a/templates/field/field--field-bs-heading-alignment.html.twig
+++ b/templates/field/field--field-bs-heading-alignment.html.twig
@@ -1,12 +1,10 @@
-{% for item in items %}
-  {% set headingAlignmentChoice = element['#object'].get('field_bs_heading_alignment').value %}
+{% set headingAlignmentChoice = element['#object'].get('field_bs_heading_alignment').value %}
 
 
-  {% if headingAlignmentChoice == 'bs_heading_align_centered' %}
-    {% set blockHeadingAlignment = 'bs-heading-align-centered' %}
-  {% else %}
-    {% set blockHeadingAlignment = 'bs-heading-align-default' %}
-  {% endif %}
+{% if headingAlignmentChoice == 'bs_heading_align_centered' %}
+  {% set blockHeadingAlignment = 'bs-heading-align-centered' %}
+{% else %}
+  {% set blockHeadingAlignment = 'bs-heading-align-default' %}
+{% endif %}
 
-  {{ blockHeadingAlignment }}
-{% endfor %}
+{{ blockHeadingAlignment }}

--- a/templates/field/field--field-bs-heading-style.html.twig
+++ b/templates/field/field--field-bs-heading-style.html.twig
@@ -1,12 +1,14 @@
 {% for item in items %}
+	{% set headingStyleChoice = element['#object'].get('field_bs_heading_style').value %}
 
-{% if item.content|render|striptags|trim == 'Hero' %}
+
+{% if headingStyleChoice == 'bs_heading_style_default_hero' %}
 	{% set blockHeadingStyle = 'hero' %}
-{% elseif item.content|render|striptags|trim == 'Hero Bold' %}
+{% elseif headingStyleChoice == 'bs_heading_style_default_hero_bold' %}
 	{% set blockHeadingStyle = 'hero strong' %}
-{% elseif item.content|render|striptags|trim == 'Supersize' %}
+{% elseif headingStyleChoice == 'bs_heading_style_default_supersize' %}
 	{% set blockHeadingStyle = 'supersize' %}
-{% elseif item.content|render|striptags|trim == 'Supersize Bold' %}
+{% elseif headingStyleChoice == 'bs_heading_style_default_supersize_bold' %}
 	{% set blockHeadingStyle = 'supersize bold' %}
 {% else %}
 	{% set blockHeadingStyle = 'bs-heading-style-default' %}

--- a/templates/field/field--field-bs-heading-style.html.twig
+++ b/templates/field/field--field-bs-heading-style.html.twig
@@ -1,18 +1,16 @@
-{% for item in items %}
-  {% set headingStyleChoice = element['#object'].get('field_bs_heading_style').value %}
+{% set headingStyleChoice = element['#object'].get('field_bs_heading_style').value %}
 
 
-  {% if headingStyleChoice == 'bs_heading_style_default_hero' %}
-    {% set blockHeadingStyle = 'hero' %}
-  {% elseif headingStyleChoice == 'bs_heading_style_default_hero_bold' %}
-    {% set blockHeadingStyle = 'hero strong' %}
-  {% elseif headingStyleChoice == 'bs_heading_style_default_supersize' %}
-    {% set blockHeadingStyle = 'supersize' %}
-  {% elseif headingStyleChoice == 'bs_heading_style_default_supersize_bold' %}
-    {% set blockHeadingStyle = 'supersize bold' %}
-  {% else %}
-    {% set blockHeadingStyle = 'bs-heading-style-default' %}
-  {% endif %}
+{% if headingStyleChoice == 'bs_heading_style_default_hero' %}
+  {% set blockHeadingStyle = 'hero' %}
+{% elseif headingStyleChoice == 'bs_heading_style_default_hero_bold' %}
+  {% set blockHeadingStyle = 'hero strong' %}
+{% elseif headingStyleChoice == 'bs_heading_style_default_supersize' %}
+  {% set blockHeadingStyle = 'supersize' %}
+{% elseif headingStyleChoice == 'bs_heading_style_default_supersize_bold' %}
+  {% set blockHeadingStyle = 'supersize bold' %}
+{% else %}
+  {% set blockHeadingStyle = 'bs-heading-style-default' %}
+{% endif %}
 
-  {{ blockHeadingStyle }}
-{% endfor %}
+{{ blockHeadingStyle }}

--- a/templates/field/field--field-bs-heading-style.html.twig
+++ b/templates/field/field--field-bs-heading-style.html.twig
@@ -1,18 +1,18 @@
 {% for item in items %}
-	{% set headingStyleChoice = element['#object'].get('field_bs_heading_style').value %}
+  {% set headingStyleChoice = element['#object'].get('field_bs_heading_style').value %}
 
 
-{% if headingStyleChoice == 'bs_heading_style_default_hero' %}
-	{% set blockHeadingStyle = 'hero' %}
-{% elseif headingStyleChoice == 'bs_heading_style_default_hero_bold' %}
-	{% set blockHeadingStyle = 'hero strong' %}
-{% elseif headingStyleChoice == 'bs_heading_style_default_supersize' %}
-	{% set blockHeadingStyle = 'supersize' %}
-{% elseif headingStyleChoice == 'bs_heading_style_default_supersize_bold' %}
-	{% set blockHeadingStyle = 'supersize bold' %}
-{% else %}
-	{% set blockHeadingStyle = 'bs-heading-style-default' %}
-{% endif %}
+  {% if headingStyleChoice == 'bs_heading_style_default_hero' %}
+    {% set blockHeadingStyle = 'hero' %}
+  {% elseif headingStyleChoice == 'bs_heading_style_default_hero_bold' %}
+    {% set blockHeadingStyle = 'hero strong' %}
+  {% elseif headingStyleChoice == 'bs_heading_style_default_supersize' %}
+    {% set blockHeadingStyle = 'supersize' %}
+  {% elseif headingStyleChoice == 'bs_heading_style_default_supersize_bold' %}
+    {% set blockHeadingStyle = 'supersize bold' %}
+  {% else %}
+    {% set blockHeadingStyle = 'bs-heading-style-default' %}
+  {% endif %}
 
-    {{ blockHeadingStyle }}
+  {{ blockHeadingStyle }}
 {% endfor %}

--- a/templates/field/field--field-bs-heading.html.twig
+++ b/templates/field/field--field-bs-heading.html.twig
@@ -1,20 +1,18 @@
-{% for item in items %}
-  {% set headingChoice = element['#object'].get('field_bs_heading').value %}
+{% set headingChoice = element['#object'].get('field_bs_heading').value %}
 
 
-  {% if headingChoice == 'bs_heading_h3' %}
-    {% set blockHeading = 'h3' %}
-  {% elseif headingChoice == 'bs_heading_h4' %}
-    {% set blockHeading = 'h4' %}
-  {% elseif headingChoice == 'bs_heading_h5' %}
-    {% set blockHeading = 'h5' %}
-  {% elseif headingChoice == 'bs_heading_h6' %}
-    {% set blockHeading = 'h6' %}
-  {% elseif headingChoice == 'bs_heading_strong' %}
-    {% set blockHeading = 'strong' %}
-  {% else %}
-    {% set blockHeading = 'h2' %}
-  {% endif %}
+{% if headingChoice == 'bs_heading_h3' %}
+  {% set blockHeading = 'h3' %}
+{% elseif headingChoice == 'bs_heading_h4' %}
+  {% set blockHeading = 'h4' %}
+{% elseif headingChoice == 'bs_heading_h5' %}
+  {% set blockHeading = 'h5' %}
+{% elseif headingChoice == 'bs_heading_h6' %}
+  {% set blockHeading = 'h6' %}
+{% elseif headingChoice == 'bs_heading_strong' %}
+  {% set blockHeading = 'strong' %}
+{% else %}
+  {% set blockHeading = 'h2' %}
+{% endif %}
 
-  {{ blockHeading }}
-{% endfor %}
+{{ blockHeading }}

--- a/templates/field/field--field-bs-heading.html.twig
+++ b/templates/field/field--field-bs-heading.html.twig
@@ -1,14 +1,16 @@
 {% for item in items %}
+	{% set headingChoice = element['#object'].get('field_bs_heading').value %}
 
-{% if item.content|render|striptags|trim == 'H3' %}
+
+{% if headingChoice == 'bs_heading_h3' %}
 	{% set blockHeading = 'h3' %}
-{% elseif item.content|render|striptags|trim == 'H4' %}
+{% elseif headingChoice == 'bs_heading_h4' %}
 	{% set blockHeading = 'h4' %}
-{% elseif item.content|render|striptags|trim == 'H5' %}
+{% elseif headingChoice == 'bs_heading_h5' %}
 	{% set blockHeading = 'h5' %}
-{% elseif item.content|render|striptags|trim == 'H6' %}
+{% elseif headingChoice == 'bs_heading_h6' %}
 	{% set blockHeading = 'h6' %}
-{% elseif item.content|render|striptags|trim == 'Strong' %}
+{% elseif headingChoice == 'bs_heading_strong' %}
 	{% set blockHeading = 'strong' %}
 {% else %}
 	{% set blockHeading = 'h2' %}

--- a/templates/field/field--field-bs-heading.html.twig
+++ b/templates/field/field--field-bs-heading.html.twig
@@ -1,20 +1,20 @@
 {% for item in items %}
-	{% set headingChoice = element['#object'].get('field_bs_heading').value %}
+  {% set headingChoice = element['#object'].get('field_bs_heading').value %}
 
 
-{% if headingChoice == 'bs_heading_h3' %}
-	{% set blockHeading = 'h3' %}
-{% elseif headingChoice == 'bs_heading_h4' %}
-	{% set blockHeading = 'h4' %}
-{% elseif headingChoice == 'bs_heading_h5' %}
-	{% set blockHeading = 'h5' %}
-{% elseif headingChoice == 'bs_heading_h6' %}
-	{% set blockHeading = 'h6' %}
-{% elseif headingChoice == 'bs_heading_strong' %}
-	{% set blockHeading = 'strong' %}
-{% else %}
-	{% set blockHeading = 'h2' %}
-{% endif %}
+  {% if headingChoice == 'bs_heading_h3' %}
+    {% set blockHeading = 'h3' %}
+  {% elseif headingChoice == 'bs_heading_h4' %}
+    {% set blockHeading = 'h4' %}
+  {% elseif headingChoice == 'bs_heading_h5' %}
+    {% set blockHeading = 'h5' %}
+  {% elseif headingChoice == 'bs_heading_h6' %}
+    {% set blockHeading = 'h6' %}
+  {% elseif headingChoice == 'bs_heading_strong' %}
+    {% set blockHeading = 'strong' %}
+  {% else %}
+    {% set blockHeading = 'h2' %}
+  {% endif %}
 
-	{{ blockHeading }} 
+  {{ blockHeading }}
 {% endfor %}

--- a/templates/field/field--field-bs-icon-color.html.twig
+++ b/templates/field/field--field-bs-icon-color.html.twig
@@ -1,19 +1,22 @@
 {% for item in items %}
-	{% if item.content|render|striptags|trim == 'Gray' %}
+	{% set iconColorChoice = element['#object'].get('field_bs_icon_color').value %}
+
+
+	{% if iconColorChoice == 'bs_icon_color_gray' %}
 		{% set blockIconColor = 'bs-icon-color-gray' %}
-	{% elseif item.content|render|striptags|trim == 'Gold' %}
+	{% elseif iconColorChoice == 'bs_icon_color_gold' %}
 		{% set blockIconColor = 'bs-icon-color-gold' %}
-	{% elseif item.content|render|striptags|trim == 'Blue' %}
+	{% elseif iconColorChoice == 'bs_icon_color_blue' %}
 		{% set blockIconColor = 'bs-icon-color-blue' %}
-	{% elseif item.content|render|striptags|trim == 'Green' %}
+	{% elseif iconColorChoice == 'bs_icon_color_green' %}
 		{% set blockIconColor = 'bs-icon-color-green' %}
-	{% elseif item.content|render|striptags|trim == 'Orange' %}
+	{% elseif iconColorChoice == 'bs_icon_color_orange' %}
 		{% set blockIconColor = 'bs-icon-color-orange' %}
-	{% elseif item.content|render|striptags|trim == 'Purple' %}
+	{% elseif iconColorChoice == 'bs_icon_color_purple' %}
 		{% set blockIconColor = 'bs-icon-color-purple' %}
-	{% elseif item.content|render|striptags|trim == 'Red' %}
+	{% elseif iconColorChoice == 'bs_icon_color_red' %}
 		{% set blockIconColor = 'bs-icon-color-red' %}
-	{% elseif item.content|render|striptags|trim == 'Yellow' %}
+	{% elseif iconColorChoice == 'bs_icon_color_yellow' %}
 		{% set blockIconColor = 'bs-icon-color-yellow' %}
 	{% else %}
 		{% set blockIconColor = 'bs-icon-color-default' %}

--- a/templates/field/field--field-bs-icon-color.html.twig
+++ b/templates/field/field--field-bs-icon-color.html.twig
@@ -1,26 +1,24 @@
-{% for item in items %}
-  {% set iconColorChoice = element['#object'].get('field_bs_icon_color').value %}
+{% set iconColorChoice = element['#object'].get('field_bs_icon_color').value %}
 
 
-  {% if iconColorChoice == 'bs_icon_color_gray' %}
-    {% set blockIconColor = 'bs-icon-color-gray' %}
-  {% elseif iconColorChoice == 'bs_icon_color_gold' %}
-    {% set blockIconColor = 'bs-icon-color-gold' %}
-  {% elseif iconColorChoice == 'bs_icon_color_blue' %}
-    {% set blockIconColor = 'bs-icon-color-blue' %}
-  {% elseif iconColorChoice == 'bs_icon_color_green' %}
-    {% set blockIconColor = 'bs-icon-color-green' %}
-  {% elseif iconColorChoice == 'bs_icon_color_orange' %}
-    {% set blockIconColor = 'bs-icon-color-orange' %}
-  {% elseif iconColorChoice == 'bs_icon_color_purple' %}
-    {% set blockIconColor = 'bs-icon-color-purple' %}
-  {% elseif iconColorChoice == 'bs_icon_color_red' %}
-    {% set blockIconColor = 'bs-icon-color-red' %}
-  {% elseif iconColorChoice == 'bs_icon_color_yellow' %}
-    {% set blockIconColor = 'bs-icon-color-yellow' %}
-  {% else %}
-    {% set blockIconColor = 'bs-icon-color-default' %}
-  {% endif %}
+{% if iconColorChoice == 'bs_icon_color_gray' %}
+  {% set blockIconColor = 'bs-icon-color-gray' %}
+{% elseif iconColorChoice == 'bs_icon_color_gold' %}
+  {% set blockIconColor = 'bs-icon-color-gold' %}
+{% elseif iconColorChoice == 'bs_icon_color_blue' %}
+  {% set blockIconColor = 'bs-icon-color-blue' %}
+{% elseif iconColorChoice == 'bs_icon_color_green' %}
+  {% set blockIconColor = 'bs-icon-color-green' %}
+{% elseif iconColorChoice == 'bs_icon_color_orange' %}
+  {% set blockIconColor = 'bs-icon-color-orange' %}
+{% elseif iconColorChoice == 'bs_icon_color_purple' %}
+  {% set blockIconColor = 'bs-icon-color-purple' %}
+{% elseif iconColorChoice == 'bs_icon_color_red' %}
+  {% set blockIconColor = 'bs-icon-color-red' %}
+{% elseif iconColorChoice == 'bs_icon_color_yellow' %}
+  {% set blockIconColor = 'bs-icon-color-yellow' %}
+{% else %}
+  {% set blockIconColor = 'bs-icon-color-default' %}
+{% endif %}
 
-  {{ blockIconColor }}
-{% endfor %}
+{{ blockIconColor }}

--- a/templates/field/field--field-bs-icon-color.html.twig
+++ b/templates/field/field--field-bs-icon-color.html.twig
@@ -1,26 +1,26 @@
 {% for item in items %}
-	{% set iconColorChoice = element['#object'].get('field_bs_icon_color').value %}
+  {% set iconColorChoice = element['#object'].get('field_bs_icon_color').value %}
 
 
-	{% if iconColorChoice == 'bs_icon_color_gray' %}
-		{% set blockIconColor = 'bs-icon-color-gray' %}
-	{% elseif iconColorChoice == 'bs_icon_color_gold' %}
-		{% set blockIconColor = 'bs-icon-color-gold' %}
-	{% elseif iconColorChoice == 'bs_icon_color_blue' %}
-		{% set blockIconColor = 'bs-icon-color-blue' %}
-	{% elseif iconColorChoice == 'bs_icon_color_green' %}
-		{% set blockIconColor = 'bs-icon-color-green' %}
-	{% elseif iconColorChoice == 'bs_icon_color_orange' %}
-		{% set blockIconColor = 'bs-icon-color-orange' %}
-	{% elseif iconColorChoice == 'bs_icon_color_purple' %}
-		{% set blockIconColor = 'bs-icon-color-purple' %}
-	{% elseif iconColorChoice == 'bs_icon_color_red' %}
-		{% set blockIconColor = 'bs-icon-color-red' %}
-	{% elseif iconColorChoice == 'bs_icon_color_yellow' %}
-		{% set blockIconColor = 'bs-icon-color-yellow' %}
-	{% else %}
-		{% set blockIconColor = 'bs-icon-color-default' %}
-	{% endif %}
+  {% if iconColorChoice == 'bs_icon_color_gray' %}
+    {% set blockIconColor = 'bs-icon-color-gray' %}
+  {% elseif iconColorChoice == 'bs_icon_color_gold' %}
+    {% set blockIconColor = 'bs-icon-color-gold' %}
+  {% elseif iconColorChoice == 'bs_icon_color_blue' %}
+    {% set blockIconColor = 'bs-icon-color-blue' %}
+  {% elseif iconColorChoice == 'bs_icon_color_green' %}
+    {% set blockIconColor = 'bs-icon-color-green' %}
+  {% elseif iconColorChoice == 'bs_icon_color_orange' %}
+    {% set blockIconColor = 'bs-icon-color-orange' %}
+  {% elseif iconColorChoice == 'bs_icon_color_purple' %}
+    {% set blockIconColor = 'bs-icon-color-purple' %}
+  {% elseif iconColorChoice == 'bs_icon_color_red' %}
+    {% set blockIconColor = 'bs-icon-color-red' %}
+  {% elseif iconColorChoice == 'bs_icon_color_yellow' %}
+    {% set blockIconColor = 'bs-icon-color-yellow' %}
+  {% else %}
+    {% set blockIconColor = 'bs-icon-color-default' %}
+  {% endif %}
 
-    {{ blockIconColor }}
+  {{ blockIconColor }}
 {% endfor %}

--- a/templates/field/field--field-bs-icon-position.html.twig
+++ b/templates/field/field--field-bs-icon-position.html.twig
@@ -1,14 +1,12 @@
-{% for item in items %}
-  {% set iconPositionChoice = element['#object'].get('field_bs_icon_position').value %}
+{% set iconPositionChoice = element['#object'].get('field_bs_icon_position').value %}
 
 
-  {% if iconPositionChoice == 'bs_icon_position_offset' %}
-    {% set blockIconPosition = 'bs-icon-position-offset' %}
-  {% elseif iconPositionChoice == 'bs_icon_position_top' %}
-    {% set blockIconPosition = 'bs-icon-position-top' %}
-  {% else %}
-    {% set blockIconPosition = 'bs-icon-position-default' %}
-  {% endif %}
+{% if iconPositionChoice == 'bs_icon_position_offset' %}
+  {% set blockIconPosition = 'bs-icon-position-offset' %}
+{% elseif iconPositionChoice == 'bs_icon_position_top' %}
+  {% set blockIconPosition = 'bs-icon-position-top' %}
+{% else %}
+  {% set blockIconPosition = 'bs-icon-position-default' %}
+{% endif %}
 
-  {{ blockIconPosition }}
-{% endfor %}
+{{ blockIconPosition }}

--- a/templates/field/field--field-bs-icon-position.html.twig
+++ b/templates/field/field--field-bs-icon-position.html.twig
@@ -1,14 +1,14 @@
 {% for item in items %}
-	{% set iconPositionChoice = element['#object'].get('field_bs_icon_position').value %}
+  {% set iconPositionChoice = element['#object'].get('field_bs_icon_position').value %}
 
 
-{% if iconPositionChoice == 'bs_icon_position_offset' %}
-	{% set blockIconPosition = 'bs-icon-position-offset' %}
-{% elseif iconPositionChoice == 'bs_icon_position_top' %}
-	{% set blockIconPosition = 'bs-icon-position-top' %}
-{% else %}
-	{% set blockIconPosition = 'bs-icon-position-default' %}
-{% endif %}
+  {% if iconPositionChoice == 'bs_icon_position_offset' %}
+    {% set blockIconPosition = 'bs-icon-position-offset' %}
+  {% elseif iconPositionChoice == 'bs_icon_position_top' %}
+    {% set blockIconPosition = 'bs-icon-position-top' %}
+  {% else %}
+    {% set blockIconPosition = 'bs-icon-position-default' %}
+  {% endif %}
 
-    {{ blockIconPosition }}
+  {{ blockIconPosition }}
 {% endfor %}

--- a/templates/field/field--field-bs-icon-position.html.twig
+++ b/templates/field/field--field-bs-icon-position.html.twig
@@ -1,8 +1,10 @@
 {% for item in items %}
+	{% set iconPositionChoice = element['#object'].get('field_bs_icon_position').value %}
 
-{% if item.content|render|striptags|trim == 'Offset' %}
+
+{% if iconPositionChoice == 'bs_icon_position_offset' %}
 	{% set blockIconPosition = 'bs-icon-position-offset' %}
-{% elseif item.content|render|striptags|trim == 'Top' %}
+{% elseif iconPositionChoice == 'bs_icon_position_top' %}
 	{% set blockIconPosition = 'bs-icon-position-top' %}
 {% else %}
 	{% set blockIconPosition = 'bs-icon-position-default' %}

--- a/templates/field/field--field-bs-icon-size.html.twig
+++ b/templates/field/field--field-bs-icon-size.html.twig
@@ -1,12 +1,10 @@
-{% for item in items %}
-  {% set iconSizeChoice = element['#object'].get('field_bs_icon_size').value %}
+{% set iconSizeChoice = element['#object'].get('field_bs_icon_size').value %}
 
 
-  {% if iconSizeChoice == 'bs_icon_size_increase' %}
-    {% set blockIconSize = 'bs-icon-size-increase' %}
-  {% else %}
-    {% set blockIconSize = 'bs-icon-size-default' %}
-  {% endif %}
+{% if iconSizeChoice == 'bs_icon_size_increase' %}
+  {% set blockIconSize = 'bs-icon-size-increase' %}
+{% else %}
+  {% set blockIconSize = 'bs-icon-size-default' %}
+{% endif %}
 
-  {{ blockIconSize }}
-{% endfor %}
+{{ blockIconSize }}

--- a/templates/field/field--field-bs-icon-size.html.twig
+++ b/templates/field/field--field-bs-icon-size.html.twig
@@ -1,12 +1,12 @@
 {% for item in items %}
-	{% set iconSizeChoice = element['#object'].get('field_bs_icon_size').value %}
+  {% set iconSizeChoice = element['#object'].get('field_bs_icon_size').value %}
 
 
-	{% if iconSizeChoice == 'bs_icon_size_increase' %}
-		{% set blockIconSize = 'bs-icon-size-increase' %}
-	{% else %}
-		{% set blockIconSize = 'bs-icon-size-default' %}
-	{% endif %}
+  {% if iconSizeChoice == 'bs_icon_size_increase' %}
+    {% set blockIconSize = 'bs-icon-size-increase' %}
+  {% else %}
+    {% set blockIconSize = 'bs-icon-size-default' %}
+  {% endif %}
 
-	{{ blockIconSize }}
+  {{ blockIconSize }}
 {% endfor %}

--- a/templates/field/field--field-bs-icon-size.html.twig
+++ b/templates/field/field--field-bs-icon-size.html.twig
@@ -1,6 +1,8 @@
 {% for item in items %}
+	{% set iconSizeChoice = element['#object'].get('field_bs_icon_size').value %}
 
-	{% if item.content|render|striptags|trim == 'Increase' %}
+
+	{% if iconSizeChoice == 'bs_icon_size_increase' %}
 		{% set blockIconSize = 'bs-icon-size-increase' %}
 	{% else %}
 		{% set blockIconSize = 'bs-icon-size-default' %}

--- a/templates/field/field--field-bs-icon.html.twig
+++ b/templates/field/field--field-bs-icon.html.twig
@@ -7,5 +7,5 @@
     {% set firstIconHtml = firstIconHtml|replace({(attribute): ''}) %}
   {% endfor %}
 
-  {{ firstIconHtml|t }}
+  {{ firstIconHtml|raw }}
 {% endfor %}

--- a/templates/field/field--field-bs-icon.html.twig
+++ b/templates/field/field--field-bs-icon.html.twig
@@ -1,11 +1,11 @@
 {% for item in items %}
-  {% set attributeList = ['fa-xs', 'fa-sm', 'fa-lg', 'fa-2x', 'fa-3x', 'fa-4x', 'fa-5x', 'fa-6x', 'fa-7x', 'fa-8x', 'fa-9x', 'fa-10x', 'ucb-icon-color-black', 'ucb-icon-color-white', 'ucb-icon-color-lightgray', 'ucb-icon-color-darkgray', 'ucb-icon-color-gold', 'ucb-icon-style-square', 'ucb-icon-style-square-rounded', 'ucb-icon-style-circle', 'fa-pull-left', 'fa-pull-right'] %}
-  {% set iconList = item.content['#text']|striptags('<i>')|split('<i') %}
-  {% set firstIconHtml = '<i' ~ iconList[1]|split('</i>')[0] ~ '</i>' %}
+  {% set attributeList = ['fa-xs', 'fa-sm', 'fa-lg', 'fa-2x', 'fa-3x', 'fa-4x', 'fa-5x', 'fa-6x', 'fa-7x', 'fa-8x', 'fa-9x', 'fa-10x', 'ucb-icon-color-black', 'ucb-icon-color-white', 'ucb-icon-color-lightgray', 'ucb-icon-color-darkgray', 'ucb-icon-color-gold', 'ucb-icon-style-square-rounded', 'ucb-icon-style-square', 'ucb-icon-style-circle', 'fa-pull-left', 'fa-pull-right'] %}
+  {% set iconList = item.content['#text']|striptags('<i>')|split('<i class="') %}
+  {% set firstIconClasses = iconList[1]|split('"')[0] %}
 
   {% for attribute in attributeList %}
-    {% set firstIconHtml = firstIconHtml|replace({(attribute): ''}) %}
+    {% set firstIconClasses = firstIconClasses|replace({(attribute): ''}) %}
   {% endfor %}
 
-  {{ firstIconHtml|raw }}
+  <i{{create_attribute({class:firstIconClasses})}}></i>
 {% endfor %}

--- a/templates/field/field--field-bs-icon.html.twig
+++ b/templates/field/field--field-bs-icon.html.twig
@@ -1,5 +1,5 @@
 {% for item in items %}
-  {% set attributeList = ['fa-xs', 'fa-sm', 'fa-lg', 'fa-2x', 'fa-3x', 'fa-4x', 'fa-5x', 'fa-6x', 'fa-7x', 'fa-8x', 'fa-9x', 'fa-10x', 'ucb-icon-color-black', 'ucb-icon-color-white', 'ucb-icon-color-lightgray', 'ucb-icon-color-darkgray', 'ucb-icon-color-gold', 'ucb-icon-style-square-rounded', 'ucb-icon-style-square', 'ucb-icon-style-circle', 'fa-pull-left', 'fa-pull-right'] %}
+  {% set attributeList = ['fa-xs', 'fa-sm', 'fa-lg', 'fa-xl', 'fa-2x', 'fa-3x', 'fa-4x', 'fa-5x', 'fa-6x', 'fa-7x', 'fa-8x', 'fa-9x', 'fa-10x', 'ucb-icon-color-black', 'ucb-icon-color-white', 'ucb-icon-color-lightgray', 'ucb-icon-color-darkgray', 'ucb-icon-color-gold', 'ucb-icon-style-square-rounded', 'ucb-icon-style-square', 'ucb-icon-style-circle', 'fa-pull-left', 'fa-pull-right'] %}
   {% set iconList = item.content['#text']|striptags('<i>')|split('<i class="') %}
   {% set firstIconClasses = iconList[1]|split('"')[0] %}
 

--- a/templates/field/field--field-bs-icon.html.twig
+++ b/templates/field/field--field-bs-icon.html.twig
@@ -1,11 +1,11 @@
 {% for item in items %}
-	{% set attributeList = ['fa-xs', 'fa-sm', 'fa-lg', 'fa-2x', 'fa-3x', 'fa-4x', 'fa-5x', 'fa-6x', 'fa-7x', 'fa-8x', 'fa-9x', 'fa-10x', 'ucb-icon-color-black', 'ucb-icon-color-white', 'ucb-icon-color-lightgray', 'ucb-icon-color-darkgray', 'ucb-icon-color-gold', 'ucb-icon-style-square', 'ucb-icon-style-square-rounded', 'ucb-icon-style-circle', 'fa-pull-left', 'fa-pull-right'] %}
-	{% set iconList = item.content['#text']|striptags('<i>')|split('<i') %}
-	{% set firstIconHtml = '<i' ~ iconList[1]|split('</i>')[0] ~ '</i>' %}
+  {% set attributeList = ['fa-xs', 'fa-sm', 'fa-lg', 'fa-2x', 'fa-3x', 'fa-4x', 'fa-5x', 'fa-6x', 'fa-7x', 'fa-8x', 'fa-9x', 'fa-10x', 'ucb-icon-color-black', 'ucb-icon-color-white', 'ucb-icon-color-lightgray', 'ucb-icon-color-darkgray', 'ucb-icon-color-gold', 'ucb-icon-style-square', 'ucb-icon-style-square-rounded', 'ucb-icon-style-circle', 'fa-pull-left', 'fa-pull-right'] %}
+  {% set iconList = item.content['#text']|striptags('<i>')|split('<i') %}
+  {% set firstIconHtml = '<i' ~ iconList[1]|split('</i>')[0] ~ '</i>' %}
 
-{% for attribute in attributeList %}
+  {% for attribute in attributeList %}
     {% set firstIconHtml = firstIconHtml|replace({(attribute): ''}) %}
-{% endfor %}
+  {% endfor %}
 
-	{{ firstIconHtml|t }}
+  {{ firstIconHtml|t }}
 {% endfor %}

--- a/templates/field/field--field-bs-title-font-scale.html.twig
+++ b/templates/field/field--field-bs-title-font-scale.html.twig
@@ -1,14 +1,14 @@
 {% for item in items %}
-	{% set titleScaleChoice = element['#object'].get('field_bs_title_font_scale').value %}
+  {% set titleScaleChoice = element['#object'].get('field_bs_title_font_scale').value %}
 
 
-{% if titleScaleChoice == 'bs_title_font_scale_increase' %}
-	{% set blockTitleScale = 'bs-title-scale-increase' %}
-{% elseif titleScaleChoice == 'bs_title_font_scale_decrease' %}
-	{% set blockTitleScale = 'bs-title-scale-decrease' %}
-{% else %}
-	{% set blockTitleScale = 'bs-title-scale-default' %}
-{% endif %}
+  {% if titleScaleChoice == 'bs_title_font_scale_increase' %}
+    {% set blockTitleScale = 'bs-title-scale-increase' %}
+  {% elseif titleScaleChoice == 'bs_title_font_scale_decrease' %}
+    {% set blockTitleScale = 'bs-title-scale-decrease' %}
+  {% else %}
+    {% set blockTitleScale = 'bs-title-scale-default' %}
+  {% endif %}
 
-    {{ blockTitleScale }}
+  {{ blockTitleScale }}
 {% endfor %}

--- a/templates/field/field--field-bs-title-font-scale.html.twig
+++ b/templates/field/field--field-bs-title-font-scale.html.twig
@@ -1,14 +1,12 @@
-{% for item in items %}
-  {% set titleScaleChoice = element['#object'].get('field_bs_title_font_scale').value %}
+{% set titleScaleChoice = element['#object'].get('field_bs_title_font_scale').value %}
 
 
-  {% if titleScaleChoice == 'bs_title_font_scale_increase' %}
-    {% set blockTitleScale = 'bs-title-scale-increase' %}
-  {% elseif titleScaleChoice == 'bs_title_font_scale_decrease' %}
-    {% set blockTitleScale = 'bs-title-scale-decrease' %}
-  {% else %}
-    {% set blockTitleScale = 'bs-title-scale-default' %}
-  {% endif %}
+{% if titleScaleChoice == 'bs_title_font_scale_increase' %}
+  {% set blockTitleScale = 'bs-title-scale-increase' %}
+{% elseif titleScaleChoice == 'bs_title_font_scale_decrease' %}
+  {% set blockTitleScale = 'bs-title-scale-decrease' %}
+{% else %}
+  {% set blockTitleScale = 'bs-title-scale-default' %}
+{% endif %}
 
-  {{ blockTitleScale }}
-{% endfor %}
+{{ blockTitleScale }}

--- a/templates/field/field--field-bs-title-font-scale.html.twig
+++ b/templates/field/field--field-bs-title-font-scale.html.twig
@@ -1,8 +1,10 @@
 {% for item in items %}
+	{% set titleScaleChoice = element['#object'].get('field_bs_title_font_scale').value %}
 
-{% if item.content|render|striptags|trim == 'Increase' %}
+
+{% if titleScaleChoice == 'bs_title_font_scale_increase' %}
 	{% set blockTitleScale = 'bs-title-scale-increase' %}
-{% elseif item.content|render|striptags|trim == 'Decrease' %}
+{% elseif titleScaleChoice == 'bs_title_font_scale_decrease' %}
 	{% set blockTitleScale = 'bs-title-scale-decrease' %}
 {% else %}
 	{% set blockTitleScale = 'bs-title-scale-default' %}


### PR DESCRIPTION
Refactored code to use machine name rather than label value. For grabbing machine name from list fields you need to use `element['#object'].get('FIELD_NAME').value` as machine names aren't in the render array.

These changes affects all the background style field templates. 
Please test each background style option to make sure I didn't mislabel something.

Resolves #1001