### PR TITLE
Content Rows: Styling Adjustments and Feature Fix

### DIFF
--- a/css/block/content-row.css
+++ b/css/block/content-row.css
@@ -30,7 +30,7 @@
   flex-direction: column;
   margin-bottom: 20px;
 }
-.row-text-container-tile{ 
+.row-text-container-tile{
   padding: 80px 40px
 }
 
@@ -110,13 +110,13 @@
 }
 
 .ucb-teaser-lg-row{
-  align-items: center;
+  align-items: flex-start;
   margin-bottom: 20px;
   flex-direction: row-reverse;
 }
 
 .ucb-teaser-lg-row.ucb-teaser-lg-alternate{
-  align-items: center;
+  align-items: flex-start;
   margin-bottom: 20px;
   flex-direction: inherit;
 }

--- a/templates/block/block--content-row.html.twig
+++ b/templates/block/block--content-row.html.twig
@@ -148,61 +148,63 @@
 		{% elseif layoutSelection == 3 %}
 			<div class="row row-col-lg-2 row-col-1 feature-row">
 				{% for key, item in content['#block_content'].field_row_layout_content %}
+        {% if loop.index0 < 3 %}
 					{% set rowLink = item.entity.field_row_layout_content_link.0.url|render %}
 					{% set smallFeatureBGValue = "background-image:url(#{ file_url( item.entity.field_row_layout_content_image.entity.field_media_image.entity.fileuri ) });background-repeat:no-repeat;background-position:center;background-size:cover;" %}
-					{% if (loop.index0 % 3 == 0) or (loop.index0 == 0) %}
-						<div class="col-lg-7">
-							<div class="feature-row-image-container feature-row-fill">
-								{% if rowLink %}
-									<a role="presentation" aria-hidden="true" href="{{ rowLink }} ">
-										{{ item.entity.field_row_layout_content_image|view }}
-									</a>
-								{% else %}
-									{{ item.entity.field_row_layout_content_image|view }}
-								{% endif %}
-								<div class="feature-row-text">
-									{% if rowLink %}
-										<a href="{{ rowLink }} ">
-											<h3>{{ item.entity.field_row_layout_content_title.0.value }}</h3>
-										</a>
-									{% else %}
-										<h3>{{ item.entity.field_row_layout_content_title.0.value }}</h3>
-									{% endif %}
-									{{ item.entity.field_row_layout_content_text|view }}
-								</div>
-							</div>
-						</div>
-						<div class="col-lg-5 row small-feature-row">
-						{% elseif loop.index0 is odd %}
-							<div class="col-lg-12 small-feature">
-								<div class="small-feature-row-image-container" style={{ smallFeatureBGValue }}>
-									<div class="feature-row-text">
-										{% if rowLink %}
-											<a href="{{ rowLink }} ">
-												<h3>{{ item.entity.field_row_layout_content_title.0.value }}</h3>
-											</a>
-										{% else %}
-											<h3>{{ item.entity.field_row_layout_content_title.0.value }}</h3>
-										{% endif %}
-									</div>
-								</div>
-							</div>
-						{% else %}
-							<div class="col-lg-12 small-feature">
-								<div class="small-feature-row-image-container" style={{ smallFeatureBGValue }}>
-									<div class="feature-row-text">
-										{% if rowLink %}
-											<a href="{{ rowLink }} ">
-												<h3>{{ item.entity.field_row_layout_content_title.0.value }}</h3>
-											</a>
-										{% else %}
-											<h3>{{ item.entity.field_row_layout_content_title.0.value }}</h3>
-										{% endif %}
-									</div>
-								</div>
-							</div>
-						</div>
-					{% endif %}
+            {% if (loop.index0 % 3 == 0) or (loop.index0 == 0) %}
+              <div class="col-lg-7">
+                <div class="feature-row-image-container feature-row-fill">
+                  {% if rowLink %}
+                    <a role="presentation" aria-hidden="true" href="{{ rowLink }} ">
+                      {{ item.entity.field_row_layout_content_image|view }}
+                    </a>
+                  {% else %}
+                    {{ item.entity.field_row_layout_content_image|view }}
+                  {% endif %}
+                  <div class="feature-row-text">
+                    {% if rowLink %}
+                      <a href="{{ rowLink }} ">
+                        <h3>{{ item.entity.field_row_layout_content_title.0.value }}</h3>
+                      </a>
+                    {% else %}
+                      <h3>{{ item.entity.field_row_layout_content_title.0.value }}</h3>
+                    {% endif %}
+                    {{ item.entity.field_row_layout_content_text|view }}
+                  </div>
+                </div>
+              </div>
+              <div class="col-lg-5 row small-feature-row">
+              {% elseif loop.index0 is odd %}
+                <div class="col-lg-12 small-feature">
+                  <div class="small-feature-row-image-container" style={{ smallFeatureBGValue }}>
+                    <div class="feature-row-text">
+                      {% if rowLink %}
+                        <a href="{{ rowLink }} ">
+                          <h3>{{ item.entity.field_row_layout_content_title.0.value }}</h3>
+                        </a>
+                      {% else %}
+                        <h3>{{ item.entity.field_row_layout_content_title.0.value }}</h3>
+                      {% endif %}
+                    </div>
+                  </div>
+                </div>
+              {% else %}
+                <div class="col-lg-12 small-feature">
+                  <div class="small-feature-row-image-container" style={{ smallFeatureBGValue }}>
+                    <div class="feature-row-text">
+                      {% if rowLink %}
+                        <a href="{{ rowLink }} ">
+                          <h3>{{ item.entity.field_row_layout_content_title.0.value }}</h3>
+                        </a>
+                      {% else %}
+                        <h3>{{ item.entity.field_row_layout_content_title.0.value }}</h3>
+                      {% endif %}
+                    </div>
+                  </div>
+                </div>
+              </div>
+            {% endif %}
+          {% endif %}
 				{% endfor %}
 			</div>
 		{% else %}


### PR DESCRIPTION
Adjusts the following styles on the "Content Row" block:

### Teaser Large + Teaser Large Alternate
- Aligns image and text to top of the row on these two display types, previously the text was centered

### Feature
- Feature style display are now fixed to only show 3 items

Resolves #1009 