### PR TITLE
Block styles: Heading Style 'Hero' Font Family Changes

### DIFF
--- a/boulder_base.libraries.yml
+++ b/boulder_base.libraries.yml
@@ -5,7 +5,7 @@ ucb-global:
       css/bootstrap/bootstrap.min.css: {}
       css/layout.css: {}
     theme:
-      https://fonts.googleapis.com/css2?family=Roboto+Condensed:wght@700&family=Roboto:wght@400;500;700&display=swap: { type: external }
+      https://fonts.googleapis.com/css2?family=Roboto+Condensed:wght@400;700&family=Roboto:wght@400;500;700&display=swap: { type: external }
       css/style-responsive.css: {}
       css/styleguide/global.css: {}
       css/styleguide/branding.css: {}

--- a/css/block/block-styles.css
+++ b/css/block/block-styles.css
@@ -5,6 +5,7 @@
 
 .block-title.hero, .block-title.supersize {
   font-weight: normal;
+  font-family: "Roboto Condensed", "Helvetica Neue", Helvetica, Arial, sans-serif; ;
 }
 
 .block-title.strong, .block-title.bold {

--- a/css/block/block-styles.css
+++ b/css/block/block-styles.css
@@ -3,9 +3,13 @@
   display: flex;
 }
 
-.block-title.hero, .block-title.supersize {
+.block-title.hero {
   font-weight: normal;
   font-family: "Roboto Condensed", "Helvetica Neue", Helvetica, Arial, sans-serif; ;
+}
+
+.block-title.supersize{
+  font-weight: normal;
 }
 
 .block-title.strong, .block-title.bold {


### PR DESCRIPTION
### Block Styles
The heading styles `Hero` and `Hero Bold` have been adjusted to both use 'Roboto Condensed', mirroring the D7 block style versions

Resolves #1164 