### PR TITLE
Updates site footer links

### DIFF
--- a/templates/block/block--site-info.html.twig
+++ b/templates/block/block--site-info.html.twig
@@ -28,11 +28,11 @@
 {{ attach_library('boulder_base/ucb-site-contact-info-footer') }}
 {% set data = content['#data'] %}
 {% set icons_visible = data.icons_visible %}
-{%
-  set classes = []
-%}
-<div{{ attributes.addClass(classes) }}>
-  <h2 class="h5"><a href="/">{{ site_name }}</a></h2>
+
+<div{{ attributes }}>
+  <h2 class="h5">
+    <a href="{{ url('<front>') }}">{{ site_name }}</a>
+  </h2>
   {% block content %}
     <div class="ucb-site-contact-info-footer">
       {% if data.general_visible == '1' %}

--- a/templates/regions/region--site-information.html.twig
+++ b/templates/regions/region--site-information.html.twig
@@ -24,7 +24,7 @@
           <p><a href="https://www.colorado.edu"><img alt="Be Boulder." class="ucb-footer-be-boulder" src="https://cdn.colorado.edu/static/brand-assets/live/images/be-boulder-white.svg" style="max-width:240px; height:auto;"></a></p>
           <p><a class="ucb-home-link" href="https://www.colorado.edu">University of Colorado Boulder</a></p>
           <p>&copy; Regents of the University of Colorado</p>
-          <p class="ucb-info-footer-links"><a href="https://www.colorado.edu/compliance">Privacy</a> &bull; <a href="https://www.colorado.edu/about/legal-trademarks">Legal &amp; Trademarks</a> &bull; <a href="https://www.colorado.edu/map">Campus Map</a></p>
+          <p class="ucb-info-footer-links"><a href="https://www.colorado.edu/compliance/policies/privacy-statement">Privacy</a> &bull; <a href="https://www.colorado.edu/about/legal-trademarks">Legal &amp; Trademarks</a> &bull; <a href="https://www.colorado.edu/map">Campus Map</a></p>
         </div>
       </div>
     </div>


### PR DESCRIPTION
This update:
- [Bug] Corrects the site link in the site contact info footer block to correctly point to the active site's home page. Resolves CuBoulder/tiamat-theme#1127
- [Change] Changes the privacy policy link to link directly to the privacy policy. Resolves CuBoulder/tiamat-theme#1093