### PR TITLE
Article List: Fixes Exclusion Filters

### DIFF
--- a/js/ucb-article-list.js
+++ b/js/ucb-article-list.js
@@ -212,13 +212,16 @@
 
             let results = await Promise.all(promises);
 
-            results.forEach(result => {
+            results
+            .filter(result => result !== undefined)
+            .forEach(result => {
               let dataOutput = document.getElementById("ucb-al-data");
               let thisArticle = document.createElement("article");
               thisArticle.className = 'ucb-article-card-container';
               thisArticle.appendChild(result.articleRow);
               dataOutput.append(thisArticle);
             });
+
 
             if (NEXTJSONURL) {
               toggleMessage('ucb-el-load-more', 'inline-block');


### PR DESCRIPTION
### Article List
Fixes a bug with the `Article List` introduced when we refactored Article Lists to strictly enforce chronological order despite API timings. The bug would cause exclusions to throw an API Error instead of skipping processing entirely, which they had done when chronological order was not strictly enforced. 

This has been corrected and Articles flagged with Excluded Categories / Excluded Tags are properly removed with an additional check.

Resolves #1207 