### PR TITLE
Content List: Image size adjustment

### DIFF
--- a/css/block/content-list.css
+++ b/css/block/content-list.css
@@ -128,7 +128,7 @@
 .ucb-content-list-sidebar .row.ucb-content-list-row .ucb-content-list-image-container,
 .ucb-content-list-sidebar .row.ucb-content-list-row .ucb-content-list-image{
   padding-left: 0px;
-  width: calc(75px + var(--bs-gutter-x));
+  width: 75px;
   height: auto;
 }
 
@@ -146,7 +146,7 @@
   .ucb-content-list-sidebar .row.ucb-content-list-row .ucb-content-list-image-container,
   .ucb-content-list-sidebar .row.ucb-content-list-row .ucb-content-list-image{
     padding-left: 0px;
-    width: calc(50px + var(--bs-gutter-x));
+    width: 50px;
     height: auto;
   }
 	.ucb-content-list-full .ucb-content-list-row {


### PR DESCRIPTION
### Content List Block
Adjusts size of "Sidebar" - styled Content List Block images to be exactly 75px on desktop and 50px on mobile screen sizes. Previously there was additional width added.

Resolves #1217 