### PR TITLE
Secondary and Mobile Menu fixes

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -295,6 +295,7 @@ section.ucb-main-nav-section {
   .page-header {
     box-shadow: 0 2px 5px rgba(0 0 0 / 10%);
   }
+
   .ucb-main-nav-container {
     flex-direction: column;
   }

--- a/css/style.css
+++ b/css/style.css
@@ -295,6 +295,9 @@ section.ucb-main-nav-section {
   .page-header {
     box-shadow: 0 2px 5px rgba(0 0 0 / 10%);
   }
+  .ucb-main-nav-container {
+    flex-direction: column;
+  }
 }
 
 /*********** Intro Wide **************/

--- a/css/ucb-menu.css
+++ b/css/ucb-menu.css
@@ -183,10 +183,12 @@
   .ucb-main-nav-container .ucb-menu .ucb-menu .ucb-menu .ucb-menu .ucb-menu li.menu-item a.nav-link {
     padding-left: calc(var(--ucb-menu-indent-start) + var(--ucb-menu-indent-inc) * 4);
   }
+
   .ucb-main-nav-container .ucb-menu .expanded.active > a.nav-link,
   .ucb-main-nav-container .ucb-menu .expanded.active > .ucb-menu {
     border-left: var(--ucb-menu-indent-border-width) solid var(--ucb-gold);
   }
+
   .ucb-main-nav-container .ucb-menu .ucb-menu .expanded.active > a.nav-link,
   .ucb-main-nav-container .ucb-menu .ucb-menu .expanded.active > .ucb-menu {
     border-left: none;

--- a/css/ucb-menu.css
+++ b/css/ucb-menu.css
@@ -183,12 +183,10 @@
   .ucb-main-nav-container .ucb-menu .ucb-menu .ucb-menu .ucb-menu .ucb-menu li.menu-item a.nav-link {
     padding-left: calc(var(--ucb-menu-indent-start) + var(--ucb-menu-indent-inc) * 4);
   }
-
   .ucb-main-nav-container .ucb-menu .expanded.active > a.nav-link,
   .ucb-main-nav-container .ucb-menu .expanded.active > .ucb-menu {
     border-left: var(--ucb-menu-indent-border-width) solid var(--ucb-gold);
   }
-
   .ucb-main-nav-container .ucb-menu .ucb-menu .expanded.active > a.nav-link,
   .ucb-main-nav-container .ucb-menu .ucb-menu .expanded.active > .ucb-menu {
     border-left: none;
@@ -362,6 +360,15 @@
   .ucb-secondary-menu-region-container .block-system-menu-blocksocial-media-menu,
   .ucb-secondary-menu-region-container #block-boulder-base-secondary-menu {
   width: 100% !important;
+  }
+
+  .ucb-main-nav-container .ucb-menu .expanded.active > a.nav-link,
+  .ucb-main-nav-container .ucb-menu .expanded.active > .ucb-menu {
+    border-left: none;
+  }
+
+  .ucb-main-nav-container .ucb-menu .expanded.active > .ucb-menu {
+    display: none;
   }
 }
 


### PR DESCRIPTION
Closes #1197.
Makes the secondary and mobile footer menu to stay within a column for the mobile menu. This also disables the footer menu being able to expand in the mobile menu.