### PR TITLE
Block Title Fixes

### DIFF
--- a/css/block/block-styles.css
+++ b/css/block/block-styles.css
@@ -3,8 +3,12 @@
   display: flex;
 }
 
-.block-title {
-  font-size: 200%
+.block-title.hero, .block-title.supersize {
+  font-weight: normal;
+}
+
+.block-title.strong, .block-title.bold {
+  font-weight: bold;
 }
 
 .bs-title-scale-decrease .block-title .block-title-text {

--- a/templates/block/block--article-list-block.html.twig
+++ b/templates/block/block--article-list-block.html.twig
@@ -187,11 +187,11 @@
 		{{ title_prefix }}
 		{% if label %}
 			<div class="block-title-outer">
-				<{{ headingTag }}{{title_attributes}} class="block-title">
+				<{{ headingTag }}{{title_attributes}} class="block-title {{ headingStyle }}">
 					<span class='block-title-icon {{ iconColor }} {{ iconPosition }} {{ iconSize }}'>
 						{{ content.field_bs_icon }}
 					</span>
-					<span class="block-title-text {{ headingStyle }}">
+					<span class="block-title-text">
 						{{ label }}
 					</span>
 				</{{ headingTag }}>

--- a/templates/block/block--collection-grid.html.twig
+++ b/templates/block/block--collection-grid.html.twig
@@ -68,11 +68,11 @@
     {{ title_prefix }}
     {% if label %}
       <div class="block-title-outer">
-				<{{ headingTag }}{{title_attributes}} class="block-title">
+				<{{ headingTag }}{{title_attributes}} class="block-title {{ headingStyle }}">
 					<span class='block-title-icon {{ iconColor }} {{ iconPosition }} {{ iconSize }}'>
 						{{ content.field_bs_icon }}
 					</span>
-					<span class="block-title-text {{ headingStyle }}">
+					<span class="block-title-text">
 						{{ label }}
 					</span>
 				</{{ headingTag }}>

--- a/templates/block/block--content-grid.html.twig
+++ b/templates/block/block--content-grid.html.twig
@@ -57,11 +57,11 @@
     {{ title_prefix }}
     {% if label %}
       <div class="block-title-outer">
-				<{{ headingTag }}{{title_attributes}} class="block-title">
+				<{{ headingTag }}{{title_attributes}} class="block-title {{ headingStyle }}">
 					<span class='block-title-icon {{ iconColor }} {{ iconPosition }} {{ iconSize }}'>
 						{{ content.field_bs_icon }}
 					</span>
-					<span class="block-title-text {{ headingStyle }}">
+					<span class="block-title-text">
 						{{ label }}
 					</span>
 				</{{ headingTag }}>

--- a/templates/block/block--content-list.html.twig
+++ b/templates/block/block--content-list.html.twig
@@ -57,11 +57,11 @@
 		{{ title_prefix }}
 		{% if label %}
 			<div class="block-title-outer">
-				<{{ headingTag }}{{title_attributes}} class="block-title">
+				<{{ headingTag }}{{title_attributes}} class="block-title {{ headingStyle }}">
 					<span class='block-title-icon {{ iconColor }} {{ iconPosition }} {{ iconSize }}'>
 						{{ content.field_bs_icon }}
 					</span>
-					<span class="block-title-text {{ headingStyle }}">
+					<span class="block-title-text">
 						{{ label }}
 					</span>
 				</{{ headingTag }}>

--- a/templates/block/block--content-row.html.twig
+++ b/templates/block/block--content-row.html.twig
@@ -42,11 +42,11 @@
 		{{ title_prefix }}
 		{% if label %}
 			<div class="block-title-outer">
-				<{{ headingTag }}{{title_attributes}} class="block-title">
+				<{{ headingTag }}{{title_attributes}} class="block-title {{ headingStyle }}">
 					<span class='block-title-icon {{ iconColor }} {{ iconPosition }} {{ iconSize }}'>
 						{{ content.field_bs_icon }}
 					</span>
-					<span class="block-title-text {{ headingStyle }}">
+					<span class="block-title-text">
 						{{ label }}
 					</span>
 				</{{ headingTag }}>

--- a/templates/block/block--content-sequence.html.twig
+++ b/templates/block/block--content-sequence.html.twig
@@ -37,11 +37,11 @@
     {{ title_prefix }}
     {% if label %}
       <div class="block-title-outer">
-				<{{ headingTag }}{{title_attributes}} class="block-title">
+				<{{ headingTag }}{{title_attributes}} class="block-title {{ headingStyle }}">
 					<span class='block-title-icon {{ iconColor }} {{ iconPosition }} {{ iconSize }}'>
 						{{ content.field_bs_icon }}
 					</span>
-					<span class="block-title-text {{ headingStyle }}">
+					<span class="block-title-text">
 						{{ label }}
 					</span>
 				</{{ headingTag }}>

--- a/templates/block/block--events-calendar.html.twig
+++ b/templates/block/block--events-calendar.html.twig
@@ -40,11 +40,11 @@
 		{{ title_prefix }}
 		{% if label %}
 			<div class="block-title-outer">
-				<{{ headingTag }}{{title_attributes}} class="block-title">
+				<{{ headingTag }}{{title_attributes}} class="block-title {{ headingStyle }}">
 					<span class='block-title-icon {{ iconColor }} {{ iconPosition }} {{ iconSize }}'>
 						{{ content.field_bs_icon }}
 					</span>
-					<span class="block-title-text {{ headingStyle }}">
+					<span class="block-title-text">
 						{{ label }}
 					</span>
 				</{{ headingTag }}>

--- a/templates/block/block--expandable-content.html.twig
+++ b/templates/block/block--expandable-content.html.twig
@@ -62,11 +62,11 @@
     {{ title_prefix }}
     {% if label %}
       <div class="block-title-outer">
-        <{{headingTag}}{{title_attributes}} class="block-title">
+        <{{headingTag}}{{title_attributes}} class="block-title {{ headingStyle }}">
           <span class='block-title-icon {{ iconColor }} {{ iconPosition }} {{ iconSize }}'>
             {{ content.field_bs_icon }}
           </span>
-          <span class="block-title-text {{ headingStyle }}">
+          <span class="block-title-text">
             {{ label }}
           </span>
         </{{headingTag}}>

--- a/templates/block/block--hero-unit.html.twig
+++ b/templates/block/block--hero-unit.html.twig
@@ -81,11 +81,11 @@
 		{{ title_prefix }}
 		{% if label %}
 			<div class="block-title-outer">
-				<{{ headingTag }}{{title_attributes}} class="block-title">
+				<{{ headingTag }}{{title_attributes}} class="block-title {{ headingStyle }}">
 					<span class='block-title-icon {{ iconColor }} {{ iconPosition }} {{ iconSize }}'>
 						{{ content.field_bs_icon }}
 					</span>
-					<span class="block-title-text {{ headingStyle }}">
+					<span class="block-title-text">
 						{{ label }}
 					</span>
 				</{{ headingTag }}>

--- a/templates/block/block--slider.html.twig
+++ b/templates/block/block--slider.html.twig
@@ -58,11 +58,11 @@
 		{{ title_prefix }}
 		{% if label %}
 			<div class="block-title-outer">
-				<{{ headingTag }}{{title_attributes}} class="block-title">
+				<{{ headingTag }}{{title_attributes}} class="block-title {{ headingStyle }}">
 					<span class='block-title-icon {{ iconColor }} {{ iconPosition }} {{ iconSize }}'>
 						{{ content.field_bs_icon }}
 					</span>
-					<span class="block-title-text {{ headingStyle }}">
+					<span class="block-title-text">
 						{{ label }}
 					</span>
 				</{{ headingTag }}>

--- a/templates/block/block--social-media-icons.html.twig
+++ b/templates/block/block--social-media-icons.html.twig
@@ -61,11 +61,11 @@
     {{ title_prefix }}
     {% if label %}
       <div class="block-title-outer">
-				<{{ headingTag }}{{title_attributes}} class="block-title">
+				<{{ headingTag }}{{title_attributes}} class="block-title {{ headingStyle }}">
 					<span class='block-title-icon {{ iconColor }} {{ iconPosition }} {{ iconSize }}'>
 						{{ content.field_bs_icon }}
 					</span>
-					<span class="block-title-text {{ headingStyle }}">
+					<span class="block-title-text">
 						{{ label }}
 					</span>
 				</{{ headingTag }}>

--- a/templates/block/block--statuspage-block.html.twig
+++ b/templates/block/block--statuspage-block.html.twig
@@ -30,11 +30,11 @@
 		{{ title_prefix }}
 		{% if label %}
 			<div class="block-title-outer">
-				<{{ headingTag }}{{title_attributes}} class="block-title">
+				<{{ headingTag }}{{title_attributes}} class="block-title {{ headingStyle }}">
 					<span class='block-title-icon {{ iconColor }} {{ iconPosition }} {{ iconSize }}'>
 						{{ content.field_bs_icon }}
 					</span>
-					<span class="block-title-text {{ headingStyle }}">
+					<span class="block-title-text">
 						{{ label }}
 					</span>
 				</{{ headingTag }}>

--- a/templates/block/block--text-block.html.twig
+++ b/templates/block/block--text-block.html.twig
@@ -54,11 +54,11 @@
 		{{ title_prefix }}
 		{% if label %}
 			<div class="block-title-outer">
-				<{{ headingTag }}{{title_attributes}} class="block-title">
+				<{{ headingTag }}{{title_attributes}} class="block-title {{ headingStyle }}">
 					<span class='block-title-icon {{ iconColor }} {{ iconPosition }} {{ iconSize }}'>
 						{{ content.field_bs_icon }}
 					</span>
-					<span class="block-title-text {{ headingStyle }}">
+					<span class="block-title-text">
 						{{ label }}
 					</span>
 				</{{ headingTag }}>

--- a/templates/block/block--ucb-article-feature.html.twig
+++ b/templates/block/block--ucb-article-feature.html.twig
@@ -186,11 +186,11 @@
 		{{ title_prefix }}
 		{% if label %}
 			<div class="block-title-outer">
-				<{{ headingTag }}{{title_attributes}} class="block-title">
+				<{{ headingTag }}{{title_attributes}} class="block-title {{ headingStyle }}">
 					<span class='block-title-icon {{ iconColor }} {{ iconPosition }} {{ iconSize }}'>
 						{{ content.field_bs_icon }}
 					</span>
-					<span class="block-title-text {{ headingStyle }}">
+					<span class="block-title-text">
 						{{ label }}
 					</span>
 				</{{ headingTag }}>

--- a/templates/block/block--ucb-article-grid.html.twig
+++ b/templates/block/block--ucb-article-grid.html.twig
@@ -186,11 +186,11 @@
 		{{ title_prefix }}
 		{% if label %}
 			<div class="block-title-outer">
-				<{{ headingTag }}{{title_attributes}} class="block-title">
+				<{{ headingTag }}{{title_attributes}} class="block-title {{ headingStyle }}">
 					<span class='block-title-icon {{ iconColor }} {{ iconPosition }} {{ iconSize }}'>
 						{{ content.field_bs_icon }}
 					</span>
-					<span class="block-title-text {{ headingStyle }}">
+					<span class="block-title-text">
 						{{ label }}
 					</span>
 				</{{ headingTag }}>

--- a/templates/block/block--ucb-article-slider.html.twig
+++ b/templates/block/block--ucb-article-slider.html.twig
@@ -186,11 +186,11 @@
 	{{ title_prefix }}
 	{% if label %}
 		<div class="block-title-outer">
-				<{{ headingTag }}{{title_attributes}} class="block-title">
+				<{{ headingTag }}{{title_attributes}} class="block-title {{ headingStyle }}">
 					<span class='block-title-icon {{ iconColor }} {{ iconPosition }} {{ iconSize }}'>
 						{{ content.field_bs_icon }}
 					</span>
-					<span class="block-title-text {{ headingStyle }}">
+					<span class="block-title-text">
 						{{ label }}
 					</span>
 				</{{ headingTag }}>

--- a/templates/block/block--ucb-category-cloud.html.twig
+++ b/templates/block/block--ucb-category-cloud.html.twig
@@ -33,11 +33,11 @@
 	{{ title_prefix }}
 	{% if label %}
 		<div class="block-title-outer">
-				<{{ headingTag }}{{title_attributes}} class="block-title">
+				<{{ headingTag }}{{title_attributes}} class="block-title {{ headingStyle }}">
 					<span class='block-title-icon {{ iconColor }} {{ iconPosition }} {{ iconSize }}'>
 						{{ content.field_bs_icon }}
 					</span>
-					<span class="block-title-text {{ headingStyle }}">
+					<span class="block-title-text">
 						{{ label }}
 					</span>
 				</{{ headingTag }}>

--- a/templates/block/block--ucb-current-issue-block.html.twig
+++ b/templates/block/block--ucb-current-issue-block.html.twig
@@ -32,11 +32,11 @@
 	{{ title_prefix }}
 	{% if label %}
 		<div class="block-title-outer">
-				<{{ headingTag }}{{title_attributes}} class="block-title">
+				<{{ headingTag }}{{title_attributes}} class="block-title {{ headingStyle }}">
 					<span class='block-title-icon {{ iconColor }} {{ iconPosition }} {{ iconSize }}'>
 						{{ content.field_bs_icon }}
 					</span>
-					<span class="block-title-text {{ headingStyle }}">
+					<span class="block-title-text">
 						{{ label }}
 					</span>
 				</{{ headingTag }}>

--- a/templates/block/block--ucb-latest-issues-block.html.twig
+++ b/templates/block/block--ucb-latest-issues-block.html.twig
@@ -32,11 +32,11 @@
 	{{ title_prefix }}
 	{% if label %}
 		<div class="block-title-outer">
-				<{{ headingTag }}{{title_attributes}} class="block-title">
+				<{{ headingTag }}{{title_attributes}} class="block-title {{ headingStyle }}">
 					<span class='block-title-icon {{ iconColor }} {{ iconPosition }} {{ iconSize }}'>
 						{{ content.field_bs_icon }}
 					</span>
-					<span class="block-title-text {{ headingStyle }}">
+					<span class="block-title-text">
 						{{ label }}
 					</span>
 				</{{ headingTag }}>

--- a/templates/block/block--ucb-people-list-block.html.twig
+++ b/templates/block/block--ucb-people-list-block.html.twig
@@ -75,11 +75,11 @@
 		{{ title_prefix }}
 		{% if label %}
 			<div class="block-title-outer">
-				<{{ headingTag }}{{title_attributes}} class="block-title">
+				<{{ headingTag }}{{title_attributes}} class="block-title {{ headingStyle }}">
 					<span class='block-title-icon {{ iconColor }} {{ iconPosition }} {{ iconSize }}'>
 						{{ content.field_bs_icon }}
 					</span>
-					<span class="block-title-text {{ headingStyle }}">
+					<span class="block-title-text">
 						{{ label }}
 					</span>
 				</{{ headingTag }}>

--- a/templates/block/block--ucb-slate-form.html.twig
+++ b/templates/block/block--ucb-slate-form.html.twig
@@ -30,11 +30,11 @@
 	{{ title_prefix }}
 	{% if label %}
 		<div class="block-title-outer">
-				<{{ headingTag }}{{title_attributes}} class="block-title">
+				<{{ headingTag }}{{title_attributes}} class="block-title {{ headingStyle }}">
 					<span class='block-title-icon {{ iconColor }} {{ iconPosition }} {{ iconSize }}'>
 						{{ content.field_bs_icon }}
 					</span>
-					<span class="block-title-text {{ headingStyle }}">
+					<span class="block-title-text">
 						{{ label }}
 					</span>
 				</{{ headingTag }}>

--- a/templates/block/block--ucb-tag-cloud.html.twig
+++ b/templates/block/block--ucb-tag-cloud.html.twig
@@ -33,11 +33,11 @@
 	{{ title_prefix }}
 	{% if label %}
 		<div class="block-title-outer">
-				<{{ headingTag }}{{title_attributes}} class="block-title">
+				<{{ headingTag }}{{title_attributes}} class="block-title {{ headingStyle }}">
 					<span class='block-title-icon {{ iconColor }} {{ iconPosition }} {{ iconSize }}'>
 						{{ content.field_bs_icon }}
 					</span>
-					<span class="block-title-text {{ headingStyle }}">
+					<span class="block-title-text">
 						{{ label }}
 					</span>
 				</{{ headingTag }}>

--- a/templates/block/block--video-hero-unit.html.twig
+++ b/templates/block/block--video-hero-unit.html.twig
@@ -95,11 +95,11 @@
     {{ title_prefix }}
     {% if label %}
       <div class="block-title-outer">
-				<{{ headingTag }}{{title_attributes}} class="block-title">
+				<{{ headingTag }}{{title_attributes}} class="block-title {{ headingStyle }}">
 					<span class='block-title-icon {{ iconColor }} {{ iconPosition }} {{ iconSize }}'>
 						{{ content.field_bs_icon }}
 					</span>
-					<span class="block-title-text {{ headingStyle }}">
+					<span class="block-title-text">
 						{{ label }}
 					</span>
 				</{{ headingTag }}>

--- a/templates/block/block--video-reveal.html.twig
+++ b/templates/block/block--video-reveal.html.twig
@@ -40,11 +40,11 @@
     {{ title_prefix }}
     {% if label %}
       <div class="block-title-outer">
-				<{{ headingTag }}{{title_attributes}} class="block-title">
+				<{{ headingTag }}{{title_attributes}} class="block-title {{ headingStyle }}">
 					<span class='block-title-icon {{ iconColor }} {{ iconPosition }} {{ iconSize }}'>
 						{{ content.field_bs_icon }}
 					</span>
-					<span class="block-title-text {{ headingStyle }}">
+					<span class="block-title-text">
 						{{ label }}
 					</span>
 				</{{ headingTag }}>


### PR DESCRIPTION
Moving of the block heading style class to the proper places allows the increase based on options picked (hero/supersize) to work correctly and not become gigantic.

Added in the correct normal/bold options if hero strong or supersize bold is chosen.

By default the hero and supersize should not be bolded.

Resolves #1111