### PR TITLE
CK5: Margin Clear styles

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1128,6 +1128,10 @@ a.tabledrag-handle .handle {
   margin: -0.25em 0.5em;
 }
 
+h1.clear-margin,h2.clear-margin,h3.clear-margin,h4.clear-margin,h5.clear-margin,h6.clear-margin,p.clear-margin{
+  margin-bottom: 0 !important;
+}
+
 /* Column List CSS */
 @media only screen and (min-width: 576px) {
   .column-list.column-list-2 {

--- a/css/style.css
+++ b/css/style.css
@@ -1128,7 +1128,7 @@ a.tabledrag-handle .handle {
   margin: -0.25em 0.5em;
 }
 
-h1.clear-margin,h2.clear-margin,h3.clear-margin,h4.clear-margin,h5.clear-margin,h6.clear-margin,p.clear-margin{
+h2.clear-margin,h3.clear-margin,h4.clear-margin,h5.clear-margin,h6.clear-margin,p.clear-margin{
   margin-bottom: 0 !important;
 }
 


### PR DESCRIPTION
Adds a 'Margin Clear' style for headers and paragraphs

Includes:
-`tiamat-profile` => https://github.com/CuBoulder/tiamat10-profile/pull/182
-`tiamat-theme` => https://github.com/CuBoulder/tiamat-theme/pull/1201

Resolves https://github.com/CuBoulder/tiamat10-profile/issues/152