### PR TITLE
Add overflow-wrap to email and links

### DIFF
--- a/css/ucb-person.css
+++ b/css/ucb-person.css
@@ -26,6 +26,7 @@
 ul.ucb-person-email-address,
 ul.ucb-person-links,
 ul.ucb-person-phone-numbers {
+  overflow-wrap: break-word;
   list-style: none;
   padding: 0;
   color: #111;

--- a/css/ucb-person.css
+++ b/css/ucb-person.css
@@ -33,7 +33,7 @@ ul.ucb-person-phone-numbers {
   margin: 0;
 }
 .ucb-person-email-icon {
-  padding-right: 5px;
+  display: inline-block;
 }
 a.ucb-person-social-link i.fa-solid,
 a.ucb-person-social-link i.fa-brands {

--- a/css/ucb-person.css
+++ b/css/ucb-person.css
@@ -32,7 +32,9 @@ ul.ucb-person-phone-numbers {
   color: #111;
   margin: 0;
 }
-
+.ucb-person-email-icon {
+  padding-right: 5px;
+}
 a.ucb-person-social-link i.fa-solid,
 a.ucb-person-social-link i.fa-brands {
   color: #111;

--- a/templates/field/field--field-ucb-person-email.html.twig
+++ b/templates/field/field--field-ucb-person-email.html.twig
@@ -8,7 +8,7 @@
     <ul class="ucb-person-email-address">
         {% for item in items %}{% set value = item.content['#context'].value|trim %}
         <li>
-            <i class="fa-solid fa-envelope ucb-person-email-icon"></i><a itemprop="email" href="mailto:{{ value|url_encode }}">{{ value }}</a>
+            <span class = "ucb-person-email-icon"><i class="fa-solid fa-envelope"></i>&nbsp;</span><a itemprop="email" href="mailto:{{ value|url_encode }}">{{ value }}</a>
         </li>
         {% endfor %}
     </ul>

--- a/templates/field/field--field-ucb-person-email.html.twig
+++ b/templates/field/field--field-ucb-person-email.html.twig
@@ -5,12 +5,12 @@
 #}
 {% if items %}
 <div>
-	<ul class="ucb-person-email-address">
-		{% for item in items %}{% set value = item.content['#context'].value|trim %}
-		<li>
-			<i class="fa-solid fa-envelope"></i>&nbsp;<a itemprop="email" href="mailto:{{ value|url_encode }}">{{ value }}</a>
-		</li>
-		{% endfor %}
-	</ul>
+    <ul class="ucb-person-email-address">
+        {% for item in items %}{% set value = item.content['#context'].value|trim %}
+        <li>
+            <i class="fa-solid fa-envelope ucb-person-email-icon"></i><a itemprop="email" href="mailto:{{ value|url_encode }}">{{ value }}</a>
+        </li>
+        {% endfor %}
+    </ul>
 </div>
 {% endif %}


### PR DESCRIPTION
Closes #1130. 
Adds an overflow-wrap to the email address in the person page in order to stop the email from overflowing into the content.