### PR TITLE
People Lists: Removing an Image breaks Lists

### DIFF
--- a/js/ucb-people-list-block.js
+++ b/js/ucb-people-list-block.js
@@ -399,25 +399,33 @@ class PeopleListBlockElement extends HTMLElement {
 		const defaultThumbnail = format == 'grid' ? defaultAvatarURL : '';
 
 		people.forEach((person) => {
-			const personRelationshipData = person['relationships'],
-				departmentsData = personRelationshipData['field_ucb_person_department']['data'],
-				jobTypesData = personRelationshipData['field_ucb_person_department']['data'],
-				personAttributeData = person['attributes'],
-				departments = [], jobTypes = [], photoId = (personRelationshipData['field_ucb_person_photo']['data'] || {})['id'] || '',
-				thisPerson = {
-					link: (personAttributeData['path'] || {})['alias'] || `/node/${personAttributeData['drupal_internal__nid']}`,
-					name: personAttributeData['title'],
-					titles: personAttributeData['field_ucb_person_title'],
-					departments: departments,
-					jobTypes: jobTypes,
-					photoId: photoId,
-					photoURI: photoId ? urlObj[idObj[photoId]] : defaultThumbnail,
-					body: '',
-					email: personAttributeData['field_ucb_person_email'],
-					phone: personAttributeData['field_ucb_person_phone'],
-					primaryLinkURI: '',
-					primaryLinkTitle: ''
-				};
+      const personRelationshipData = person['relationships'],
+        departmentsData = personRelationshipData['field_ucb_person_department']['data'],
+        jobTypesData = personRelationshipData['field_ucb_person_department']['data'],
+        personAttributeData = person['attributes'],
+        departments = [],
+        jobTypes = [],
+        photoId = (personRelationshipData['field_ucb_person_photo']['data'] || {})['id'] || '';
+
+        // Special case for if media image was removed
+      const isPhotoMissing = photoId === 'missing';
+      const photoExists = photoId && !isPhotoMissing;
+
+      const thisPerson = {
+        link: (personAttributeData['path'] || {})['alias'] || `/node/${personAttributeData['drupal_internal__nid']}`,
+        name: personAttributeData['title'],
+        titles: personAttributeData['field_ucb_person_title'],
+        departments: departments,
+        jobTypes: jobTypes,
+        photoId: photoId,
+        photoURI: photoExists ? urlObj[idObj[photoId]] : defaultThumbnail,
+        body: '',
+        email: personAttributeData['field_ucb_person_email'],
+        phone: personAttributeData['field_ucb_person_phone'],
+        primaryLinkURI: '',
+        primaryLinkTitle: ''
+      };
+
 
 			// Builds arrays of department and job type ids
 			departmentsData.forEach(departmentData => departments.push(departmentData['meta']['drupal_internal__target_id']));

--- a/js/ucb-people-list.js
+++ b/js/ucb-people-list.js
@@ -446,26 +446,35 @@
       const defaultThumbnail = format == 'grid' ? defaultAvatarURL : '';
 
       people.forEach((person) => {
+
         const personRelationshipData = person['relationships'],
-          departmentsData = personRelationshipData['field_ucb_person_department']['data'],
-          jobTypesData = personRelationshipData['field_ucb_person_department']['data'],
-          personAttributeData = person['attributes'],
-          departments = [], jobTypes = [], photoId = (personRelationshipData['field_ucb_person_photo']['data'] || {})['id'] || '',
-          thisPerson = {
-            link: (personAttributeData['path'] || {})['alias'] || `/node/${personAttributeData['drupal_internal__nid']}`,
-            name: personAttributeData['title'],
-            titles: personAttributeData['field_ucb_person_title'],
-            departments: departments,
-            jobTypes: jobTypes,
-            photoId: photoId,
-            photoUrl: photoId ? photoUrls[photoData[photoId]['id']] : defaultThumbnail,
-            photoAlt: photoId ? photoData[photoId]['meta']['alt'] : 'This person has no photo',
-            body: '',
-            email: personAttributeData['field_ucb_person_email'],
-            phone: personAttributeData['field_ucb_person_phone'],
-            primaryLinkURI: '',
-            primaryLinkTitle: ''
-          };
+        departmentsData = personRelationshipData['field_ucb_person_department']['data'],
+        jobTypesData = personRelationshipData['field_ucb_person_department']['data'],
+        personAttributeData = person['attributes'],
+        departments = [],
+        jobTypes = [],
+        photoId = (personRelationshipData['field_ucb_person_photo']['data'] || {})['id'] || '';
+
+        // Special case for if media image was removed
+        const isPhotoMissing = photoId === 'missing';
+        const photoExists = photoId && !isPhotoMissing;
+
+        const thisPerson = {
+          link: (personAttributeData['path'] || {})['alias'] || `/node/${personAttributeData['drupal_internal__nid']}`,
+          name: personAttributeData['title'],
+          titles: personAttributeData['field_ucb_person_title'],
+          departments: departments,
+          jobTypes: jobTypes,
+          photoId: photoId,
+          photoUrl: photoExists ? photoUrls[photoData[photoId]['id']] : defaultThumbnail,
+          photoAlt: photoExists ? photoData[photoId]['meta']['alt'] : 'This person has no photo',
+          body: '',
+          email: personAttributeData['field_ucb_person_email'],
+          phone: personAttributeData['field_ucb_person_phone'],
+          primaryLinkURI: '',
+          primaryLinkTitle: ''
+      };
+
 
         // Builds arrays of department and job type ids
         departmentsData.forEach(departmentData => departments.push(departmentData['meta']['drupal_internal__target_id']));


### PR DESCRIPTION
### People List Page & People List Block

Previously in the case where you had a `People List Page` or `People List Block` and then removed an Image from the Media Library that was used as a thumbnail for a `Person` page, this would make that respective Person Page's thumbnail ID to become `'missing'` rather than a `null` value, which would cause the Person List Page to completely break unless that Person's thumbnail image is fixed.

This has been corrected with additional checks in these rare cases. It will also use the Default Avatar in specific displays such as the Grid. 

Resolves #1175 