### PR TITLE
Content Row: Missing image maintains layout

### DIFF
--- a/templates/block/block--content-row.html.twig
+++ b/templates/block/block--content-row.html.twig
@@ -90,7 +90,7 @@
 				{% set rowLink = item.entity.field_row_layout_content_link.0.url|render %}
 				<div class="row d-flex row-content ucb-teaser-lg-row ucb-teaser-lg-alternate ucb-teaser-lg-row-{{oddOrEven}}">
 					{% set image = item.entity.field_row_layout_content_image.0 %}
-						<div class="{{ image ? 'col-sm-7 col-xs-12' : 'col-12' }} row-text-container">
+						<div class="col-sm-7 col-xs-12 row-text-container">
 							{% if rowLink %}
 								<a href="{{ rowLink }} ">
 									<h3>{{ item.entity.field_row_layout_content_title.0.value }}</h3>
@@ -110,6 +110,9 @@
 								<img alt="{{item.entity.field_row_layout_content_image.entity.field_media_image.alt}}" class="ucb-content-row-img-lg" src="{{item.entity.field_row_layout_content_image.entity.field_media_image.entity.fileuri|image_style('focal_image_wide')}}"></img>
 							{% endif %}
 						</div>
+            {% else %}
+            <div class="col-sm-5 col-xs-12 row-empty-image-container-lg">
+            </div>
 						{% endif %}
 				</div>
 			{% endfor %}


### PR DESCRIPTION
### Content Row - Large Teaser Alternate

Omitting the optional image on `Large Teaser - Alternate` style Content Row Blocks does not affect the layout. Previously the missing image would cause the text content to span the full width of available block space, rather than the intended alternating left & right staggered pattern and has been corrected.

Resolves #1048 