### PR TITLE
ID generation replace

### DIFF
--- a/templates/block/block--expandable-content.html.twig
+++ b/templates/block/block--expandable-content.html.twig
@@ -14,7 +14,7 @@
   'ucb-expandable-content'
 ] %}
 
-{% set entity = content['#block_content'] %}{% set id = entity.uuid.value %}
+{% set entity = content['#block_content'] %}{% set id = '-id'|clean_unique_id %}
 {% set layoutSelection = entity.field_expandable_content_type.value %}
 
 {% set accordianContent %}

--- a/templates/block/block--image-gallery.html.twig
+++ b/templates/block/block--image-gallery.html.twig
@@ -15,6 +15,7 @@
 {% set totalColumns = "6" %}
 {% set tabletColumns = "3" %}
 {% set masonryStyle = content.field_masonry_display[0]|render|striptags|trim %}
+{% set galleryID = 'gallery'|clean_unique_id %}
 
 {% if masonryStyle == "True" %}
   {% set totalColumns = content.field_masonry_columns[0]|render %}
@@ -36,7 +37,7 @@
         {% endif %}
         {% if masonryStyle == "True" %}
           <div class="col gallery-item">
-            <a href="{{ file_url(item.entity.field_media_image.entity.fileuri) }}" class="glightbox ucb-gallery-lightbox" data-gallery="gallery{{ content['#block_content'].id() }}" data-glightbox="description: {{ photoDescription }} ">
+            <a href="{{ file_url(item.entity.field_media_image.entity.fileuri) }}" class="glightbox ucb-gallery-lightbox" data-gallery="{{ galleryID }}" data-glightbox="description: {{ photoDescription }} ">
               <div class ="imageMediaStyle large_image_style">
                 <img src = "{{ file_url(item.entity.field_media_image.entity.fileuri) }}" alt = "{{item.entity.field_media_image.alt|render}}" width="1500" height = "2250">
               </div>
@@ -44,7 +45,7 @@
           </div>
         {% else %}
           <div class="col gallery-item">
-            <a href="{{ file_url(item.entity.field_media_image.entity.fileuri) }}" class="glightbox ucb-gallery-lightbox" data-gallery="gallery{{ content['#block_content'].id() }}" data-glightbox="description: {{ photoDescription }} ">
+            <a href="{{ file_url(item.entity.field_media_image.entity.fileuri) }}" class="glightbox ucb-gallery-lightbox" data-gallery="{{ galleryID }}" data-glightbox="description: {{ photoDescription }} ">
               {{ item|view }}
             </a>
           </div>

--- a/templates/block/block--slider.html.twig
+++ b/templates/block/block--slider.html.twig
@@ -24,7 +24,7 @@
   {% set size = 'size-large' %}
 {% endif %}
 
-{% set id = 'carousel-' ~ content['#block_content'].id() %}
+{% set id = 'carousel'|clean_unique_id %}
 
 {% extends '@boulder_base/block/styled-block.html.twig' %}
 {% block content %}

--- a/templates/block/block--video-hero-unit.html.twig
+++ b/templates/block/block--video-hero-unit.html.twig
@@ -12,7 +12,7 @@
   'block-hero-unit',
   'ucb-hero-outer-wrapper'
 ] %}
-{% set blockId = content['#block_content'].id() %}
+{% set blockId = 'ucb_hero_unit_video_player'|clean_unique_id %}
 
 {# set style for backgroung settings #}
 {% if content['#block_content'].field_solid_colors.value is defined %}
@@ -79,7 +79,7 @@
     {% if videoURL is defined %}
       <div hidden class="ucb-hero-unit-video-wrapper">
         <div class="hero-unit-video-overlay"></div>
-        <div class="ucb-hero-unit-video-player-wrapper" id="ucb_hero_unit_video_player_{{ blockId }}"></div>
+        <div class="ucb-hero-unit-video-player-wrapper" id="{{ blockId }}"></div>
         <div class="ucb-hero-unit-video-controls-wrapper">
           <div class="ucb-hero-unit-video-controls">
             <span class="ucb-hero-unit-video-control-button ucb-hero-unit-video-play-pause" title="Play/Pause video">
@@ -89,7 +89,7 @@
         </div>
       </div>
       <script type="text/javascript">
-        window.addEventListener('load', () => enableVideoHero('{{ videoURL }}', 'ucb_hero_unit_video_player_{{ blockId }}'));
+        window.addEventListener('load', () => enableVideoHero('{{ videoURL }}', '{{ blockId }}'));
       </script>
     {% endif %}
     {% set linkColor = content['#block_content'].field_link_color.value %}

--- a/templates/block/block--video-reveal.html.twig
+++ b/templates/block/block--video-reveal.html.twig
@@ -12,7 +12,7 @@
   view_mode ? 'block--view-mode-' ~ view_mode|clean_class
 ] %}
 
-{% set blockId = content['#block_content'].id() %}
+{% set blockId = 'reveal'|clean_unique_id %}
 {% if content['#block_content'].field_video_reveal_video.entity.field_media_oembed_video is defined %}
   {% set videoURL = content['#block_content'].field_video_reveal_video.entity.field_media_oembed_video.value %}
 {% endif %}


### PR DESCRIPTION
Replacing our ID generation for these blocks so that reusable blocks don't run into errors with duplicate reusable blocks on the same page.

This affects the video reveal, slider, image gallery video hero unit, and expandable content blocks.

Closes #1245 
Closes #1137