### PR TITLE
Taxonomy clouds: adds missing body field to templates

### DIFF
--- a/templates/block/block--ucb-category-cloud.html.twig
+++ b/templates/block/block--ucb-category-cloud.html.twig
@@ -44,5 +44,6 @@
 			</div>
 	{% endif %}
 	{{ title_suffix }}
+  {{ content.body }}
 	<category-cloud-block base-uri="{{baseurlJSON}}"></category-cloud-block>
 </div>

--- a/templates/block/block--ucb-tag-cloud.html.twig
+++ b/templates/block/block--ucb-tag-cloud.html.twig
@@ -44,5 +44,6 @@
 			</div>
 	{% endif %}
 	{{ title_suffix }}
+  {{ content.body }}
 	<tag-cloud-block base-uri="{{baseurlJSON}}"></tag-cloud-block>
 </div>


### PR DESCRIPTION
Adds `body` fields to the "Category Cloud" and "Tag Cloud" blocks, previously this was missing from the templates resulting in no body showing up on render even if the user entered one.

Resolves #1090 