### PR TITLE
Intro Wide region implementation

### DIFF
--- a/boulder_base.info.yml
+++ b/boulder_base.info.yml
@@ -15,6 +15,7 @@ regions:
   secondary_menu: "Secondary Menu"
   alerts: "Alerts"
   breadcrumb: "Breadcrumb Navigation"
+  intro_wide: "Intro Wide"
   post_wide_title: "Post Wide Title"
   above_content: "Above Content"
   content: "Content"

--- a/css/block/hero-unit.css
+++ b/css/block/hero-unit.css
@@ -26,7 +26,9 @@
   font-size: 120%;
 }
 
-.ucb-post-wide-title-region .block:first-child.block-hero-unit, .ucb-below-post-wide-region .block:first-child.block-hero-unit {
+.ucb-post-wide-title-region .block:first-child.block-hero-unit,
+.ucb-intro-wide-region .block:first-child.block-hero-unit,
+.ucb-below-post-wide-region .block:first-child.block-hero-unit {
   padding-top: 0;
   padding-bottom: 0;
   width: 100%;
@@ -50,12 +52,16 @@
   padding-bottom: 20px;
 }
 
-.ucb-post-wide-title-region .block.ucb-overlay-dark, .ucb-below-post-wide-region .block.ucb-overlay-dark {
+.ucb-post-wide-title-region .block.ucb-overlay-dark,
+.ucb-intro-wide-region .block.ucb-overlay-dark,
+.ucb-below-post-wide-region .block.ucb-overlay-dark {
   background-color: rgba(20, 20, 20, 0.5);
   background-blend-mode: overlay;
 }
 
-.ucb-post-wide-title-region .block.ucb-overlay-light, .ucb-below-post-wide-region .block.ucb-overlay-light {
+.ucb-post-wide-title-region .block.ucb-overlay-light,
+.ucb-intro-wide-region .block.ucb-overlay-light,
+.ucb-below-post-wide-region .block.ucb-overlay-light {
   background-color: rgba(200, 200, 200, 0.7);
   background-blend-mode: overlay;
 }
@@ -157,7 +163,9 @@
 }
 
 
-.ucb-post-wide-title-region .block-hero-unit .block:first-child, .ucb-below-post-wide-region .block-hero-unit .block:first-child {
+.ucb-post-wide-title-region .block-hero-unit .block:first-child,
+.ucb-intro-wide-region .block-hero-unit .block:first-child,
+.ucb-below-post-wide-region .block-hero-unit .block:first-child {
   padding-top: 0;
   padding-bottom: 0;
 }

--- a/css/style.css
+++ b/css/style.css
@@ -302,6 +302,9 @@ section.ucb-main-nav-section {
   background-color: #000;
   color: #fff;
 }
+.ucb-intro-wide-region .block-hero-unit.bs-background-none .block-title-text {
+  color: #fff;
+}
 /*********** Main Menu **************/
 ul.ucb-main-menu.nav {
   flex-grow: 1;

--- a/css/style.css
+++ b/css/style.css
@@ -298,6 +298,9 @@ section.ucb-main-nav-section {
 .ucb-intro-wide-region .block {
   margin-bottom: 0;
 }
+.ucb-intro-wide-region {
+  background-color: #000;
+}
 /*********** Main Menu **************/
 ul.ucb-main-menu.nav {
   flex-grow: 1;

--- a/css/style.css
+++ b/css/style.css
@@ -294,6 +294,10 @@ section.ucb-main-nav-section {
   }
 }
 
+/*********** Intro Wide **************/
+.ucb-intro-wide-region .block {
+  margin-bottom: 0;
+}
 /*********** Main Menu **************/
 ul.ucb-main-menu.nav {
   flex-grow: 1;

--- a/css/style.css
+++ b/css/style.css
@@ -300,6 +300,7 @@ section.ucb-main-nav-section {
 }
 .ucb-intro-wide-region {
   background-color: #000;
+  color: #fff;
 }
 /*********** Main Menu **************/
 ul.ucb-main-menu.nav {

--- a/templates/layout/page.html.twig
+++ b/templates/layout/page.html.twig
@@ -206,6 +206,11 @@
       <a id="main-content" tabindex="-1"></a>
       {# link is in html.html.twig #}
       <div class="layout-content">
+        {% if page.intro_wide|render %}
+          <div class="ucb-intro-wide-region edge-to-edge row g-0">
+            {{ page.intro_wide }}
+          </div>
+        {% endif %}
         {% if page.post_wide_title|render %}
           <div class="ucb-post-wide-title-region edge-to-edge row g-0">
             {{ page.post_wide_title }}

--- a/templates/layout/page.html.twig
+++ b/templates/layout/page.html.twig
@@ -207,8 +207,10 @@
       {# link is in html.html.twig #}
       <div class="layout-content">
         {% if page.intro_wide|render %}
-          <div class="ucb-intro-wide-region edge-to-edge row g-0">
+          <div class="ucb-intro-wide-region edge-to-edge g-0">
+           <div class = "ucb-layout-container container">
             {{ page.intro_wide }}
+            </div>
           </div>
         {% endif %}
         {% if page.post_wide_title|render %}


### PR DESCRIPTION
Closes #1126.
This adds the intro wide region to the block layout. This will primarily be used by images and hero units for a top banner.