### PR TITLE
Fixes CSS bug causing accordions nested inside tabbed expandable blocks to be hidden

### DIFF
--- a/css/ucb-accordion-styles.css
+++ b/css/ucb-accordion-styles.css
@@ -337,13 +337,21 @@
     display: none;
   }
 
-  .horizontal-tab-content .accordion-item,
-  .vertical-tab-content .accordion-item {
+  .horizontal-tab-content > .accordion > .accordion-item,
+  .vertical-tab-content > .accordion > .accordion-item {
     border-bottom: none;
   }
 
-  .horizontal-tab-content .accordion-body,
-  .vertical-tab-content .accordion-body {
+  .horizontal-tab-content
+    > .accordion
+    > .accordion-item
+    > .accordion-collapse
+    > .accordion-body,
+  .vertical-tab-content
+    > .accordion
+    > .accordion-item
+    > .accordion-collapse
+    > .accordion-body {
     padding-top: 20px;
     padding-bottom: 0;
   }

--- a/css/ucb-accordion-styles.css
+++ b/css/ucb-accordion-styles.css
@@ -304,15 +304,15 @@
     border-bottom: 2px solid var(--ucb-white);
   }
 
-  .horizontal-tab-content .accordion-header,
-  .vertical-tab-content .accordion-header,
-  .horizontal-tab-content .collapse.show,
-  .vertical-tab-content .collapse.show {
+  .horizontal-tab-content .tab-content > .accordion-header,
+  .vertical-tab-content .tab-content > .accordion-header,
+  .horizontal-tab-content .tab-content > .collapse.show,
+  .vertical-tab-content .tab-content > .collapse.show {
     display: none;
   }
 
-  .horizontal-tab-content .collapse.active,
-  .vertical-tab-content .collapse.active {
+  .horizontal-tab-content .tab-content > .collapse.active,
+  .vertical-tab-content .tab-content > .collapse.active {
     display: block;
   }
 


### PR DESCRIPTION
A CSS specificity bug existed in the expandable content block set to horizontal or vertical tab display. The bug caused accordions created using the CKEditor 5 Bootstrap Accordion plugin and nested within the content area to be unexpectedly hidden. This update resolves the issue.

Resolves CuBoulder/tiamat-theme#1228