### PR TITLE
Remove aggregated categories from Collection grid

### DIFF
--- a/js/ucb-collections-block.js
+++ b/js/ucb-collections-block.js
@@ -298,7 +298,7 @@
             });
 
             if(NEXTJSONURL){
-              resolve(renderCollectionList(NEXTJSONURL, ExcludeTags, BodyDisplay, blockID, BaseURL, aggregatedCategories));
+              resolve(renderCollectionList(NEXTJSONURL, ExcludeTags, BodyDisplay, blockID, BaseURL));
               }
               else {
                 resolve(NEXTJSONURL);


### PR DESCRIPTION
Closes #1031.
Removes aggregated categories as it was causing issues when there were more than 50 collection item nodes.