### PR TITLE
Fixes Links on Blocks using JSON:API 

### DIFF
--- a/js/ucb-article-feature-block.js
+++ b/js/ucb-article-feature-block.js
@@ -125,7 +125,7 @@ class ArticleFeatureBlockElement extends HTMLElement {
 
             return {
               title: item.attributes.title,
-              link: item.attributes.path.alias,
+              link: this._baseURI + item.attributes.path.alias,
               imageSquare: imageSrc,
               imageWide: imageSrcWide,
               date: new Date(item.attributes.created).toLocaleDateString(

--- a/js/ucb-article-grid-block.js
+++ b/js/ucb-article-grid-block.js
@@ -110,7 +110,7 @@ class ArticleGridBlockElement extends HTMLElement {
 
             return {
               title: item.attributes.title,
-              link: item.attributes.path.alias,
+              link: this._baseURI + item.attributes.path.alias,
               image: imageSrc,
               date: new Date(item.attributes.created).toLocaleDateString(
                 "en-us",

--- a/js/ucb-article-list-block.js
+++ b/js/ucb-article-list-block.js
@@ -115,7 +115,7 @@ class ArticleListBlockElement extends HTMLElement {
 
             return {
               title: item.attributes.title,
-              link: item.attributes.path.alias,
+              link: this._baseURI + item.attributes.path.alias,
               image: imageSrc,
               imageWide: imageSrcWide,
               date: new Date(item.attributes.created).toLocaleDateString(

--- a/js/ucb-article-list.js
+++ b/js/ucb-article-list.js
@@ -90,6 +90,7 @@
         fetch(JSONURL)
           .then((reponse) => reponse.json())
           .then((data) => {
+            console.log('am i here', baseURI)
             // get the next URL and return that if there is one
             if (data.links.next) {
               let nextURL = data.links.next.href.split("/jsonapi/");
@@ -203,7 +204,7 @@
                 const options = { year: 'numeric', month: 'short', day: 'numeric' };
                 let date = new Date(item.attributes.created).toLocaleDateString('en-us', options);
                 let title = item.attributes.title;
-                let link = item.attributes.path.alias;
+                let link = baseURI + item.attributes.path.alias;
                 let image = "";
                 let articleSummarySize = "col-md-12";
 

--- a/js/ucb-article-list.js
+++ b/js/ucb-article-list.js
@@ -90,7 +90,6 @@
         fetch(JSONURL)
           .then((reponse) => reponse.json())
           .then((data) => {
-            console.log('am i here', baseURI)
             // get the next URL and return that if there is one
             if (data.links.next) {
               let nextURL = data.links.next.href.split("/jsonapi/");

--- a/js/ucb-article-slider-block.js
+++ b/js/ucb-article-slider-block.js
@@ -116,7 +116,7 @@ class ArticleSliderBlockElement extends HTMLElement {
                 imageSrc = altObj[idObj[thumbId]];
 
                 let title = item.attributes.title;
-                let link = item.attributes.path.alias;
+                let link = this._baseURI + item.attributes.path.alias;
                 // Create an Article Object for programatic rendering
                 const article = {
                     title,

--- a/js/ucb-category-cloud.js
+++ b/js/ucb-category-cloud.js
@@ -30,7 +30,7 @@ class CategoryCloudElement extends HTMLElement {
                 const categoryURL = document.createElement('a')
                 categoryURL.classList = 'ucb-category-cloud-link'
                 categoryURL.innerText = categoryName
-                categoryURL.href = `taxonomy/term/${category.attributes.drupal_internal__tid}`
+                categoryURL.href = this._baseURI + `/taxonomy/term/${category.attributes.drupal_internal__tid}`
                 categoryCloudContainer.appendChild(categoryURL)
             })
 

--- a/js/ucb-collections-block.js
+++ b/js/ucb-collections-block.js
@@ -219,7 +219,7 @@
                 let title = item.attributes.title;
                 let link = "";
                 if (item.attributes.path.alias) {
-                  link = item.attributes.path.alias;
+                  link = BaseURL + item.attributes.path.alias;
                 } else {
                   link =
                     BaseURL + "/node/" + item.attributes.drupal_internal__nid;

--- a/js/ucb-current-issue-block.js
+++ b/js/ucb-current-issue-block.js
@@ -25,7 +25,7 @@ class CurrentIssueElement extends HTMLElement {
         } else {
             const title = data.data[0].attributes.title
             let imgURL
-            const issueURL = data.data[0].attributes.path.alias
+            const issueURL = this._baseURI + data.data[0].attributes.path.alias;
 
             const imgLinkEL = document.createElement('a')
             imgLinkEL.href = issueURL

--- a/js/ucb-issue-archive.js
+++ b/js/ucb-issue-archive.js
@@ -52,7 +52,7 @@ class IssueArchiveElement extends HTMLElement {
             for(let i=0;i<issues.length;i++){
                 const issue = issues[i]
                 const title = issue.attributes.title
-                const issueUrl = issue.attributes.path.alias
+                const issueUrl = this._baseURI + issue.attributes.path.alias;
                 const issueContainer = document.createElement('div')
                 issueContainer.classList = 'ucb-issue-archive-card px-3'
                 if(issue.relationships.field_ucb_issue_cover_image.data){

--- a/js/ucb-latest-issue-block.js
+++ b/js/ucb-latest-issue-block.js
@@ -1,9 +1,9 @@
 class LatestIssueElement extends HTMLElement {
 	constructor() {
 		super();
-        
+
         const handleError = response => {
-            if (!response.ok) { 
+            if (!response.ok) {
                throw new Error;
             } else {
                return response.json();
@@ -20,6 +20,7 @@ class LatestIssueElement extends HTMLElement {
     }
 
    async build(data){
+        const baseURL = this.getAttribute("baseURL");
         if(data.data.length == 0){
             this.handleError({name : "No Issues Retrieved", message : "There are no Issues created"} , 'No Issues Found')
         } else {
@@ -49,10 +50,10 @@ class LatestIssueElement extends HTMLElement {
             for(let i=0;i<issues.length;i++){
                 const issue = issues[i]
                 const title = issue.attributes.title
-                const issueUrl = issue.attributes.path.alias
+                const issueUrl = baseURL + issue.attributes.path.alias
                 const issueContainer = document.createElement('div')
                 issueContainer.classList = 'ucb-latest-issue-card'
-                // Image 
+                // Image
                 if(issue.relationships.field_ucb_issue_cover_image.data){
                     const issueId = issue.relationships.field_ucb_issue_cover_image.data.id;
                     const imgUrl = urlObj[idObj[issueId]]
@@ -77,14 +78,13 @@ class LatestIssueElement extends HTMLElement {
                 titleLink.href = issueUrl
                 titleLink.appendChild(issueTitle)
 
-                
+
                 issueContainer.appendChild(titleLink)
                 latestIssueContainer.appendChild(issueContainer)
             }
             this.toggleMessage('ucb-al-loading');
             this.appendChild(latestIssueContainer)
             const siteTitle = this.getAttribute('siteName');
-            const baseURL = this.getAttribute('baseURL');
             // Check if Archive Exists:
             let archiveExists
             const response = await fetch(`${baseURL}/${siteTitle}/issue/archive`)
@@ -100,7 +100,7 @@ class LatestIssueElement extends HTMLElement {
                 archiveContainer.classList = 'ucb-latest-issue-archive-container'
                 const archiveLink = document.createElement('a')
                 archiveLink.classList = 'ucb-latest-issue-archive-button'
-                archiveLink.href = '/issue/archive'
+                archiveLink.href = baseURL + '/issue/archive'
                 archiveLink.innerText = 'Issue Archive'
 
                 archiveContainer.appendChild(archiveLink)
@@ -127,7 +127,7 @@ class LatestIssueElement extends HTMLElement {
 
         this.appendChild(container)
         console.error(Error)
-        
+
     }
     toggleMessage(id, display = "none") {
         if (id) {

--- a/js/ucb-people-list-block.js
+++ b/js/ucb-people-list-block.js
@@ -112,7 +112,7 @@ class PeopleListBlockElement extends HTMLElement {
 		chromeElement.appendChild(loadingElement);
 		this.appendChild(chromeElement);
 		this.appendChild(contentElement);
-		const taxonomyIds = this._taxonomyIds = config['taxonomies'], 
+		const taxonomyIds = this._taxonomyIds = config['taxonomies'],
 			filters = this._filters = config['filters'] || {},
 			groupBy = this._groupBy = config['groupby'] || 'none',
 			orderBy = this._orderBy = config['orderby'] || 'last',
@@ -130,7 +130,7 @@ class PeopleListBlockElement extends HTMLElement {
 			const taxonomyId = taxonomyIds[taxonomyFieldName];
 			this.fetchTaxonomy(taxonomyId, taxonomyFieldName).then(taxonomy => {
 				this.onTaxonomyLoaded(taxonomyFieldName, taxonomy);
-			}).catch(reason => console.warn('Taxonomy with id `' + taxonomyId + '` failed to load!'));	
+			}).catch(reason => console.warn('Taxonomy with id `' + taxonomyId + '` failed to load!'));
 		});
 	}
 
@@ -145,7 +145,7 @@ class PeopleListBlockElement extends HTMLElement {
 							if(this._syncTaxonomiesLoaded >= this._syncTaxonomies.size) // Enter build method
 								this.build();
 						}
-					}).catch(reason => this.onFatalError(reason));	
+					}).catch(reason => this.onFatalError(reason));
 				}
 			});
 		} else this.build();
@@ -161,7 +161,7 @@ class PeopleListBlockElement extends HTMLElement {
 		try {
 			userConfig = this._userConfig = JSON.parse(this.getAttribute('user-config'));
 		} catch(e) {}
-		
+
 		const
 			config = this._config,
 			baseURI = this._baseURI,
@@ -206,7 +206,7 @@ class PeopleListBlockElement extends HTMLElement {
 								termPeople.push(person);
 							});
 					});
-				}	
+				}
 				// get all of the include images id => url
 				const urlObj = {}; // key from data.data to key from data.includes
 				const idObj = {}; // key from data.includes to URL
@@ -365,7 +365,7 @@ class PeopleListBlockElement extends HTMLElement {
 		return taxonomyTerm && this._groupedPeople ? this._groupedPeople.get(taxonomyTerm.id) : people;
 	}
 
-	displayPeople(format, people, urlObj, idObj, containerElement) {		
+	displayPeople(format, people, urlObj, idObj, containerElement) {
 		// If grid render and no thumbnail, use a default image for the person. Else no image.
 		const defaultThumbnail = format == 'grid' ? defaultAvatarURL : '';
 
@@ -392,7 +392,7 @@ class PeopleListBlockElement extends HTMLElement {
 
 			// Builds arrays of department and job type ids
 			departmentsData.forEach(departmentData => departments.push(departmentData['meta']['drupal_internal__target_id']));
-			jobTypesData.forEach(jobTypeData => jobTypes.push(jobTypeData['meta']['drupal_internal__target_id']));	
+			jobTypesData.forEach(jobTypeData => jobTypes.push(jobTypeData['meta']['drupal_internal__target_id']));
 			// needed to verify if primary link exists on page
 				if (personAttributeData['field_ucb_person_primary_link']) {
 					thisPerson.primaryLinkURI =  personAttributeData['field_ucb_person_primary_link']['uri'];
@@ -429,7 +429,7 @@ class PeopleListBlockElement extends HTMLElement {
 					  }
 					}
 			}
-			
+
 			this.appendPerson(format, thisPerson, containerElement);
 		});
 	}
@@ -437,7 +437,7 @@ class PeopleListBlockElement extends HTMLElement {
 	appendPerson(format, person, containerElement) {
 		let cardElement, cardHTML = '', personTitleList = '', personDepartmentList = '';
 		const
-			personLink = person.link,
+			personLink = this.getAttribute('site-base') + person.link,
 			personName = PeopleListBlockElement.escapeHTML(person.name),
 			personPhoto = person.photoURI ? '<img src="' + person.photoURI + '">' : '',
 			personBody = PeopleListBlockElement.escapeHTML(person.body),
@@ -479,7 +479,7 @@ class PeopleListBlockElement extends HTMLElement {
 								${personTitleList}
 							</span>
 							<span class="ucb-person-card-dept">
-								${personDepartmentList} 
+								${personDepartmentList}
 							</span>
 							<span class="ucb-person-card-body">
 								${personBody}
@@ -607,7 +607,7 @@ class PeopleListBlockElement extends HTMLElement {
 			const url = new URL(linkURI);
 			const domainParts = url.hostname.toLowerCase().split('.');
 			const domain = domainParts.length > 1 ? domainParts[domainParts.length - 2] : url.hostname;
-	
+
 			switch (domain.toUpperCase()) {
 				case 'FACEBOOK':
 					linkIcon = "fa-brands fa-facebook primaryLinkIcon";
@@ -654,7 +654,7 @@ class PeopleListBlockElement extends HTMLElement {
 		} catch (e) {
 			console.error(`Error processing URL ${linkURI}:`, e);
 		}
-		
+
 		return linkIcon;
 	}
 }

--- a/js/ucb-people-list.js
+++ b/js/ucb-people-list.js
@@ -373,7 +373,7 @@
     buildTableGroup(taxonomyTerm) {
       let table = this._contentElement.querySelector('table'), tableBody;
       // we only need to render the table header the first time
-      // this function will be called multiple times so check to 
+      // this function will be called multiple times so check to
       // see if we've already rendered the table header HTML
       if (!table) {
         table = document.createElement('table');
@@ -482,7 +482,7 @@
     appendPerson(format, person, containerElement) {
       let cardElement, cardHTML = '', personTitleList = '', personDepartmentList = '';
       const
-        personLink = person.link,
+        personLink = this.getAttribute('site-base') + person.link,
         personName = PeopleListElement.escapeHTML(person.name),
         personPhoto = person.photoUrl ? '<img src="' + person.photoUrl + '" alt="' + PeopleListElement.escapeHTML(person.photoAlt) + '">' : '',
         personBody = PeopleListElement.escapeHTML(person.body),
@@ -523,7 +523,7 @@
                   ${personTitleList}
                 </span>
                 <span class="ucb-person-card-dept">
-                  ${personDepartmentList} 
+                  ${personDepartmentList}
                 </span>
                 <span class="ucb-person-card-body">
                   ${personBody}
@@ -619,7 +619,7 @@
                     <i class="fa-solid fa-envelope iconColor"></i>
                     <a href="mailto:${personEmail}">
                       <span aria-hidden="true" class="ucb-people-list-contact">Email</span>
-                      <span class="visually-hidden">Email ${personName} at ${personEmail}</span> 
+                      <span class="visually-hidden">Email ${personName} at ${personEmail}</span>
                     </a>
                   </span>`
                     : ""

--- a/js/ucb-tag-cloud.js
+++ b/js/ucb-tag-cloud.js
@@ -2,6 +2,7 @@ class TagCloudElement extends HTMLElement {
 	constructor() {
 		super();
     this._baseURI = this.getAttribute("base-uri");
+    console.log(this._baseURI)
         const handleError = response => {
             if (!response.ok) {
                throw new Error;
@@ -29,7 +30,7 @@ class TagCloudElement extends HTMLElement {
                 const tagURL = document.createElement('a')
                 tagURL.classList = 'ucb-tag-cloud-link'
                 tagURL.innerText = tagName
-                tagURL.href = `taxonomy/term/${tag.attributes.drupal_internal__tid}`
+                tagURL.href = this._baseURI +`/taxonomy/term/${tag.attributes.drupal_internal__tid}`;
                 tagCloudContainer.appendChild(tagURL)
             })
 


### PR DESCRIPTION
Previously, Pages and Blocks rendering content via JSON:API would use relative pathing, which resulted in content on multi-sites to 404.

This has been corrected on the following:
### Pages
- People List Page
- Article List page
- Issue Archive

### Blocks
- People List Block

- Current Issue Block
- Latest Issue Block

- Article List Block
- Article Feature
- Article Grid
- Article Slider

- Category Cloud
- Tag Cloud

- Collection Block

Resolves #1080 