### PR TITLE
Heading size fixes

### DIFF
--- a/css/block/block-styles.css
+++ b/css/block/block-styles.css
@@ -3,9 +3,11 @@
   display: flex;
 }
 
+.block-title {
+  font-size: 200%
+}
 
-
-.bs-title-scale-decrease .block-title {
+.bs-title-scale-decrease .block-title .block-title-text {
   font-size: 80%;
 }
 
@@ -13,18 +15,18 @@
   font-size: 80%;
 }
 
-.bs-title-scale-increase .block-title {
+.bs-title-scale-increase .block-title .block-title-text {
   font-size: 110%;
 }
 
 @media screen and (min-width: 768px) {
-  .bs-title-scale-increase .block-title {
+  .bs-title-scale-increase .block-title .block-title-text {
     font-size: 125%;
   }
 }
 
 @media screen and (min-width: 960px) {
-  .bs-title-scale-increase .block-title {
+  .bs-title-scale-increase .block-title .block-title-text {
     font-size: 150%;
   }
 }

--- a/css/layout-builder-styles.css
+++ b/css/layout-builder-styles.css
@@ -232,7 +232,7 @@
 }
 
 .ucb-bootstrap-layout-section .column {
-  --bs-gutter-y: 6rem;
+  --bs-gutter-y: 3rem;
   margin-top: calc(var(--bs-gutter-y)* .5);
   margin-bottom: calc(var(--bs-gutter-y)* .5);
 }

--- a/templates/block/block--article-list-block.html.twig
+++ b/templates/block/block--article-list-block.html.twig
@@ -186,12 +186,12 @@
 	<div{{attributes.addClass(classes,blockStyles)}}>
 		{{ title_prefix }}
 		{% if label %}
-			<div class="block-title {{ headingStyle }}">
-				<{{ headingTag }}{{title_attributes}}>
+			<div class="block-title-outer">
+				<{{ headingTag }}{{title_attributes}} class="block-title">
 					<span class='block-title-icon {{ iconColor }} {{ iconPosition }} {{ iconSize }}'>
 						{{ content.field_bs_icon }}
 					</span>
-					<span class="block-title-text">
+					<span class="block-title-text {{ headingStyle }}">
 						{{ label }}
 					</span>
 				</{{ headingTag }}>

--- a/templates/block/block--collection-grid.html.twig
+++ b/templates/block/block--collection-grid.html.twig
@@ -67,16 +67,16 @@
   <div{{ attributes.addClass(classes, blockStyles) }}>
     {{ title_prefix }}
     {% if label %}
-      <div class="block-title {{ headingStyle }}">
-        <{{ headingTag }}{{ title_attributes }}>
-          <span class='block-title-icon {{ iconColor }} {{ iconPosition }} {{ iconSize }}'>
-            {{ content.field_bs_icon }}
-          </span>
-          <span class="block-title-text">
-            {{ label }}
-          </span>
-        </{{ headingTag }}>
-      </div>
+      <div class="block-title-outer">
+				<{{ headingTag }}{{title_attributes}} class="block-title">
+					<span class='block-title-icon {{ iconColor }} {{ iconPosition }} {{ iconSize }}'>
+						{{ content.field_bs_icon }}
+					</span>
+					<span class="block-title-text {{ headingStyle }}">
+						{{ label }}
+					</span>
+				</{{ headingTag }}>
+			</div>
     {% endif %}
     {{ title_suffix }}
     <collection-grid data-blockid="{{ blockID }}">

--- a/templates/block/block--content-grid.html.twig
+++ b/templates/block/block--content-grid.html.twig
@@ -56,16 +56,16 @@
   <div{{ attributes.addClass(classes, blockStyles) }}>
     {{ title_prefix }}
     {% if label %}
-      <div class="block-title {{ headingStyle }}">
-        <{{ headingTag }}{{title_attributes}}>
-          <span class="block-title-icon {{ iconColor }} {{ iconPosition }} {{ iconSize }}">
-            {{ content.field_bs_icon }}
-          </span>
-          <span class="block-title-text">
-            {{ label }}
-          </span>
-        </{{ headingTag }}>
-      </div>
+      <div class="block-title-outer">
+				<{{ headingTag }}{{title_attributes}} class="block-title">
+					<span class='block-title-icon {{ iconColor }} {{ iconPosition }} {{ iconSize }}'>
+						{{ content.field_bs_icon }}
+					</span>
+					<span class="block-title-text {{ headingStyle }}">
+						{{ label }}
+					</span>
+				</{{ headingTag }}>
+			</div>
     {% endif %}
     {{ title_suffix }}
     {# Overlay Grid Layout #}

--- a/templates/block/block--content-list.html.twig
+++ b/templates/block/block--content-list.html.twig
@@ -54,12 +54,12 @@
 	<div{{attributes.addClass(classes,blockStyles)}}>
 		{{ title_prefix }}
 		{% if label %}
-			<div class="block-title {{ headingStyle }}">
-				<{{ headingTag }}{{title_attributes}}>
+			<div class="block-title-outer">
+				<{{ headingTag }}{{title_attributes}} class="block-title">
 					<span class='block-title-icon {{ iconColor }} {{ iconPosition }} {{ iconSize }}'>
 						{{ content.field_bs_icon }}
 					</span>
-					<span class="block-title-text">
+					<span class="block-title-text {{ headingStyle }}">
 						{{ label }}
 					</span>
 				</{{ headingTag }}>

--- a/templates/block/block--content-row.html.twig
+++ b/templates/block/block--content-row.html.twig
@@ -41,12 +41,12 @@
 	<div{{attributes.addClass(classes,blockStyles)}}>
 		{{ title_prefix }}
 		{% if label %}
-			<div class="block-title {{ headingStyle }}">
-				<{{ headingTag }}{{title_attributes}}>
+			<div class="block-title-outer">
+				<{{ headingTag }}{{title_attributes}} class="block-title">
 					<span class='block-title-icon {{ iconColor }} {{ iconPosition }} {{ iconSize }}'>
 						{{ content.field_bs_icon }}
 					</span>
-					<span class="block-title-text">
+					<span class="block-title-text {{ headingStyle }}">
 						{{ label }}
 					</span>
 				</{{ headingTag }}>

--- a/templates/block/block--content-sequence.html.twig
+++ b/templates/block/block--content-sequence.html.twig
@@ -36,16 +36,16 @@
   <div{{ attributes.addClass(classes, blockStyles) }}>
     {{ title_prefix }}
     {% if label %}
-      <div class="block-title {{ headingStyle }}">
-        <{{ headingTag }}{{ title_attributes }}>
-          <span class='block-title-icon {{ iconColor }} {{ iconPosition }} {{ iconSize }}'>
-            {{ content.field_bs_icon }}
-          </span>
-          <span class="block-title-text">
-            {{ label }}
-          </span>
-        </{{ headingTag }}>
-      </div>
+      <div class="block-title-outer">
+				<{{ headingTag }}{{title_attributes}} class="block-title">
+					<span class='block-title-icon {{ iconColor }} {{ iconPosition }} {{ iconSize }}'>
+						{{ content.field_bs_icon }}
+					</span>
+					<span class="block-title-text {{ headingStyle }}">
+						{{ label }}
+					</span>
+				</{{ headingTag }}>
+			</div>
     {% endif %}
     {{ title_suffix }}
     <div class="vertical-timeline-container-wrapper">

--- a/templates/block/block--events-calendar.html.twig
+++ b/templates/block/block--events-calendar.html.twig
@@ -39,12 +39,12 @@
 	<div{{attributes.addClass(classes,blockStyles)}}>
 		{{ title_prefix }}
 		{% if label %}
-			<div class="block-title {{ headingStyle }}">
-				<{{ headingTag }}{{title_attributes}}>
+			<div class="block-title-outer">
+				<{{ headingTag }}{{title_attributes}} class="block-title">
 					<span class='block-title-icon {{ iconColor }} {{ iconPosition }} {{ iconSize }}'>
 						{{ content.field_bs_icon }}
 					</span>
-					<span class="block-title-text">
+					<span class="block-title-text {{ headingStyle }}">
 						{{ label }}
 					</span>
 				</{{ headingTag }}>

--- a/templates/block/block--expandable-content.html.twig
+++ b/templates/block/block--expandable-content.html.twig
@@ -61,12 +61,12 @@
 	<div{{attributes.addClass(classes,blockStyles)}}>
 		{{ title_prefix }}
 		{% if label %}
-			<div class="block-title {{ headingStyle }}">
-				<{{ headingTag }}{{title_attributes}}>
+			<div class="block-title-outer">
+				<{{ headingTag }}{{title_attributes}} class="block-title">
 					<span class='block-title-icon {{ iconColor }} {{ iconPosition }} {{ iconSize }}'>
 						{{ content.field_bs_icon }}
 					</span>
-					<span class="block-title-text">
+					<span class="block-title-text {{ headingStyle }}">
 						{{ label }}
 					</span>
 				</{{ headingTag }}>

--- a/templates/block/block--hero-unit.html.twig
+++ b/templates/block/block--hero-unit.html.twig
@@ -80,15 +80,15 @@
 	<div class="{{ classes|join(' ') }} {{ blockStyles|join(' ') }}">
 		{{ title_prefix }}
 		{% if label %}
-			<div class="block-title {{ headingStyle }}">
-				<{{headingTag}}{{title_attributes}}>
+			<div class="block-title-outer">
+				<{{ headingTag }}{{title_attributes}} class="block-title">
 					<span class='block-title-icon {{ iconColor }} {{ iconPosition }} {{ iconSize }}'>
 						{{ content.field_bs_icon }}
 					</span>
-					<span class="block-title-text">
+					<span class="block-title-text {{ headingStyle }}">
 						{{ label }}
 					</span>
-				</{{headingTag}}>
+				</{{ headingTag }}>
 			</div>
 		{% endif %}
 		{{ title_suffix }}

--- a/templates/block/block--image-gallery.html.twig
+++ b/templates/block/block--image-gallery.html.twig
@@ -40,15 +40,15 @@
 	<div{{attributes.addClass(classes,blockStyles)}}>
 		{{ title_prefix }}
 		{% if label %}
-			<div class="block-title {{ headingStyle }}">
-				<{{headingTag}}{{title_attributes}}>
+			<div class="block-title-outer">
+				<{{ headingTag }}{{title_attributes}} class="block-title">
 					<span class='block-title-icon {{ iconColor }} {{ iconPosition }} {{ iconSize }}'>
 						{{ content.field_bs_icon }}
 					</span>
-					<span class="block-title-text">
+					<span class="block-title-text {{ headingStyle }}">
 						{{ label }}
 					</span>
-				</{{headingTag}}>
+				</{{ headingTag }}>
 			</div>
 		{% endif %}
 		{{ title_suffix }}

--- a/templates/block/block--slider.html.twig
+++ b/templates/block/block--slider.html.twig
@@ -57,12 +57,12 @@
 	<div{{attributes.addClass(classes,blockStyles,size)}}>
 		{{ title_prefix }}
 		{% if label %}
-			<div class="block-title {{ headingStyle }}">
-				<{{ headingTag }}{{title_attributes}}>
+			<div class="block-title-outer">
+				<{{ headingTag }}{{title_attributes}} class="block-title">
 					<span class='block-title-icon {{ iconColor }} {{ iconPosition }} {{ iconSize }}'>
 						{{ content.field_bs_icon }}
 					</span>
-					<span class="block-title-text">
+					<span class="block-title-text {{ headingStyle }}">
 						{{ label }}
 					</span>
 				</{{ headingTag }}>

--- a/templates/block/block--social-media-icons.html.twig
+++ b/templates/block/block--social-media-icons.html.twig
@@ -60,16 +60,16 @@
   <div{{ attributes.addClass(classes, blockStyles) }}>
     {{ title_prefix }}
     {% if label %}
-      <div class="block-title {{ headingStyle }}">
-        <{{ headingTag }}{{ title_attributes }}>
-          <span class='block-title-icon {{ iconColor }} {{ iconPosition }} {{ iconSize }}'>
-            {{ content.field_bs_icon }}
-          </span>
-          <span class="block-title-text">
-            {{ label }}
-          </span>
-        </{{ headingTag }}>
-      </div>
+      <div class="block-title-outer">
+				<{{ headingTag }}{{title_attributes}} class="block-title">
+					<span class='block-title-icon {{ iconColor }} {{ iconPosition }} {{ iconSize }}'>
+						{{ content.field_bs_icon }}
+					</span>
+					<span class="block-title-text {{ headingStyle }}">
+						{{ label }}
+					</span>
+				</{{ headingTag }}>
+			</div>
     {% endif %}
     {{ title_suffix }}
     {{ content.field_social_media_links }}

--- a/templates/block/block--statuspage-block.html.twig
+++ b/templates/block/block--statuspage-block.html.twig
@@ -29,12 +29,12 @@
 	<div{{attributes.addClass(classes,blockStyles)}}>
 		{{ title_prefix }}
 		{% if label %}
-			<div class="block-title {{ headingStyle }}">
-				<{{ headingTag }}{{title_attributes}}>
+			<div class="block-title-outer">
+				<{{ headingTag }}{{title_attributes}} class="block-title">
 					<span class='block-title-icon {{ iconColor }} {{ iconPosition }} {{ iconSize }}'>
 						{{ content.field_bs_icon }}
 					</span>
-					<span class="block-title-text">
+					<span class="block-title-text {{ headingStyle }}">
 						{{ label }}
 					</span>
 				</{{ headingTag }}>

--- a/templates/block/block--text-block.html.twig
+++ b/templates/block/block--text-block.html.twig
@@ -53,12 +53,12 @@
 	<div{{attributes.addClass(classes,blockStyles)}}>
 		{{ title_prefix }}
 		{% if label %}
-			<div class="block-title {{ headingStyle }}">
-				<{{ headingTag }}{{title_attributes}}>
+			<div class="block-title-outer">
+				<{{ headingTag }}{{title_attributes}} class="block-title">
 					<span class='block-title-icon {{ iconColor }} {{ iconPosition }} {{ iconSize }}'>
 						{{ content.field_bs_icon }}
 					</span>
-					<span class="block-title-text">
+					<span class="block-title-text {{ headingStyle }}">
 						{{ label }}
 					</span>
 				</{{ headingTag }}>

--- a/templates/block/block--ucb-article-feature.html.twig
+++ b/templates/block/block--ucb-article-feature.html.twig
@@ -185,12 +185,12 @@
 	<div{{attributes.addClass(classes,blockStyles)}}>
 		{{ title_prefix }}
 		{% if label %}
-			<div class="block-title {{ headingStyle }}">
-				<{{ headingTag }}{{title_attributes}}>
+			<div class="block-title-outer">
+				<{{ headingTag }}{{title_attributes}} class="block-title">
 					<span class='block-title-icon {{ iconColor }} {{ iconPosition }} {{ iconSize }}'>
 						{{ content.field_bs_icon }}
 					</span>
-					<span class="block-title-text">
+					<span class="block-title-text {{ headingStyle }}">
 						{{ label }}
 					</span>
 				</{{ headingTag }}>

--- a/templates/block/block--ucb-article-grid.html.twig
+++ b/templates/block/block--ucb-article-grid.html.twig
@@ -185,12 +185,12 @@
 	<div{{attributes.addClass(classes,blockStyles)}}>
 		{{ title_prefix }}
 		{% if label %}
-			<div class="block-title {{ headingStyle }}">
-				<{{ headingTag }}{{title_attributes}}>
+			<div class="block-title-outer">
+				<{{ headingTag }}{{title_attributes}} class="block-title">
 					<span class='block-title-icon {{ iconColor }} {{ iconPosition }} {{ iconSize }}'>
 						{{ content.field_bs_icon }}
 					</span>
-					<span class="block-title-text">
+					<span class="block-title-text {{ headingStyle }}">
 						{{ label }}
 					</span>
 				</{{ headingTag }}>

--- a/templates/block/block--ucb-article-slider.html.twig
+++ b/templates/block/block--ucb-article-slider.html.twig
@@ -185,16 +185,16 @@
 <div{{attributes.addClass(classes,blockStyles)}}>
 	{{ title_prefix }}
 	{% if label %}
-		<div class="block-title {{ headingStyle }}">
-			<{{headingTag}}{{title_attributes}}>
-				<span class='block-title-icon {{ iconColor }} {{ iconPosition }} {{ iconSize }}'>
-					{{ content.field_bs_icon }}
-				</span>
-				<span class="block-title-text">
-					{{ label }}
-				</span>
-			</{{headingTag}}>
-		</div>
+		<div class="block-title-outer">
+				<{{ headingTag }}{{title_attributes}} class="block-title">
+					<span class='block-title-icon {{ iconColor }} {{ iconPosition }} {{ iconSize }}'>
+						{{ content.field_bs_icon }}
+					</span>
+					<span class="block-title-text {{ headingStyle }}">
+						{{ label }}
+					</span>
+				</{{ headingTag }}>
+			</div>
 	{% endif %}
 	{{ title_suffix }}
 	{{ content.body }}

--- a/templates/block/block--ucb-category-cloud.html.twig
+++ b/templates/block/block--ucb-category-cloud.html.twig
@@ -32,16 +32,16 @@
 <div{{attributes.addClass(classes,blockStyles)}}>
 	{{ title_prefix }}
 	{% if label %}
-		<div class="block-title {{ headingStyle }}">
-			<{{headingTag}}{{title_attributes}}>
-				<span class='block-title-icon {{ iconColor }} {{ iconPosition }} {{ iconSize }}'>
-					{{ content.field_bs_icon }}
-				</span>
-				<span class="block-title-text">
-					{{ label }}
-				</span>
-			</{{headingTag}}>
-		</div>
+		<div class="block-title-outer">
+				<{{ headingTag }}{{title_attributes}} class="block-title">
+					<span class='block-title-icon {{ iconColor }} {{ iconPosition }} {{ iconSize }}'>
+						{{ content.field_bs_icon }}
+					</span>
+					<span class="block-title-text {{ headingStyle }}">
+						{{ label }}
+					</span>
+				</{{ headingTag }}>
+			</div>
 	{% endif %}
 	{{ title_suffix }}
 	<category-cloud-block base-uri="{{baseurlJSON}}"></category-cloud-block>

--- a/templates/block/block--ucb-current-issue-block.html.twig
+++ b/templates/block/block--ucb-current-issue-block.html.twig
@@ -31,16 +31,16 @@
 <div{{attributes.addClass(classes,blockStyles)}}>
 	{{ title_prefix }}
 	{% if label %}
-		<div class="block-title {{ headingStyle }}">
-			<{{headingTag}}{{title_attributes}}>
-				<span class='block-title-icon {{ iconColor }} {{ iconPosition }} {{ iconSize }}'>
-					{{ content.field_bs_icon }}
-				</span>
-				<span class="block-title-text">
-					{{ label }}
-				</span>
-			</{{headingTag}}>
-		</div>
+		<div class="block-title-outer">
+				<{{ headingTag }}{{title_attributes}} class="block-title">
+					<span class='block-title-icon {{ iconColor }} {{ iconPosition }} {{ iconSize }}'>
+						{{ content.field_bs_icon }}
+					</span>
+					<span class="block-title-text {{ headingStyle }}">
+						{{ label }}
+					</span>
+				</{{ headingTag }}>
+			</div>
 	{% endif %}
 	{{ title_suffix }}
 	<current-issue-block base-uri="{{baseurlJSON}}">

--- a/templates/block/block--ucb-latest-issues-block.html.twig
+++ b/templates/block/block--ucb-latest-issues-block.html.twig
@@ -31,16 +31,16 @@
 <div{{attributes.addClass(classes,blockStyles)}}>
 	{{ title_prefix }}
 	{% if label %}
-		<div class="block-title {{ headingStyle }}">
-			<{{headingTag}}{{title_attributes}}>
-				<span class='block-title-icon {{ iconColor }} {{ iconPosition }} {{ iconSize }}'>
-					{{ content.field_bs_icon }}
-				</span>
-				<span class="block-title-text">
-					{{ label }}
-				</span>
-			</{{headingTag}}>
-		</div>
+		<div class="block-title-outer">
+				<{{ headingTag }}{{title_attributes}} class="block-title">
+					<span class='block-title-icon {{ iconColor }} {{ iconPosition }} {{ iconSize }}'>
+						{{ content.field_bs_icon }}
+					</span>
+					<span class="block-title-text {{ headingStyle }}">
+						{{ label }}
+					</span>
+				</{{ headingTag }}>
+			</div>
 	{% endif %}
 	{{ title_suffix }}
 	<latest-issue-block baseURL="{{baseurlJSON}}" siteName="{{ site_name|lower|replace({' ': '-', '_': '-'}) }}">

--- a/templates/block/block--ucb-people-list-block.html.twig
+++ b/templates/block/block--ucb-people-list-block.html.twig
@@ -74,12 +74,12 @@
 	<div{{attributes.addClass(classes,blockStyles)}}>
 		{{ title_prefix }}
 		{% if label %}
-			<div class="block-title {{ headingStyle }}">
-				<{{ headingTag }}{{title_attributes}}>
+			<div class="block-title-outer">
+				<{{ headingTag }}{{title_attributes}} class="block-title">
 					<span class='block-title-icon {{ iconColor }} {{ iconPosition }} {{ iconSize }}'>
 						{{ content.field_bs_icon }}
 					</span>
-					<span class="block-title-text">
+					<span class="block-title-text {{ headingStyle }}">
 						{{ label }}
 					</span>
 				</{{ headingTag }}>

--- a/templates/block/block--ucb-slate-form.html.twig
+++ b/templates/block/block--ucb-slate-form.html.twig
@@ -29,16 +29,16 @@
 <div{{attributes.addClass(classes,blockStyles)}}>
 	{{ title_prefix }}
 	{% if label %}
-		<div class="block-title {{ headingStyle }}">
-			<{{headingTag}}{{title_attributes}}>
-				<span class='block-title-icon {{ iconColor }} {{ iconPosition }} {{ iconSize }}'>
-					{{ content.field_bs_icon }}
-				</span>
-				<span class="block-title-text">
-					{{ label }}
-				</span>
-			</{{headingTag}}>
-		</div>
+		<div class="block-title-outer">
+				<{{ headingTag }}{{title_attributes}} class="block-title">
+					<span class='block-title-icon {{ iconColor }} {{ iconPosition }} {{ iconSize }}'>
+						{{ content.field_bs_icon }}
+					</span>
+					<span class="block-title-text {{ headingStyle }}">
+						{{ label }}
+					</span>
+				</{{ headingTag }}>
+			</div>
 	{% endif %}
 	{{ title_suffix }}
 	<slate-form slateid="{{content.field_ucb_slate_form_id|render|striptags|trim|lower}}" slatedomain="{{content.field_ucb_slate_form_domain.0['#url']}}"></slate-form>

--- a/templates/block/block--ucb-tag-cloud.html.twig
+++ b/templates/block/block--ucb-tag-cloud.html.twig
@@ -32,16 +32,16 @@
 <div{{attributes.addClass(classes,blockStyles)}}>
 	{{ title_prefix }}
 	{% if label %}
-		<div class="block-title {{ headingStyle }}">
-			<{{headingTag}}{{title_attributes}}>
-				<span class='block-title-icon {{ iconColor }} {{ iconPosition }} {{ iconSize }}'>
-					{{ content.field_bs_icon }}
-				</span>
-				<span class="block-title-text">
-					{{ label }}
-				</span>
-			</{{headingTag}}>
-		</div>
+		<div class="block-title-outer">
+				<{{ headingTag }}{{title_attributes}} class="block-title">
+					<span class='block-title-icon {{ iconColor }} {{ iconPosition }} {{ iconSize }}'>
+						{{ content.field_bs_icon }}
+					</span>
+					<span class="block-title-text {{ headingStyle }}">
+						{{ label }}
+					</span>
+				</{{ headingTag }}>
+			</div>
 	{% endif %}
 	{{ title_suffix }}
 	<tag-cloud-block base-uri="{{baseurlJSON}}"></tag-cloud-block>

--- a/templates/block/block--video-hero-unit.html.twig
+++ b/templates/block/block--video-hero-unit.html.twig
@@ -94,16 +94,16 @@
   <div class="{{ classes|join(' ') }} {{ blockStyles|join(' ') }}">
     {{ title_prefix }}
     {% if label %}
-      <div class="block-title {{ headingStyle }}">
-        <{{headingTag}}{{title_attributes}}>
-          <span class='block-title-icon {{ iconColor }} {{ iconPosition }} {{ iconSize }}'>
-            {{ content.field_bs_icon }}
-          </span>
-          <span class="block-title-text">
-            {{ label }}
-          </span>
-        </{{headingTag}}>
-      </div>
+      <div class="block-title-outer">
+				<{{ headingTag }}{{title_attributes}} class="block-title">
+					<span class='block-title-icon {{ iconColor }} {{ iconPosition }} {{ iconSize }}'>
+						{{ content.field_bs_icon }}
+					</span>
+					<span class="block-title-text {{ headingStyle }}">
+						{{ label }}
+					</span>
+				</{{ headingTag }}>
+			</div>
     {% endif %}
     {{ title_suffix }}
 			<div class="{{ classes|join(' ') }} {{size}} {{overlayClass}} {{videoClass}} {{containerSize}}" style="{{ bgValue }}">

--- a/templates/block/block--video-reveal.html.twig
+++ b/templates/block/block--video-reveal.html.twig
@@ -39,16 +39,16 @@
   <div{{ attributes.addClass(classes, blockStyles) }}>
     {{ title_prefix }}
     {% if label %}
-      <div class="block-title {{ headingStyle }}">
-        <{{ headingTag }}{{ title_attributes }}>
-          <span class='block-title-icon {{ iconColor }} {{ iconPosition }} {{ iconSize }}'>
-            {{ content.field_bs_icon }}
-          </span>
-          <span class="block-title-text">
-            {{ label }}
-          </span>
-        </{{ headingTag }}>
-      </div>
+      <div class="block-title-outer">
+				<{{ headingTag }}{{title_attributes}} class="block-title">
+					<span class='block-title-icon {{ iconColor }} {{ iconPosition }} {{ iconSize }}'>
+						{{ content.field_bs_icon }}
+					</span>
+					<span class="block-title-text {{ headingStyle }}">
+						{{ label }}
+					</span>
+				</{{ headingTag }}>
+			</div>
     {% endif %}
     {{ title_suffix }}
     <div id="ucb-video-block-{{ blockId }}" class="ucb-video-text-div">


### PR DESCRIPTION
Updated the block-title class position so that the title class name is getting applied at the right level.

Previously the block-title was wrapping the h2/h3/h4/h5/h6 so that the font-size wasn't getting applied correctly.
Example: The block title is supposed to be 200% of the main font size (16px/1rem). That was getting applied on top of the 160% of h2 instead of h2.block-title just being made 200%. So instead of 32px it was becoming 52px. Essentially we were just double increasing, 16px\*160%\*200% rather than 16x\*200%.

With the change of positioning on the block-title class that resolves this issue. It also fixes an issue with the block-title-increase/decrease options that we didn't know we had.

This also tightens up the vertical spacing a bit with blocks/columns

Resolves #1050 