### PR TITLE
Article: Article Title Background Style Adjustments

### DIFF
--- a/css/ucb-article-dark.css
+++ b/css/ucb-article-dark.css
@@ -34,6 +34,11 @@ article.ucb-page-style-dark {
 	padding-bottom: 1.75em;
 }
 
+/* Override for Dark-style Articles with a Title Image */
+article.ucb-page-style-dark:has(.backgroundTitleDiv){
+  padding-top: 0;
+}
+
 /* Override for the content wrapper on Dark Mode Articles to maintain background color */
 article.ucb-page-style-dark.ucb-content-wrapper{
   margin-top: 0px;

--- a/css/ucb-article.css
+++ b/css/ucb-article.css
@@ -205,3 +205,10 @@ i.fa-regular.fa-calendar {
 .backgroundTitleDiv .imageMediaStyle img {
   padding-bottom: 0px;
 }
+
+/* Fixes the overlay covering the mobile hamburger menu */
+@media only screen and (max-width: 575px) {
+  .backgroundTitleDiv .ucb-article-heading {
+    padding: 150px 20px 30px;
+  }
+}


### PR DESCRIPTION
### Articles
Corrects the following on Articles with an `Article Title Background` set

- On mobile sizes, the navbar hamburger menu could become unclickable due to an Articles Title Background overlay extending too far.
- Removes extra padding on "Dark mode" Articles with an Article Title Background image set that created an extra gap between the navbar and the image

Resolves #1187 
Resolves #1195 