### PR TITLE
Update Slide Size/Image

### DIFF
--- a/templates/block/block--slider.html.twig
+++ b/templates/block/block--slider.html.twig
@@ -13,17 +13,6 @@
   'ucb-slider-block'
 ] %}
 
-{# set classes for the size of the component #}
-{% if content['#block_content'].field_slider_size.value == '0' %}
-  {% set size = 'size-ultrawide' %}
-{% elseif content['#block_content'].field_slider_size.value == '1' %}
-  {% set size = 'size-widescreen' %}
-{% elseif content['#block_content'].field_slider_size.value == '2' %}
-  {% set size = 'size-threetwo' %}
-{% else %}
-  {% set size = 'size-large' %}
-{% endif %}
-
 {% set id = 'carousel'|clean_unique_id %}
 
 {% extends '@boulder_base/block/styled-block.html.twig' %}
@@ -33,15 +22,11 @@
   <div id="{{ id }}" class="carousel slide" data-bs-ride="carousel" data-bs-interval="7000" data-bs-pause="hover">
     <div class="carousel-indicators">
       {% for i in 1..content['#block_content'].field_slider_slide.value|length %}
-        <button{{ create_attribute({
-          type: 'button',
-          'data-bs-target': '#' ~ id,
-          'data-bs-slide-to': i - 1,
-          'aria-label': 'Slide ' ~ i
-        }).addClass(loop.first ? 'active') }}></button>
+        <button{{create_attribute({type:'button','data-bs-target':'#'~id,'data-bs-slide-to':i-1,'aria-label':'Slide'~i}).addClass(loop.first?'active')}}></button>
       {% endfor %}
     </div>
-    <div class="carousel-inner">
+    <div
+      class="carousel-inner">
       {# Don't render these fields #}
       {{ content|without(
         'field_slider_size',

--- a/templates/paragraphs/paragraph--slider-image.html.twig
+++ b/templates/paragraphs/paragraph--slider-image.html.twig
@@ -13,37 +13,55 @@
   ]
 %}
 
+{# set paragraph's parent for field information #}
+{% set parent = paragraph._referringItem.parent.parent.entity %}
+
+{# set classes for the image style  #}
+{% if parent.field_slider_size.value == '0' %}
+  {% set imgStyle = 'slider_ultrawide' %}
+{% elseif parent.field_slider_size.value == '1' %}
+  {% set imgStyle = 'slider_widescreen' %}
+{% elseif parent.field_slider_size.value == '2' %}
+  {% set imgStyle = 'slider_3_2' %}
+{% else %}
+  {% set imgStyle = 'original_image_size' %}
+{% endif %}
+
+{# set classes for the size of the component #}
+{% set imgUrl = paragraph.field_slide_image.entity.field_media_image.entity.fileuri|image_style(imgStyle) %}
+{% set imgAlt = paragraph.field_slide_image.entity.field_media_image.alt %}
+
+
 {% block paragraph %}
-	{% block content %}
+  {% block content %}
     <div class="slide-image-container">
       {% if paragraph.field_slide_link.0.url is not empty %}
         <a href="{{ paragraph.field_slide_link.0.url }}">
-          {{ content.field_slide_image|render }}
-        </a>
-      {% else %}
-        {{ content.field_slide_image|render }}
-      {% endif %}
-    </div>
-		{% if paragraph.field_slide_title.value is not empty or paragraph.field_slide_image_text is not empty %}
-			<div class="carousel-caption d-md-block">
-      <div class="slide-text-container">
-				{% if paragraph.field_slide_title is not empty %}
-					<span>
-						<h3>{{ content.field_slide_title|render|striptags|trim }}
-							{% if paragraph.field_slide_link.0.url is not empty %}
-								<a href="{{ paragraph.field_slide_link.0.url }}" class="slide-link">
-									<i class="fa-solid fa-up-right-from-square"></i>
-								</a>
-							{% endif %}
-						</h3>
-					</span>
+          <img{{create_attribute({src:imgUrl,alt:imgAlt})}}></a>
+        {% else %}
+          <img{{create_attribute({src:imgUrl,alt:imgAlt})}}>
+          {% endif %}
+        </div>
+        {% if paragraph.field_slide_title.value is not empty or paragraph.field_slide_image_text is not empty %}
+          <div class="carousel-caption d-md-block">
+            <div class="slide-text-container">
+              {% if paragraph.field_slide_title is not empty %}
+                <span>
+                  <h3>{{ content.field_slide_title|render|striptags|trim }}
+                    {% if paragraph.field_slide_link.0.url is not empty %}
+                      <a href="{{ paragraph.field_slide_link.0.url }}" class="slide-link">
+                        <i class="fa-solid fa-up-right-from-square"></i>
+                      </a>
+                    {% endif %}
+                  </h3>
+                </span>
 
-				{% endif %}
-				{% if paragraph.field_slide_image_text.value is not empty %}
-					<p>{{ content.field_slide_image_text|render }}</p>
-				{% endif %}
-			</div>
-      </div>
-		{% endif %}
-	{% endblock %}
-{% endblock paragraph %}
+              {% endif %}
+              {% if paragraph.field_slide_image_text.value is not empty %}
+                <p>{{ content.field_slide_image_text|render }}</p>
+              {% endif %}
+            </div>
+          </div>
+        {% endif %}
+      {% endblock %}
+    {% endblock paragraph %}


### PR DESCRIPTION
Added three new image styles:
Slider Ultrawide (1600x600)
Slider Widescreen (1600:900)
Slider 3:2 (1500:1000)

Each style has the proper sizing dictated by Kevin
The Slider block has been updated to have the proper names and sizes associated with them.
The slide paragraph now has the default image style set to Original.
The slider block template has had it's sizing logic moved to the paragraph slide template.
The paragraph slide template uses parent logic to check what side the slider is going to be and applies the appropriate style to each image.

Sister PR: https://github.com/CuBoulder/tiamat-custom-entities/pull/165

Closes #1240 