### PR TITLE
Content List Block: Updates to 'Sidebar' Style

### DIFF
--- a/css/block/content-list.css
+++ b/css/block/content-list.css
@@ -132,11 +132,15 @@
   height: auto;
 }
 
-.ucb-content-list-sidebar .row.ucb-content-list-row > *{
-    padding-right: calc(var(--bs-gutter-x) * .5);
-    padding-left: calc(var(--bs-gutter-x) * .5);
+.ucb-content-list-sidebar .row.ucb-content-list-row > * {
+  padding-right: 0;
+  padding-left: 0;
 }
 
+.ucb-content-list-sidebar .row.ucb-content-list-row > .ucb-content-list-image-container + .ucb-content-list-text-container {
+  padding-right: calc(var(--bs-gutter-x) * .5);
+  padding-left: calc(var(--bs-gutter-x) * .5);
+}
 
 @media only screen and (max-width: 575px) {
   .ucb-content-list-sidebar .row.ucb-content-list-row .ucb-content-list-image-container,

--- a/css/block/content-list.css
+++ b/css/block/content-list.css
@@ -108,7 +108,7 @@
 
 .ucb-content-list-sidebar .ucb-content-list-row,
 .ucb-content-list-teaser .ucb-content-list-row,
-.ucb-content-list-condensed .ucb-content-list-row, 
+.ucb-content-list-condensed .ucb-content-list-row,
 .ucb-content-list-full .ucb-content-list-row {
 	display: flex;
 	flex-direction: row;
@@ -125,8 +125,26 @@
 	flex: 1;
 }
 
+.ucb-content-list-sidebar .row.ucb-content-list-row .ucb-content-list-image-container,
+.ucb-content-list-sidebar .row.ucb-content-list-row .ucb-content-list-image{
+  padding-left: 0px;
+  width: calc(75px + var(--bs-gutter-x));
+  height: auto;
+}
+
+.ucb-content-list-sidebar .row.ucb-content-list-row > *{
+    padding-right: calc(var(--bs-gutter-x) * .5);
+    padding-left: calc(var(--bs-gutter-x) * .5);
+}
+
 
 @media only screen and (max-width: 575px) {
+  .ucb-content-list-sidebar .row.ucb-content-list-row .ucb-content-list-image-container,
+  .ucb-content-list-sidebar .row.ucb-content-list-row .ucb-content-list-image{
+    padding-left: 0px;
+    width: calc(50px + var(--bs-gutter-x));
+    height: auto;
+  }
 	.ucb-content-list-full .ucb-content-list-row {
 		flex-direction: column-reverse;
 	}
@@ -135,4 +153,4 @@
 	.ucb-content-list-teaser .ucb-content-list-row {
 		flex-direction: column;
 	}
-  }
+}

--- a/templates/block/block--content-list.html.twig
+++ b/templates/block/block--content-list.html.twig
@@ -164,14 +164,14 @@
         </ul>
         {% elseif display == 'sidebar' %}
           <div class="row ucb-content-list-row">
-            <div class="ucb-content-list-text-container ">
-              <span class="ucb-content-list-title"><a href="{{ baseURL ~ item.entity.path.alias }}">{{ item.entity.title.0.value }}</a></span>
-            </div>
             {% if image %}
-              <div class="ucb-content-list-image-container">
+              <div class="ucb-content-list-image-container col-2">
                   <a role="presentation" aria-hidden="true" href="{{ baseURL ~ item.entity.path.alias }}"><img class="ucb-content-list-image" src="{{ imageURI }}" alt="{{ imageAlt }}"></a>
               </div>
             {% endif %}
+            <div class="ucb-content-list-text-container col-10 ">
+              <span class="ucb-content-list-title"><a href="{{ baseURL ~ item.entity.path.alias }}">{{ item.entity.title.0.value }}</a></span>
+            </div>
           </div>
         {% endif %}
       {% endif %}


### PR DESCRIPTION
Updates the look of the 'Sidebar' style of `Content List` Blocks to better match D7, as specified by Kevin in the ticket. Will swap the image to the left and make smaller on both desktop and mobile sizing.

Resolves #1169 