### PR TITLE
Article Slider: Fixes Issue with Multiple Reuseable Article Slider Blocks on the same Page

### DIFF
--- a/js/ucb-article-slider-block.js
+++ b/js/ucb-article-slider-block.js
@@ -5,6 +5,7 @@ class ArticleSliderBlockElement extends HTMLElement {
         var count = 6;
         var API = this.getAttribute('jsonapi');
         this._baseURI = this.getAttribute("base-uri");
+        this._id = this.getAttribute("id")
 
         // Exclusions are done on the JS side, get into arrays. Blank if no exclusions
         var excludeCatArray = this.getAttribute('exCats').split(",").map(Number);
@@ -146,7 +147,7 @@ class ArticleSliderBlockElement extends HTMLElement {
 }
 
     renderDisplay(articleArray){
-      var fliktyInit = document.getElementsByClassName('ucb-article-slider')[0]
+      var fliktyInit = document.getElementsByClassName(`ucb-article-slider${this._id}`)[0]
       articleArray.map(article=>{
         var articleContainer = document.createElement('div')
         articleContainer.className = 'ucb-article-slider-container carousel-cell'
@@ -176,7 +177,7 @@ class ArticleSliderBlockElement extends HTMLElement {
       this.toggleMessage('ucb-al-loading')
       this.toggleMessage('ucb-el-flick','block')
       // Make this a Flickity container -- this line appears to need to be here, creating the container before
-      new Flickity('.ucb-article-slider',{
+      new Flickity(`.ucb-article-slider${this._id}`,{
         'autoPlay': false,
         'wrapAround': true,
         'adaptiveHeight': true,

--- a/templates/block/block--ucb-article-slider.html.twig
+++ b/templates/block/block--ucb-article-slider.html.twig
@@ -12,6 +12,9 @@
   view_mode ? 'block--view-mode-' ~ view_mode|clean_class
 ] %}
 
+{# Unique Id #}
+{% set id = ''|clean_unique_id %}
+
 {# This block mirrors the Article List Node - constructs a JSON endpoint in TWIG using include filters #}
 {# JSON API Endpoint information #}
 {% set articlesJSON = (url('<front>')|render|trim('/'))
@@ -173,7 +176,7 @@
   {{ attach_library('boulder_base/ucb-article-slider-block') }}
   {{ content.body }}
   {# Article Slider Main Block#}
-  <article-slider-block base-uri="{{ baseurlJSON }}" jsonapi="{{ articlesJSON }}{{ IncludeFilter }}{{ pageCountFilter }}{{ sortFilter }}" excats="{{ excludeCategories }}" extags="{{ excludeTags }}">
+  <article-slider-block id="{{id}}" base-uri="{{ baseurlJSON }}" jsonapi="{{ articlesJSON }}{{ IncludeFilter }}{{ pageCountFilter }}{{ sortFilter }}" excats="{{ excludeCategories }}" extags="{{ excludeTags }}">
     <div id="ucb-al-loading" class="ucb-list-msg ucb-loading-data">
       <i class="fa-solid fa-spinner fa-3x fa-spin-pulse"></i>
     </div>
@@ -183,6 +186,6 @@
     <div id="ucb-al-api-error" style="display:none" class="ucb-list-msg">
       <h3>An error has occured with the API - please try again later</h3>
     </div>
-    <div id='ucb-el-flick' style="display:none" class="ucb-article-slider"></div>
+    <div id='ucb-el-flick' style="display:none" class="ucb-article-slider ucb-article-slider{{id}}"></div>
   </article-slider-block>
 {% endblock %}


### PR DESCRIPTION
While a rare situation, if a user happens to add two copies of a re-useable `Article Slider` block to the same page, it would cause them both to break. Similar to the other JavaScript blocks, this issue has been corrected by giving every instance of the block a Unique ID. 

Resolves #1247 