### PR TITLE
Print css to force black text

### DIFF
--- a/css/ucb-print.css
+++ b/css/ucb-print.css
@@ -39,6 +39,9 @@ body {
   color: #000 !important;
 
 }
+.ucb-video-reveal-controls,
+.text-white,
+.ucb-hero-unit-links,
 .ucb-bootstrap-layout-section {
   color: #000 !important;
 


### PR DESCRIPTION
Resolves #1276.
Adds css to force the hero and video reveal to have black text at all times.