### PR TITLE
Article List Block: remove image requirement for all displays

### DIFF
--- a/js/ucb-article-list-block.js
+++ b/js/ucb-article-list-block.js
@@ -75,7 +75,6 @@ class ArticleListBlockElement extends HTMLElement {
 
     // Process each article
     const promises = data.data.map(async (item) => {
-      if (item.relationships.field_ucb_article_thumbnail.data) {
         const thisArticleCats =
           item.relationships.field_ucb_article_categories?.data.map(
             (cat) => cat.meta.drupal_internal__target_id
@@ -124,7 +123,6 @@ class ArticleListBlockElement extends HTMLElement {
             body: body.trim(),
           };
         }
-      }
       return null;
     });
 


### PR DESCRIPTION
### Article List Block
Removes the Thumbnail requirement for `Article List Blocks`, which would previously filter out any Articles that do not have a thumbnail field from showing up across all displays. This change will make the block perform more like the `Article List Page` and not omit Articles missing those fields from being displayed on the final output.

Resolves #1224 