### PR TITLE
Person page: fix mobile columns

### DIFF
--- a/templates/content/node--ucb-person.html.twig
+++ b/templates/content/node--ucb-person.html.twig
@@ -34,7 +34,7 @@
     </div>
     <div class="container ucb-person">
         <div class="row ucb-person-personal">
-            <div class="col col-sm-12 col-md-6 col-lg-4 ucb-person-main">
+            <div class="col-sm-12 col-md-6 col-lg-4 ucb-person-main">
                 <div class="col col-sm-6 col-md-12">
                     {{ content.field_ucb_person_photo }}
                 </div>
@@ -65,7 +65,7 @@
                     {% endif %}
                 </div>
             </div>
-            <div class="col col-sm-12 col-md-6 col-lg-8">
+            <div class="col-sm-12 col-md-6 col-lg-8">
                 {% if content.body.0 %}
                     <div class="ucb-person-section ucb-person-body">
                         {{ content.body }}


### PR DESCRIPTION
### Person Page
Fixes a display issue where a Person Page would arrange back to 2 columns on a mobile display instead of 1.

Resolves #1215 