### PR TITLE
Sidebar spacing fixes

### DIFF
--- a/css/layout-builder-styles.css
+++ b/css/layout-builder-styles.css
@@ -337,6 +337,10 @@
   --bs-gutter-x: 0;
 }
 
+.ucb-sidebar-container .ucb-contained-row {
+  --bs-gutter-x: 0;
+}
+
 /*** !important needed to override inline background image styles ***/
 
 .scrolling-background {

--- a/templates/layout/page.html.twig
+++ b/templates/layout/page.html.twig
@@ -228,23 +228,23 @@
         {# We are checking for length below to make sure that the sidebars have any content. This is so that sidebar menus don't render the sidebars if the menu is empty #}
         {% if page.sidebar|render|striptags|trim|length > 0 %}
           {% if ucb_sidebar_position == 'left' %}
-            <div class="ucb-layout-container container g-0">
+            <div class="ucb-layout-container ucb-sidebar-container container">
               <div class="layout-row row">
-                <div class="ucb-left-sidebar ucb-sidebar col-sm-12 col-md-4 col-lg-3">
+                <div class="ucb-left-sidebar ucb-sidebar col-12 col-lg-4">
                   {{ page.sidebar }}
                 </div>
-                <div class="ucb-layout-main col-sm-12 col-md-8 col-lg-9 ucb-has-sidebar">
+                <div class="ucb-layout-main col-12 col-lg-8 ucb-has-sidebar">
                   {{ page.content }}
                 </div>
               </div>
             </div>
           {% else %}
-            <div class="ucb-layout-container container g-0">
+            <div class="ucb-layout-container ucb-sidebar-container container">
               <div class="layout-row row">
-                <div class="ucb-layout-main col-sm-12 col-md-8 col-lg-9 ucb-has-sidebar">
+                <div class="ucb-layout-main col-12 col-lg-8 ucb-has-sidebar">
                   {{ page.content }}
                 </div>
-                <div class="ucb-left-right ucb-sidebar col-sm-12 col-md-4 col-lg-3">
+                <div class="ucb-left-right ucb-sidebar col-12 col-lg-4">
                   {{ page.sidebar }}
                 </div>
               </div>


### PR DESCRIPTION
Fixed sidebar spacing so that things vertically aligned. 

Also solves the problem of a mobile horizontal scroll bar appearing because of the `g-0` class. 

Changed the column sizes to match the same sizes as layout builder sidebars. 

Finally fixed alignment of multi-column layoutbuilders + a sidebar. Though this should be a rare case, the new changes make it so all the content aligns as expected.

To test the horizontal mobile scroll bar fix you'll need to have a block or menu in the block layout sidebar.

Resolves #1198 