### PR TITLE
Block Alignments

### DIFF
--- a/css/block/block-styles.css
+++ b/css/block/block-styles.css
@@ -57,61 +57,61 @@
 .block.bs-background-white {
   background-color: var(--ucb-white);
   color: var(--ucb-black);
-  padding: 20px;
+
 }
 
 .block.bs-background-gray {
   background-color: var(--ucb-light-gray);
   color: var(--ucb-black);
-  padding: 20px;
+
 }
 
 .block.bs-background-dark-gray {
   background-color: var(--ucb-dark-gray);
   color: var(--ucb-white);
-  padding: 20px;
+
 }
 
 .block.bs-background-tan {
   background-color: var(--ucb-light-gold);
   color: var(--ucb-black);
-  padding: 20px;
+
 }
 
 .block.bs-background-light-blue {
   background-color: var(--ucb-light-blue);
   color: var(--ucb-black);
-  padding: 20px;
+
 }
 
 .block.bs-background-medium-blue {
   background-color: var(--ucb-medium-blue);
   color: var(--ucb-black);
-  padding: 20px;
+
 }
 
 .block.bs-background-dark-blue {
   background-color: var(--ucb-dark-blue);
   color: var(--ucb-white);
-  padding: 20px;
+
 }
 
 .block.bs-background-light-green {
   background-color: var(--ucb-light-green);
   color: var(--ucb-black);
-  padding: 20px;
+
 }
 
 .block.bs-background-brick {
   background-color: var(--ucb-brick);
   color: var(--ucb-white);
-  padding: 20px;
+
 }
 
 .block.bs-background-outline {
   background-color: transparent;
   color: inherit;
-  padding: 20px;
+
   border: 1px solid rgba(200, 200, 200, 0.5);
 }
 
@@ -125,7 +125,7 @@
 .block.bs-background-alert {
   background-color: var(--ucb-alert);
   color: var(--ucb-black);
-  padding: 20px;
+
 }
 
 /*** Link Color Settings ***/

--- a/css/block/hero-unit.css
+++ b/css/block/hero-unit.css
@@ -26,6 +26,13 @@
   font-size: 120%;
 }
 
+.ucb-post-wide-title-region .block:first-child.block-hero-unit, .ucb-below-post-wide-region .block:first-child.block-hero-unit {
+  padding-top: 0;
+  padding-bottom: 0;
+  width: 100%;
+  margin: 0;
+}
+
 .ucb-boostrap-layout-section .column .block:first-child.block-hero-unit {
   padding-top: 0;
   padding-bottom: 0;
@@ -41,6 +48,16 @@
 .block-hero-unit.size-small .ucb-hero-unit-content {
   padding-top: 20px;
   padding-bottom: 20px;
+}
+
+.ucb-post-wide-title-region .block.ucb-overlay-dark, .ucb-below-post-wide-region .block.ucb-overlay-dark {
+  background-color: rgba(20, 20, 20, 0.5);
+  background-blend-mode: overlay;
+}
+
+.ucb-post-wide-title-region .block.ucb-overlay-light, .ucb-below-post-wide-region .block.ucb-overlay-light {
+  background-color: rgba(200, 200, 200, 0.7);
+  background-blend-mode: overlay;
 }
 
 .ucb-boostrap-layout-section .column .block.ucb-overlay-dark {
@@ -113,11 +130,11 @@
   margin: .5em
 }
 
-.ucb-hero-outer-wrapper {
+/* .ucb-hero-outer-wrapper {
   --bs-gutter-x: 1.5rem;
   padding-right: calc(var(--bs-gutter-x) * .5);
   padding-left: calc(var(--bs-gutter-x) * .5);
-}
+} */
 
 .ucb-hero-unit-video {
   aspect-ratio: 16 / 9;
@@ -147,6 +164,11 @@
 .ucb-hero-unit-video-player-wrapper iframe {
   width: 100%;
   height: 100%;
+}
+
+.ucb-post-wide-title-region .block-hero-unit .block:first-child, .ucb-below-post-wide-region .block-hero-unit .block:first-child {
+  padding-top: 0;
+  padding-bottom: 0;
 }
 
 .ucb-boostrap-layout-section .column .block-hero-unit .block:first-child {

--- a/css/layout-builder-styles.css
+++ b/css/layout-builder-styles.css
@@ -232,14 +232,14 @@
 }
 
 .ucb-boostrap-layout-section .column .block {
-  padding-bottom: 1em;
-  margin-bottom: 1.5rem;
+  padding-bottom: 1.5em;
+  margin-bottom: 12px;
 }
 
 .ucb-boostrap-layout-section .column .block:first-child {
-  padding-top: 1em;
-  padding-bottom: 1em;
-  margin-top: 1.5rem;
+  padding-top: 1.5rem;
+  padding-bottom: 1.5em;
+  margin-top: 12px;
 }
 
 /*** Content Frame ***/
@@ -251,7 +251,6 @@
 .content-frame-light-gray .column {
   background: rgba(255, 255, 255, 0.85);
   color: var(--ucb-black);
-  padding: 0 20px;
   margin: 20px 0;
 }
 
@@ -266,7 +265,6 @@
 .content-frame-dark-gray .column {
   background: rgba(0, 0, 0, 0.75);
   color: var(--ucb-white);
-  padding: 0 20px;
   margin: 20px 0;
 }
 
@@ -278,9 +276,8 @@
   color: var(--ucb-white);
 }
 
-/*** EDGE-TO-EDGE OPTIONS ***/
-.ucb-contained-row .container {
-  --bs-gutter-y: 0;
+/*** EDGE-TO-EDGE FIXES ***/
+.ucb-contained-row .bs-background-unstyled.container {
   --bs-gutter-x: 0;
 }
 

--- a/templates/block/block--field-block--node--basic-page--title.html.twig
+++ b/templates/block/block--field-block--node--basic-page--title.html.twig
@@ -35,7 +35,7 @@
   {{ title_suffix }}
   {% block content %}
     {% if not is_front %}
-      <div class="container ucb-page-title">
+      <div class="container ucb-page-title bs-background-unstyled">
         <div aria-hidden="true" class="h1">
           {{ content }}
         </div>

--- a/templates/field/field--field-bs-background-style.html.twig
+++ b/templates/field/field--field-bs-background-style.html.twig
@@ -1,29 +1,29 @@
 {% set backgroundChoice = element['#object'].get('field_bs_background_style').value %}
 
 {% if backgroundChoice == 'bs_background_style_white' %}
-  {% set blockBackground = 'bs-background-white' %}
+  {% set blockBackground = 'bs-background-styled bs-background-white' %}
 {% elseif backgroundChoice == 'bs_background_style_gray' %}
-  {% set blockBackground = 'bs-background-gray' %}
+  {% set blockBackground = 'bs-background-styled bs-background-gray' %}
 {% elseif backgroundChoice == 'bs_background_style_dark_gray' %}
-  {% set blockBackground = 'bs-background-dark-gray' %}
+  {% set blockBackground = 'bs-background-styled bs-background-dark-gray' %}
 {% elseif backgroundChoice == 'bs_background_style_tan' %}
-  {% set blockBackground = 'bs-background-tan' %}
+  {% set blockBackground = 'bs-background-styled bs-background-tan' %}
 {% elseif backgroundChoice == 'bs_background_style_light_blue' %}
-  {% set blockBackground = 'bs-background-light-blue' %}
+  {% set blockBackground = 'bs-background-styled bs-background-light-blue' %}
 {% elseif backgroundChoice == 'bs_background_style_medium_blue' %}
-  {% set blockBackground = 'bs-background-medium-blue' %}
+  {% set blockBackground = 'bs-background-styled bs-background-medium-blue' %}
 {% elseif backgroundChoice == 'bs_background_style_dark_blue' %}
-  {% set blockBackground = 'bs-background-dark-blue' %}
+  {% set blockBackground = 'bs-background-styled bs-background-dark-blue' %}
 {% elseif backgroundChoice == 'bs_background_style_light_green' %}
-  {% set blockBackground = 'bs-background-light-green' %}
+  {% set blockBackground = 'bs-background-styled bs-background-light-green' %}
 {% elseif backgroundChoice == 'bs_background_style_brick' %}
-  {% set blockBackground = 'bs-background-brick' %}
+  {% set blockBackground = 'bs-background-styled bs-background-brick' %}
 {% elseif backgroundChoice == 'bs_background_style_outline' %}
-  {% set blockBackground = 'bs-background-outline' %}
+  {% set blockBackground = 'bs-background-styled bs-background-outline' %}
 {% elseif backgroundChoice == 'bs_background_style_underline' %}
-  {% set blockBackground = 'bs-background-underline' %}
+  {% set blockBackground = 'bs-background-styled bs-background-underline' %}
 {% else %}
-  {% set blockBackground = 'bs-background-none' %}
+  {% set blockBackground = 'bs-background-unstyled bs-background-none' %}
 {% endif %}
 
 {{ blockBackground }}

--- a/templates/field/field--node--body--basic-page.html.twig
+++ b/templates/field/field--node--body--basic-page.html.twig
@@ -5,7 +5,7 @@
  */
 #}
 
-<div class="container bs-background-unstyled">
+<div class="container bs-background-unstyled block">
     {% for item in items %}
         {{ item.content|render }}
     {% endfor %}

--- a/templates/field/field--node--body--basic-page.html.twig
+++ b/templates/field/field--node--body--basic-page.html.twig
@@ -5,7 +5,7 @@
  */
 #}
 
-<div class="container">
+<div class="container bs-background-unstyled">
     {% for item in items %}
         {{ item.content|render }}
     {% endfor %}

--- a/templates/layout/page.html.twig
+++ b/templates/layout/page.html.twig
@@ -181,7 +181,7 @@
       {# link is in html.html.twig #}
       <div class="layout-content">
         {% if page.post_wide_title|render %}
-          <div class="ucb-post-wide-title-region">
+          <div class="ucb-post-wide-title-region edge-to-edge row g-0">
             {{ page.post_wide_title }}
           </div>
         {% endif %}
@@ -222,7 +222,7 @@
         {% endif %}
 
         {% if page.wide_post|render %}
-          <div class="ucb-below-content-region">
+          <div class="ucb-below-post-wide-region edge-to-edge row g-0">
             {{ page.wide_post }}
           </div>
         {% endif %}


### PR DESCRIPTION
Made fixes to layout alignment so that blocks will always be synced.
The main thing is that the left edge and right edge of the row content should align properly. 
There are very slight deviations in the 3 and 4 column options but those are normal for how css handles rows more than 2 columns. (The D7 version has the same discrepancies) 

Test by making tones of rows with different combos of frames and background colors with various different block types

Sister PR: https://github.com/CuBoulder/ucb_bootstrap_layouts/pull/43

Resolves #847 

<img width="1355" alt="image" src="https://github.com/CuBoulder/tiamat-theme/assets/94021017/093fb2b9-9ef0-482e-8c1c-e4619e2365b0">
<img width="1327" alt="image" src="https://github.com/CuBoulder/tiamat-theme/assets/94021017/47778b20-de74-464a-82df-fd6185093a34">
<img width="1421" alt="image" src="https://github.com/CuBoulder/tiamat-theme/assets/94021017/9b44b5be-8a94-4b7b-b75c-50afd4c8cce1">
<img width="1431" alt="image" src="https://github.com/CuBoulder/tiamat-theme/assets/94021017/ecf20eac-cbe2-40a4-a752-07b3b274eded">



