### PR TITLE
Content List Block: A11y Changes, Unpublished Content Appearing in Lists

### DIFF
--- a/templates/block/block--content-list.html.twig
+++ b/templates/block/block--content-list.html.twig
@@ -111,7 +111,6 @@
                 {% autoescape false %}
                   {{ summary }}
                 {% endautoescape %}
-                <a aria-hidden="true" class="ucb-content-list-read-more" href="{{ item.entity.path.alias }}">Read more &raquo;</a>
               </p>
             </div>
             {% if image %}

--- a/templates/block/block--content-list.html.twig
+++ b/templates/block/block--content-list.html.twig
@@ -73,110 +73,113 @@
 		{% endif %}
 
 		{% for item in items %}
-			{% set image = item.entity.field_ucb_article_thumbnail.entity.field_media_image ?? item.entity.field_ucb_person_photo.entity.field_media_image ?? item.entity.field_how_to_initial_image.entity.field_media_image ?? item.entity.field_social_sharing_image.entity.field_media_image %}
-			{% if image %}
-			{% set imageURI = image.entity.fileuri|image_style('focal_image_square') %}{% set imageAlt = image.alt|render %}
-			{% endif %}
-			{% set summary = item.entity.body.0.summary ?? item.entity.field_ucb_article_summary.0.value %}
-			{% if not summary %}
-				{% set body = (item.entity.body.0 ?? item.entity.field_ucb_article_content.0.entity.field_article_text.0).value|render|replace({"&nbsp;": ""})|striptags|trim %}
-				{% set bodyTrimmed = body|slice(0, 512) %}
-				{% set summary = bodyTrimmed ~ (body|length > bodyTrimmed|length ? '...') %}
+    {# Skip unpublished items if the user is not logged in #}
+			{% if item.entity.status.value == 1 or user.isAuthenticated %}
+        {% set image = item.entity.field_ucb_article_thumbnail.entity.field_media_image ?? item.entity.field_ucb_person_photo.entity.field_media_image ?? item.entity.field_how_to_initial_image.entity.field_media_image ?? item.entity.field_social_sharing_image.entity.field_media_image %}
+        {% if image %}
+        {% set imageURI = image.entity.fileuri|image_style('focal_image_square') %}{% set imageAlt = image.alt|render %}
+        {% endif %}
+        {% set summary = item.entity.body.0.summary ?? item.entity.field_ucb_article_summary.0.value %}
+        {% if not summary %}
+          {% set body = (item.entity.body.0 ?? item.entity.field_ucb_article_content.0.entity.field_article_text.0).value|render|replace({"&nbsp;": ""})|striptags|trim %}
+          {% set bodyTrimmed = body|slice(0, 512) %}
+          {% set summary = bodyTrimmed ~ (body|length > bodyTrimmed|length ? '...') %}
 
-			{% endif %}
+        {% endif %}
 
-			{% if display == 'full' %}
-				<div class="row ucb-content-list-row ">
-					<div class="ucb-content-list-text-container ">
-						<h4 class="ucb-content-list-title">
-							<a href="{{ item.entity.path.alias }}">{{ item.entity.title.0.value }}</a>
-						</h4>
-						{% if item.entity.type.0.entity.id == 'ucb_person' %}
-							<div class="ucb-content-list-person-info">
-								<div class="ucb-content-list-person-titles">
-									{% for title in item.entity.field_ucb_person_title %}<span class="ucb-content-list-person-title">{{ title.value }}</span>{% endfor %}
-								</div>
-								<div class="ucb-content-list-person-departments">
-									{% for department in item.entity.field_ucb_person_department %}<span class="ucb-content-list-person-department">{{ department.entity.name.value }}</span>{% endfor %}
-								</div>
-								<div class="ucb-content-list-person-contact">
-									{% set email = item.entity.field_ucb_person_email.0.value %}{% if email %}<span class="ucb-content-list-person-contact-item ucb-content-list-person-email"><a href="mailto:{{ email }}">{{ email }}</a></span>{% endif %}
-									{% set phone = item.entity.field_ucb_person_phone.0.value %}{% if phone %}<span class="ucb-content-list-person-contact-item ucb-content-list-person-phone"><a href="tel:{{ phone|preg_replace('/[^0-9\+]/', '') }}">{{ phone }}</a></span>{% endif %}
-								</div>
-							</div>
-						{% endif %}
-						<p class="ucb-content-list-summary">
-							{% autoescape false %}
-								{{ summary }}
-							{% endautoescape %}
-							<a aria-hidden="true" class="ucb-content-list-read-more" href="{{ item.entity.path.alias }}">Read more &raquo;</a>
-						</p>
-					</div>
-					{% if image %}
-						<div class="ucb-content-list-image-container">
-								<a role="presentation" aria-hidden="true" href="{{ item.entity.path.alias }}">
-									<img class="ucb-content-list-image" src="{{ imageURI }}" alt="{{ imageAlt }}">
-								</a>
-						</div>
-					{% endif %}
-				</div>
-			{% elseif display == 'condensed' or display == 'teaser' %}
-			<div class="row ucb-content-list-row">
-				{% if image %}
-					<div class="ucb-content-list-image-container">
-						<a role="presentation" aria-hidden="true" href="{{ item.entity.path.alias }}"><img class="ucb-content-list-image" src="{{ imageURI }}" alt="{{ imageAlt }}"></a>
-					</div>
-				{% endif %}
-				<div class="ucb-content-list-text-container container">
-					<h4 class="ucb-content-list-title">
-						<a href="{{ item.entity.path.alias }}">{{ item.entity.title.0.value }}</a>
-					</h4>
-					{% if item.entity.type.0.entity.id == 'ucb_person' %}
-						<div class="ucb-content-list-person-info">
-							<div class="ucb-content-list-person-titles">
-								{% for title in item.entity.field_ucb_person_title %}<span class="ucb-content-list-person-title">{{ title.value }}</span>{% endfor %}
-							</div>
-							<div class="ucb-content-list-person-departments">
-								{% for department in item.entity.field_ucb_person_department %}<span class="ucb-content-list-person-department">{{ department.entity.name.value }}</span>{% endfor %}
-							</div>
-							<div class="ucb-content-list-person-contact">
-								{% set email = item.entity.field_ucb_person_email.0.value %}{% if email %}<span class="ucb-content-list-person-contact-item ucb-content-list-person-email"><a href="mailto:{{ email }}">{{ email }}</a></span>{% endif %}
-								{% set phone = item.entity.field_ucb_person_phone.0.value %}{% if phone %}<span class="ucb-content-list-person-contact-item ucb-content-list-person-phone"><a href="tel:{{ phone|preg_replace('/[^0-9\+]/', '') }}">{{ phone }}</a></span>{% endif %}
-							</div>
-						</div>
-					{% endif %}
-					<p class="ucb-content-list-summary">
-						{% autoescape false %}
-							{{ summary }}
-						{% endautoescape %}
-					</p>
-				</div>
-			</div>
-			{% elseif display == 'title' %}
-			<ul class="ucb-content-list-list">
-			{# ISSUE WE NEED TO MAKE EACH ITEM AN LI INSTEAD OF DUPLICATING THE UL #}
-				<li class="ucb-content-list-row ucb-content-list-title">
-					<a href="{{ item.entity.path.alias }}">{{ item.entity.title.0.value }}</a>
-				</li>
-			</ul>
-			{% elseif display == 'sidebar' %}
-				<div class="row ucb-content-list-row">
-					<div class="ucb-content-list-text-container ">
-						<span class="ucb-content-list-title"><a href="{{ item.entity.path.alias }}">{{ item.entity.title.0.value }}</a></span>
-					</div>
-					{% if image %}
-						<div class="ucb-content-list-image-container">
-								<a role="presentation" aria-hidden="true" href="{{ item.entity.path.alias }}"><img class="ucb-content-list-image" src="{{ imageURI }}" alt="{{ imageAlt }}"></a>
-						</div>
-					{% endif %}
-				</div>
-			{% endif %}
+        {% if display == 'full' %}
+          <div class="row ucb-content-list-row ">
+            <div class="ucb-content-list-text-container ">
+              <h4 class="ucb-content-list-title">
+                <a href="{{ item.entity.path.alias }}">{{ item.entity.title.0.value }}</a>
+              </h4>
+              {% if item.entity.type.0.entity.id == 'ucb_person' %}
+                <div class="ucb-content-list-person-info">
+                  <div class="ucb-content-list-person-titles">
+                    {% for title in item.entity.field_ucb_person_title %}<span class="ucb-content-list-person-title">{{ title.value }}</span>{% endfor %}
+                  </div>
+                  <div class="ucb-content-list-person-departments">
+                    {% for department in item.entity.field_ucb_person_department %}<span class="ucb-content-list-person-department">{{ department.entity.name.value }}</span>{% endfor %}
+                  </div>
+                  <div class="ucb-content-list-person-contact">
+                    {% set email = item.entity.field_ucb_person_email.0.value %}{% if email %}<span class="ucb-content-list-person-contact-item ucb-content-list-person-email"><a href="mailto:{{ email }}">{{ email }}</a></span>{% endif %}
+                    {% set phone = item.entity.field_ucb_person_phone.0.value %}{% if phone %}<span class="ucb-content-list-person-contact-item ucb-content-list-person-phone"><a href="tel:{{ phone|preg_replace('/[^0-9\+]/', '') }}">{{ phone }}</a></span>{% endif %}
+                  </div>
+                </div>
+              {% endif %}
+              <p class="ucb-content-list-summary">
+                {% autoescape false %}
+                  {{ summary }}
+                {% endautoescape %}
+                <a aria-hidden="true" class="ucb-content-list-read-more" href="{{ item.entity.path.alias }}">Read more &raquo;</a>
+              </p>
+            </div>
+            {% if image %}
+              <div class="ucb-content-list-image-container">
+                  <a role="presentation" aria-hidden="true" href="{{ item.entity.path.alias }}">
+                    <img class="ucb-content-list-image" src="{{ imageURI }}" alt="{{ imageAlt }}">
+                  </a>
+              </div>
+            {% endif %}
+          </div>
+        {% elseif display == 'condensed' or display == 'teaser' %}
+        <div class="row ucb-content-list-row">
+          {% if image %}
+            <div class="ucb-content-list-image-container">
+              <a role="presentation" aria-hidden="true" href="{{ item.entity.path.alias }}"><img class="ucb-content-list-image" src="{{ imageURI }}" alt="{{ imageAlt }}"></a>
+            </div>
+          {% endif %}
+          <div class="ucb-content-list-text-container container">
+            <h4 class="ucb-content-list-title">
+              <a href="{{ item.entity.path.alias }}">{{ item.entity.title.0.value }}</a>
+            </h4>
+            {% if item.entity.type.0.entity.id == 'ucb_person' %}
+              <div class="ucb-content-list-person-info">
+                <div class="ucb-content-list-person-titles">
+                  {% for title in item.entity.field_ucb_person_title %}<span class="ucb-content-list-person-title">{{ title.value }}</span>{% endfor %}
+                </div>
+                <div class="ucb-content-list-person-departments">
+                  {% for department in item.entity.field_ucb_person_department %}<span class="ucb-content-list-person-department">{{ department.entity.name.value }}</span>{% endfor %}
+                </div>
+                <div class="ucb-content-list-person-contact">
+                  {% set email = item.entity.field_ucb_person_email.0.value %}{% if email %}<span class="ucb-content-list-person-contact-item ucb-content-list-person-email"><a href="mailto:{{ email }}">{{ email }}</a></span>{% endif %}
+                  {% set phone = item.entity.field_ucb_person_phone.0.value %}{% if phone %}<span class="ucb-content-list-person-contact-item ucb-content-list-person-phone"><a href="tel:{{ phone|preg_replace('/[^0-9\+]/', '') }}">{{ phone }}</a></span>{% endif %}
+                </div>
+              </div>
+            {% endif %}
+            <p class="ucb-content-list-summary">
+              {% autoescape false %}
+                {{ summary }}
+              {% endautoescape %}
+            </p>
+          </div>
+        </div>
+        {% elseif display == 'title' %}
+        <ul class="ucb-content-list-list">
+        {# ISSUE WE NEED TO MAKE EACH ITEM AN LI INSTEAD OF DUPLICATING THE UL #}
+          <li class="ucb-content-list-row ucb-content-list-title">
+            <a href="{{ item.entity.path.alias }}">{{ item.entity.title.0.value }}</a>
+          </li>
+        </ul>
+        {% elseif display == 'sidebar' %}
+          <div class="row ucb-content-list-row">
+            <div class="ucb-content-list-text-container ">
+              <span class="ucb-content-list-title"><a href="{{ item.entity.path.alias }}">{{ item.entity.title.0.value }}</a></span>
+            </div>
+            {% if image %}
+              <div class="ucb-content-list-image-container">
+                  <a role="presentation" aria-hidden="true" href="{{ item.entity.path.alias }}"><img class="ucb-content-list-image" src="{{ imageURI }}" alt="{{ imageAlt }}"></a>
+              </div>
+            {% endif %}
+          </div>
+        {% endif %}
+      {% endif %}
 		{% endfor %}
 
 		{# Adds a closing ul tag around the content if the display is selected as 'title' #}
 		{% if display == 'title' %}
 			</ul>
-		{% endif %}
+	{% endif %}
 	</div>
 </div>
 {% endblock content %}

--- a/templates/block/block--content-list.html.twig
+++ b/templates/block/block--content-list.html.twig
@@ -82,9 +82,9 @@
 				{% set body = (item.entity.body.0 ?? item.entity.field_ucb_article_content.0.entity.field_article_text.0).value|render|replace({"&nbsp;": ""})|striptags|trim %}
 				{% set bodyTrimmed = body|slice(0, 512) %}
 				{% set summary = bodyTrimmed ~ (body|length > bodyTrimmed|length ? '...') %}
-				
+
 			{% endif %}
-					
+
 			{% if display == 'full' %}
 				<div class="row ucb-content-list-row ">
 					<div class="ucb-content-list-text-container ">
@@ -109,12 +109,12 @@
 							{% autoescape false %}
 								{{ summary }}
 							{% endautoescape %}
-							<a class="ucb-content-list-read-more" href="{{ item.entity.path.alias }}">Read more &raquo;</a>
+							<a aria-hidden="true" class="ucb-content-list-read-more" href="{{ item.entity.path.alias }}">Read more &raquo;</a>
 						</p>
 					</div>
 					{% if image %}
 						<div class="ucb-content-list-image-container">
-								<a href="{{ item.entity.path.alias }}">
+								<a role="presentation" aria-hidden="true" href="{{ item.entity.path.alias }}">
 									<img class="ucb-content-list-image" src="{{ imageURI }}" alt="{{ imageAlt }}">
 								</a>
 						</div>
@@ -124,7 +124,7 @@
 			<div class="row ucb-content-list-row">
 				{% if image %}
 					<div class="ucb-content-list-image-container">
-						<a href="{{ item.entity.path.alias }}"><img class="ucb-content-list-image" src="{{ imageURI }}" alt="{{ imageAlt }}"></a>
+						<a role="presentation" aria-hidden="true" href="{{ item.entity.path.alias }}"><img class="ucb-content-list-image" src="{{ imageURI }}" alt="{{ imageAlt }}"></a>
 					</div>
 				{% endif %}
 				<div class="ucb-content-list-text-container container">
@@ -149,7 +149,6 @@
 						{% autoescape false %}
 							{{ summary }}
 						{% endautoescape %}
-						<a class="ucb-content-list-read-more" href="{{ item.entity.path.alias }}">Read more &raquo;</a>
 					</p>
 				</div>
 			</div>
@@ -167,7 +166,7 @@
 					</div>
 					{% if image %}
 						<div class="ucb-content-list-image-container">
-								<a href="{{ item.entity.path.alias }}"><img class="ucb-content-list-image" src="{{ imageURI }}" alt="{{ imageAlt }}"></a>
+								<a role="presentation" aria-hidden="true" href="{{ item.entity.path.alias }}"><img class="ucb-content-list-image" src="{{ imageURI }}" alt="{{ imageAlt }}"></a>
 						</div>
 					{% endif %}
 				</div>


### PR DESCRIPTION
### Content List Block
- Adds `role="presentation" aria-hidden="true"` to image links for an improved screen reader experience
- Removes "Read More" link from `Teaser` and `Full` display
- Hides unpublished content from appearing in Content Lists if user is not authenticated

Resolves #1008 