### PR TITLE
Menus: Parent page highlight in navigation, even if child page isn't enabled in menu

### DIFF
--- a/css/ucb-menu.css
+++ b/css/ucb-menu.css
@@ -249,7 +249,8 @@
   background-color: rgba(0, 0, 0, .09);
 }
 
-.ucb-page-content .ucb-menu li.menu-item a.nav-link.is-active {
+.ucb-page-content .ucb-menu li.menu-item a.nav-link.is-active,
+.ucb-page-content .ucb-menu .menu-item.active:last-child > a{
   color: #000;
   background-color: var(--ucb-gold);
 }


### PR DESCRIPTION
Previously there were cases where the child page wouldn't highlight the parent page in menus, specifically when that child page was disabled from the menu. This has been adjusted so that the final parent element in the menu will be highlighted as active as well.

Resolves #1032 