### PR TITLE
Article Feature: fixes 'Read More' link

### DIFF
--- a/templates/block/block--ucb-article-feature.html.twig
+++ b/templates/block/block--ucb-article-feature.html.twig
@@ -219,7 +219,7 @@
 {# More Link #}
   {% if content.field_article_feature_more_link|render %}
   <div class="ucb-article-feature-block-button-container">
-    <a class="ucb-article-feature-block-button"href="{{content.ffield_article_feature_more_link.0['#url']}}">
+    <a class="ucb-article-feature-block-button"href="{{content.field_article_feature_more_link.0['#url']}}">
       {{content.field_article_feature_more_link.0['#title']}}
     </a>
   </div>


### PR DESCRIPTION
### Article Feature Block

Fixes a template issue preventing the 'Read More' link from linking to the chosen url correctly. 

Resolves #1163 