### PR TITLE
Newsletter: Major bug fixes and style adjustments

### DIFF
--- a/templates/content/node--newsletter--email-html.html.twig
+++ b/templates/content/node--newsletter--email-html.html.twig
@@ -334,17 +334,17 @@ h1,h2,h3,h4,h5,h6,.h1,.h2,.h3,.h4,.h5,.h6 {
         {# HEADER -- to do: might need to be different tables for styling purposes #}
         <!-- Header -->
         {% if designType == 'lightbox' or designType == 'darkbox' %}
-        <table style="{{boxBackground}}" align="center">
+        <table style="{{boxBackground}}" align="center" width="600">
             <tbody>
                 <tr>
                     <td>
         {% endif %}
         <center>
-        <table class="ucb-email-header-{{designType}}" style="{{headerStyles}}">
+        <table width="600" class="ucb-email-header-{{designType}}" style="{{headerStyles}}">
             <tbody>
                 <tr>
                     <td style='{{headerStyles}}'>
-                        <table role='presentation' align="center" style="max-width:600px;">
+                        <table width="600" role='presentation' align="center" style="max-width:600px;">
                             <tbody>
                                 {# CU LOGO #}
                                 <tr>
@@ -383,11 +383,11 @@ h1,h2,h3,h4,h5,h6,.h1,.h2,.h3,.h4,.h5,.h6 {
             </tbody>
         </table>
         <center align="center" style="background-color: white;{{addtlPad}}">
-            <table style="max-width:600px;" align="center">
+            <table width="600" style="max-width:600px;" align="center">
                 <tbody>
                     <td>
                         <td>
-                            <table role="presentation" border="0" width="100%" cellspacing="0" style="text-align: left; vertical-align: top; width: 100%; color: #222222; font-family: Helvetica, Arial, sans-serif; padding-bottom:20px;font-weight: normal; margin: 0; font-size: 14px; background-color: white;{{classicTableOffset}}">
+                            <table role="presentation" border="0" width="600" cellspacing="0" style="text-align: left; vertical-align: top; width: 100%; color: #222222; font-family: Helvetica, Arial, sans-serif; padding-bottom:20px;font-weight: normal; margin: 0; font-size: 14px; background-color: white;{{classicTableOffset}}">
                                 <tr>
                                   <td align="center">
                                 <!-- Intro Img -->
@@ -426,7 +426,7 @@ h1,h2,h3,h4,h5,h6,.h1,.h2,.h3,.h4,.h5,.h6 {
                                 {# It's an internal link; prepend the base URL #}
                                 {% set final_url_one = base_url ~ link_url_one %}
                             {% endif %}
-                                <table role="presentation"  border="0" width="100%" cellspacing="0" style="border-collapse: collapse; border-spacing: 0; padding: 0; text-align: left; vertical-align: top; width: 100%; color: #222222; font-family: Helvetica, Arial, sans-serif; font-weight: normal; line-height: 19px; margin: 0; font-size: 14px; background-color: white;">
+                                <table role="presentation"  border="0" width="600" cellspacing="0" style="border-collapse: collapse; border-spacing: 0; padding: 0; text-align: left; vertical-align: top; width: 100%; color: #222222; font-family: Helvetica, Arial, sans-serif; font-weight: normal; line-height: 19px; margin: 0; font-size: 14px; background-color: white;">
                                     <tbody>
                                         <tr>
                                             <td align="center" style="text-align: left; padding-right:10px; padding-left:10px;padding-bottom:20px">
@@ -469,7 +469,7 @@ h1,h2,h3,h4,h5,h6,.h1,.h2,.h3,.h4,.h5,.h6 {
 
                             {# Render the blocks side by side #}
                             {% if blocksToRender %}
-                                <table role="presentation" border="0" width="100%" cellspacing="0" style="border-collapse: collapse; border-spacing: 0; padding: 0; text-align: left; vertical-align: top; width: 100%; color: #222222; font-family: Helvetica, Arial, sans-serif; font-weight: normal; line-height: 19px; margin: 0; font-size: 14px; background-color: white" class="row row-content ucb-newsletter-blocks">
+                                <table role="presentation" border="0" width="600" cellspacing="0" style="border-collapse: collapse; border-spacing: 0; padding: 0; text-align: left; vertical-align: top; width: 100%; color: #222222; font-family: Helvetica, Arial, sans-serif; font-weight: normal; line-height: 19px; margin: 0; font-size: 14px; background-color: white" class="row row-content ucb-newsletter-blocks">
                                     <tbody>
                                         {% for i in 0..(blocksToRender|length - 1) %}
                                             {% if loop.index is odd %}
@@ -499,7 +499,7 @@ h1,h2,h3,h4,h5,h6,.h1,.h2,.h3,.h4,.h5,.h6 {
                                 {# It's an internal link; prepend the base URL #}
                                 {% set final_url = base_url ~ link_url %}
                             {% endif %}
-                        <table role="presentation"  border="0" width="100%" cellspacing="0" style="border-collapse: collapse; border-spacing: 0; padding: 0; text-align: left; vertical-align: top; height: 100%; width: 100%; color: #222222; font-family: Helvetica, Arial, sans-serif; font-weight: normal; line-height: 19px; margin: 0; font-size: 14px; background-color: white;">
+                        <table role="presentation"  border="0" width="600" cellspacing="0" style="border-collapse: collapse; border-spacing: 0; padding: 0; text-align: left; vertical-align: top; height: 100%; width: 100%; color: #222222; font-family: Helvetica, Arial, sans-serif; font-weight: normal; line-height: 19px; margin: 0; font-size: 14px; background-color: white;">
                             <tbody>
                                 <tr>
                                     <td width="500px" style="text-align: left; padding-right:10px; padding-left:10px;padding-bottom:20px">
@@ -511,7 +511,7 @@ h1,h2,h3,h4,h5,h6,.h1,.h2,.h3,.h4,.h5,.h6 {
                             </tbody>
                         </table>
                         {% else %}
-                        <table role="presentation" border="0" width="100%" cellspacing="0" style="border-collapse: collapse; border-spacing: 0; padding: 0; text-align: left; vertical-align: top; height: 100%; width: 100%; color: #222222; font-family: Helvetica, Arial, sans-serif; font-weight: normal; line-height: 19px; margin: 0; font-size: 14px; background-color: white;">
+                        <table role="presentation" border="0" width="600" cellspacing="0" style="border-collapse: collapse; border-spacing: 0; padding: 0; text-align: left; vertical-align: top; height: 100%; width: 100%; color: #222222; font-family: Helvetica, Arial, sans-serif; font-weight: normal; line-height: 19px; margin: 0; font-size: 14px; background-color: white;">
                             <tbody>
                                 <tr>
                                     <td style="text-align: left; padding-right:10px; padding-left:10px;padding-bottom:20px">
@@ -531,11 +531,11 @@ h1,h2,h3,h4,h5,h6,.h1,.h2,.h3,.h4,.h5,.h6 {
          <!--Footer-->
          {% if node.field_newsletter_type.entity.field_newsletter_footer.value %}
          <center>
-            <table class="ucb-email-footer-{{designType}}"role="presentation" border="0" width="100%" cellspacing="0" style="{{footerStyles}}border-collapse: collapse; border-spacing: 0; padding: 0; text-align: left; vertical-align: top; height: 100%; width: 100%; font-family: Helvetica, Arial, sans-serif; font-weight: normal; line-height: 19px; margin: 0; font-size: 14px;">
+            <table class="ucb-email-footer-{{designType}}"role="presentation" border="0" width="600" cellspacing="0" style="{{footerStyles}}border-collapse: collapse; border-spacing: 0; padding: 0; text-align: left; vertical-align: top; height: 100%; width: 100%; font-family: Helvetica, Arial, sans-serif; font-weight: normal; line-height: 19px; margin: 0; font-size: 14px;">
                 <tbody>
                     <tr>
                         <td style="text-align: left; padding-right:10px; padding-left:10px;padding-bottom:20px; padding-top:20px">
-                            <table align="center" style="max-width:600px;">
+                            <table align="center" width="600" style="max-width:600px;">
                                 <tbody>
                                     <tr>
                                     <td>
@@ -552,7 +552,7 @@ h1,h2,h3,h4,h5,h6,.h1,.h2,.h3,.h4,.h5,.h6 {
         {% endif %}
         {# Social share #}
             {% if node.field_newsletter_type.entity.field_newsletter_social_link is defined and node.field_newsletter_type.entity.field_newsletter_social_link is not empty %}
-                <table role="presentation" border="0" width="100%" cellspacing="0" style="{{footerStyles}}border-collapse: collapse; border-spacing: 0; padding: 0; text-align: left; vertical-align: top; height: 100%; width: 100%; font-family: Helvetica, Arial, sans-serif; font-weight: normal; line-height: 19px; margin: 0; font-size: 14px;">
+                <table role="presentation" border="0" width="600" cellspacing="0" style="{{footerStyles}}border-collapse: collapse; border-spacing: 0; padding: 0; text-align: left; vertical-align: top; height: 100%; width: 100%; font-family: Helvetica, Arial, sans-serif; font-weight: normal; line-height: 19px; margin: 0; font-size: 14px;">
                 <tbody>
                         <tr class="newsletter-social-{{designType}}">
                             <td>

--- a/templates/content/node--newsletter--email-html.html.twig
+++ b/templates/content/node--newsletter--email-html.html.twig
@@ -167,7 +167,7 @@ color: inherit !important;
             line-height: inherit !important;
 }
 
-u + #ucb-email-body a {
+u + #ucb-email-body a, u + #ucb-email-body .ii a[href]{
             color: inherit !important;
             text-decoration: none !important;
             font-size: inherit !important;
@@ -176,7 +176,7 @@ u + #ucb-email-body a {
             line-height: inherit !important;
 }
 
-#MessageViewBody a {
+#MessageViewBody a, #MessageViewBody .ii a[href] {
             color: inherit !important;
             text-decoration: none !important;
             font-size: inherit !important;
@@ -187,7 +187,7 @@ u + #ucb-email-body a {
 
 
 
-                .tags > a{
+                .tags > a, .tags > .ii a[href]{
                     color: #656565 !important;
                     text-decoration: none;
                     background-color: #e7e7e7 !important;
@@ -247,7 +247,7 @@ u + #ucb-email-body a {
     -moz-box-shadow: 0 3px 15px rgba(0,0,0,0.35);
     box-shadow: 0 3px 15px rgba(0,0,0,0.35);
 };
-a:link,a:visited {
+a:link,a:visited,.ii a[href] {
     color: #0277BD !important;
     transition: background-color 0.25s ease,border-color 0.25s ease,color 0.25s ease;
     text-decoration: none;
@@ -255,13 +255,13 @@ a:link,a:visited {
     -webkit-text-decoration-color: rgba(2,119,189,0.65);
 }
 
-a:hover {
+a:hover,.ii a[href]:hover {
     color: #B71C1C;
     text-decoration-color: rgba(183,28,28,0.65);
     -webkit-text-decoration-color: rgba(183,28,28,0.65);
 }
 
-a:active {
+a:active, .ii a[href]:active {
     color: #B71C1C;
     text-decoration-color: rgba(183,28,28,0.65);
     -webkit-text-decoration-color: rgba(183,28,28,0.65);

--- a/templates/content/node--newsletter--email-html.html.twig
+++ b/templates/content/node--newsletter--email-html.html.twig
@@ -513,9 +513,9 @@ h1,h2,h3,h4,h5,h6,.h1,.h2,.h3,.h4,.h5,.h6 {
                         <table role="presentation"  border="0" width="600" cellspacing="0" style="border-collapse: collapse; border-spacing: 0; padding: 0; text-align: left; vertical-align: top; height: 100%; width: 100%; color: #222222; font-family: Helvetica, Arial, sans-serif; font-weight: normal; line-height: 19px; margin: 0; font-size: 14px; background-color: white;">
                             <tbody>
                                 <tr>
-                                    <td width="500px" style="text-align: left; padding-right:10px; padding-left:10px;padding-bottom:20px">
+                                    <td width="600" style="text-align: left; padding-right:10px; padding-left:10px;padding-bottom:20px">
                                         <a href="{{ final_url }}">
-                                            <img width="500" src="{{base_domain}}{{file_url(node.field_newsletter_promo_image_two.entity.field_media_image.entity.fileuri|image_style('focal_image_square'))}}"/>
+                                            <img width="600" src="{{base_domain}}{{file_url(node.field_newsletter_promo_image_two.entity.field_media_image.entity.fileuri|image_style('focal_image_square'))}}"/>
                                         </a>
                                     </td>
                                 </tr>

--- a/templates/content/node--newsletter--email-html.html.twig
+++ b/templates/content/node--newsletter--email-html.html.twig
@@ -125,6 +125,17 @@
             {# This should force browsers to stop using DarkMode overrides #}
             <meta name="color-scheme" content="light">
             <meta name="supported-color-schemes" content="light">
+            <meta name="color-scheme" content="only">
+            <meta name="supported-color-scheme" content="only">
+            {# This should override Outlook on Mac #}
+            <style type="text/css">
+              .body, .darkmode, .darkmode div { /* With class body on the body tag, and all elements represented here that have a background color */
+                  background-image: linear-gradient(#ffffff,#ffffff) !important;
+              }
+              .darkmode p { /* Add other selectors for other text elements */
+                  -webkit-text-fill-color: #000000 !important;
+              }
+            </style>
             <style>
 
                 img{

--- a/templates/content/node--newsletter--email-html.html.twig
+++ b/templates/content/node--newsletter--email-html.html.twig
@@ -122,6 +122,9 @@
 <div class="container" id="email-preview" style="background-color: grey; display: flex; justify-content:center">
     <html>
         <head>
+            {# This should force browsers to stop using DarkMode overrides #}
+            <meta name="color-scheme" content="light">
+            <meta name="supported-color-schemes" content="light">
             <style>
 
                 img{

--- a/templates/content/node--newsletter--email-html.html.twig
+++ b/templates/content/node--newsletter--email-html.html.twig
@@ -431,7 +431,7 @@ h1,h2,h3,h4,h5,h6,.h1,.h2,.h3,.h4,.h5,.h6 {
                                         <tr>
                                             <td align="center" style="text-align: left; padding-right:10px; padding-left:10px;padding-bottom:20px">
                                                 <a href="{{ final_url_one}}">
-                                                    <img width="100%" src="{{base_domain}}{{file_url(node.field_newsletter_promo_image_one.entity.field_media_image.entity.fileuri|image_style('focal_image_square'))}}"/>
+                                                    <img width="600" src="{{base_domain}}{{file_url(node.field_newsletter_promo_image_one.entity.field_media_image.entity.fileuri|image_style('focal_image_square'))}}"/>
                                                 </a>
                                             </td>
                                         </tr>
@@ -442,7 +442,7 @@ h1,h2,h3,h4,h5,h6,.h1,.h2,.h3,.h4,.h5,.h6 {
                                     <tbody>
                                         <tr>
                                             <td align="center"style="text-align: left; padding-right:10px; padding-left:10px; padding-bottom:20px">
-                                                <img width="100%"src="{{base_domain}}{{file_url(node.field_newsletter_promo_image_one.entity.field_media_image.entity.fileuri|image_style('focal_image_square'))}}"/>
+                                                <img width="600"src="{{base_domain}}{{file_url(node.field_newsletter_promo_image_one.entity.field_media_image.entity.fileuri|image_style('focal_image_square'))}}"/>
                                             </td>
                                         </tr>
                                     </tbody>
@@ -504,7 +504,7 @@ h1,h2,h3,h4,h5,h6,.h1,.h2,.h3,.h4,.h5,.h6 {
                                 <tr>
                                     <td width="500px" style="text-align: left; padding-right:10px; padding-left:10px;padding-bottom:20px">
                                         <a href="{{ final_url }}">
-                                            <img width="100%" src="{{base_domain}}{{file_url(node.field_newsletter_promo_image_two.entity.field_media_image.entity.fileuri|image_style('focal_image_square'))}}"/>
+                                            <img width="500" src="{{base_domain}}{{file_url(node.field_newsletter_promo_image_two.entity.field_media_image.entity.fileuri|image_style('focal_image_square'))}}"/>
                                         </a>
                                     </td>
                                 </tr>
@@ -515,7 +515,7 @@ h1,h2,h3,h4,h5,h6,.h1,.h2,.h3,.h4,.h5,.h6 {
                             <tbody>
                                 <tr>
                                     <td style="text-align: left; padding-right:10px; padding-left:10px;padding-bottom:20px">
-                                        <img src="{{base_domain}}{{file_url(node.field_newsletter_promo_image_two.entity.field_media_image.entity.fileuri|image_style('focal_image_square'))}}"/>
+                                        <img width="600" src="{{base_domain}}{{file_url(node.field_newsletter_promo_image_two.entity.field_media_image.entity.fileuri|image_style('focal_image_square'))}}"/>
                                     </td>
                                 </tr>
                             </tbody>

--- a/templates/content/node--newsletter--email-html.html.twig
+++ b/templates/content/node--newsletter--email-html.html.twig
@@ -617,3 +617,9 @@ h1,h2,h3,h4,h5,h6,.h1,.h2,.h3,.h4,.h5,.h6 {
     </div>
     </html>
 </div>
+
+<!--[if mso]>
+<style type="text/css">
+body, table, td {font-family: Arial, Helvetica, sans-serif !important;}
+</style>
+<![endif]-->

--- a/templates/content/node--newsletter--email-html.html.twig
+++ b/templates/content/node--newsletter--email-html.html.twig
@@ -594,7 +594,7 @@ h1,h2,h3,h4,h5,h6,.h1,.h2,.h3,.h4,.h5,.h6 {
                                     {% set color = designType == 'darkbox' or designType == 'simple' or designType == 'classic' ? 'white' : 'black' %}
                                     <a{{ create_attribute({ class: 'ucb-email-social-icon', href: uri }) }}>
                                         <img{{ create_attribute({
-                                            src: base_domain ~ '/' ~  base_path ~ directory ~ '/images/social_icons/' ~ color ~ '-' ~ service|lower ~ '.png',
+                                            src: base_url ~ '/' ~  base_path ~ directory ~ '/images/social_icons/' ~ color ~ '-' ~ service|lower ~ '.png',
                                             alt: alt,
                                             style: 'width:20px;height:20px' }) }}/>
                                     </a>

--- a/templates/paragraphs/paragraph--newsletter-section--email-html.html.twig
+++ b/templates/paragraphs/paragraph--newsletter-section--email-html.html.twig
@@ -148,9 +148,9 @@
             item.entity.field_newsletter_content_text.value|render %}
 	  					<!--Teaser Article-->
 					<center align="left">
-						<table role="presentation" width="600" style="padding-bottom: 20px;">
+						<table role="presentation" width="600" style="padding-bottom: 20px; border-bottom: solid 1px #cccccc;">
 							<tbody>
-								<tr class="email-feature-art-row"style="border-bottom: solid rgba(128, 128, 128, 0.333);">
+								<tr class="email-feature-art-row">
 									{# Image #}
                   {% if item.entity.field_newsletter_content_image.entity.field_media_image or  item.entity.field_newsletter_article_select.entity.field_ucb_article_thumbnail.entity.field_media_image or tem.entity.field_newsletter_article_select.entity.field_ucb_article_content.entity.field_article_media_selection.entity.field_media.entity.field_media_image %}
 									<td valign="top" width="27%"style="text-align: left; padding-right:10px; padding-left:10px">

--- a/templates/paragraphs/paragraph--newsletter-section--email-html.html.twig
+++ b/templates/paragraphs/paragraph--newsletter-section--email-html.html.twig
@@ -10,7 +10,7 @@
 
 
 {% set base_url = url('<front>')|render|split('/', -1)|join('/') %}
-<table role="presentation"  border="0" width="100%" cellspacing="0" style="border-collapse: collapse; border-spacing: 0; text-align: left; vertical-align: top; width: 100%; color: #222222; font-family: Helvetica, Arial, sans-serif; font-weight: normal; line-height: 19px; margin: 0; font-size: 14px; background-color: white;">
+<table role="presentation"  border="0" width="600" cellspacing="0" style="border-collapse: collapse; border-spacing: 0; text-align: left; vertical-align: top; width: 100%; color: #222222; font-family: Helvetica, Arial, sans-serif; font-weight: normal; line-height: 19px; margin: 0; font-size: 14px; background-color: white;">
 	<tbody>
   		<tr>
 			<td align="center" style="font-size:20px;text-align: left; padding-right:10px; padding-left:10px;padding-top:20px; padding-bottom:20px;">
@@ -35,26 +35,26 @@
           %}
 					{# Code to render selected article content (thumbnail) #}
 					<!--Feature Article-->
-					<table role="presentation" style="padding-bottom: 20px;">
+					<table role="presentation"  width="600" style="padding-bottom: 20px;">
 						<tbody>
 							<tr>
 								{% if item.entity.field_newsletter_article_select.entity.field_ucb_article_thumbnail.entity.field_media_image.alt|render %}
 								<td align="center" style="text-align: left; padding-right:10px; padding-left:10px; padding-bottom:20px">
 									<a href="{{base_url}}{{ path('entity.node.canonical', {'node': item.entity.field_newsletter_article_select.target_id}) }}">
-									<img width="100%" style="aspect-ratio:2/1;object-fit:cover;" src="{{base_url}}{{file_url(item.entity.field_newsletter_article_select.entity.field_ucb_article_thumbnail.entity.field_media_image.entity.fileuri|image_style('focal_image_wide'))}}"/>
+									<img width="600" style="aspect-ratio:2/1;object-fit:cover;" src="{{base_url}}{{file_url(item.entity.field_newsletter_article_select.entity.field_ucb_article_thumbnail.entity.field_media_image.entity.fileuri|image_style('focal_image_wide'))}}"/>
 									</a>
 								</td>
 									{# Code to render selected article content (!thumbnail) #}
 								{% elseif item.entity.field_newsletter_article_select.entity.field_ucb_article_content.entity.field_article_media_selection.entity.field_media.entity.field_media_image.alt|render %}
 								<td align="center" style="text-align: left; padding-right:10px; padding-left:10px;padding-bottom:20px">
 									<a href="{{base_url}}{{ path('entity.node.canonical', {'node': item.entity.field_newsletter_article_select.target_id}) }}">
-									<img width="100%" style="aspect-ratio:2/1;object-fit:cover;" src="{{base_url}}{{file_url(item.entity.field_newsletter_article_select.entity.field_ucb_article_content.entity.field_article_media_selection.entity.field_media.entity.field_media_image.entity.fileuri|image_style('focal_image_wide'))}}"/>
+									<img width="600" style="aspect-ratio:2/1;object-fit:cover;" src="{{base_url}}{{file_url(item.entity.field_newsletter_article_select.entity.field_ucb_article_content.entity.field_article_media_selection.entity.field_media.entity.field_media_image.entity.fileuri|image_style('focal_image_wide'))}}"/>
 									</a>
 								</td>
 									{# Code to render user made content #}
 								{% elseif item.entity.field_newsletter_content_image.entity.field_media_image.alt|render %}
 								<td align="center" style="text-align: left; padding-right:10px; padding-left:10px;padding-bottom:20px;">
-									<img width="100%" style="aspect-ratio:2/1;object-fit:cover;" src="{{base_url}}{{file_url(item.entity.field_newsletter_content_image.entity.field_media_image.entity.fileuri|image_style('focal_image_wide'))}}"/>
+									<img width="600" style="aspect-ratio:2/1;object-fit:cover;" src="{{base_url}}{{file_url(item.entity.field_newsletter_content_image.entity.field_media_image.entity.fileuri|image_style('focal_image_wide'))}}"/>
 								</td>
 								{% endif %}
 							</tr>
@@ -148,7 +148,7 @@
             item.entity.field_newsletter_content_text.value|render %}
 	  					<!--Teaser Article-->
 					<center align="left">
-						<table role="presentation" width="100%" style="padding-bottom: 20px;">
+						<table role="presentation" width="600" style="padding-bottom: 20px;">
 							<tbody>
 								<tr class="email-feature-art-row"style="border-bottom: solid rgba(128, 128, 128, 0.333);">
 									{# Image #}

--- a/templates/paragraphs/paragraph--newsletter-section--email-html.html.twig
+++ b/templates/paragraphs/paragraph--newsletter-section--email-html.html.twig
@@ -111,7 +111,7 @@
 						{# Code to render selected article content (article text) #}
 					{% elseif item.entity.field_newsletter_article_select.entity.field_ucb_article_content.entity.field_article_text.value|render %}
 						<tr id="feature-article-summary-text-email-{{key}}">
-							{% set textContent = item.entity.field_newsletter_article_select.entity.field_ucb_article_content.entity.field_article_text.value|striptags %}
+              {% set textContent = item.entity.field_newsletter_article_select.entity.field_ucb_article_content.entity.field_article_text.value|striptags|replace({'&nbsp;': ' '}) %}
 							{% set maxLength = 300 %}
 							{% if textContent|length > maxLength %}
 								{% set trimmedText = textContent|slice(0, maxLength)|trim ~ '...' %}
@@ -229,7 +229,7 @@
 								{# Code to render selected article content (article text) #}
 							{% elseif item.entity.field_newsletter_article_select.entity.field_ucb_article_content.entity.field_article_text.value|render %}
 								<tr>
-									{% set textContent = item.entity.field_newsletter_article_select.entity.field_ucb_article_content.entity.field_article_text.value|striptags %}
+                  {% set textContent = item.entity.field_newsletter_article_select.entity.field_ucb_article_content.entity.field_article_text.value|striptags|replace({'&nbsp;': ' '}) %}
 									{% set maxLength = 300 %}
 									{% if textContent|length > maxLength %}
 										{% set trimmedText = textContent|slice(0, maxLength)|trim ~ '...' %}

--- a/templates/paragraphs/paragraph--newsletter-section.html.twig
+++ b/templates/paragraphs/paragraph--newsletter-section.html.twig
@@ -115,20 +115,18 @@
 							  <div class="teaser-article-img px-2">
 								<img
 								src="{{ item.entity.field_newsletter_article_select.entity.field_ucb_article_thumbnail.entity.field_media_image.entity.fileuri|image_style('focal_image_square') }}" alt="{{ item.entity.field_newsletter_article_select.entity.field_ucb_article_thumbnail.entity.field_media_image.alt|render }}"/>
-              </div>
 								{# Code to render selected article content (!thumbnail) #}
 							{% elseif item.entity.field_newsletter_article_select.entity.field_ucb_article_content.entity.field_article_media_selection.entity.field_media.entity.field_media_image.alt|render %}
 							<div class="teaser-article-img px-2">
               <img
 								src="{{ item.entity.field_newsletter_article_select.entity.field_ucb_article_content.entity.field_article_media_selection.entity.field_media.entity.field_media_image.entity.fileuri|image_style('focal_image_square') }}" alt="{{ item.entity.field_newsletter_article_select.entity.field_ucb_article_content.entity.field_article_media_selection.entity.field_media.entity.field_media_image.alt|render }}"/>
-              </div>
 								{# Code to render user made content #}
 							{% elseif item.entity.field_newsletter_content_image.entity.field_media_image.alt|render %}
 							<div class="teaser-article-img px-2">
               <img src="{{ item.entity.field_newsletter_content_image.entity.field_media_image.entity.fileuri|image_style('focal_image_square') }}" alt="{{ item.entity.field_newsletter_content_image.entity.field_media_image.alt|render }}"/>
-							</div>
               {% endif %}
-						</div>
+            </div>
+
 
 							{# Code to render selected article title/url #}
 							{% if item.entity.field_newsletter_article_select.entity.title.value|render %}
@@ -169,7 +167,7 @@
 								{# Code to render selected article content (article text) #}
 							{% elseif item.entity.field_newsletter_article_select.entity.field_ucb_article_content.entity.field_article_text.value|render %}
 								<div class="article-summary">
-									{% set textContent = item.entity.field_newsletter_article_select.entity.field_ucb_article_content.entity.field_article_text.value|striptags %}
+                  {% set textContent = item.entity.field_newsletter_article_select.entity.field_ucb_article_content.entity.field_article_text.value|striptags|replace({'&nbsp;': ' '}) %}
 									{% set maxLength = 300 %}
 									{% if textContent|length > maxLength %}
 										{% set trimmedText = textContent|slice(0, maxLength)|trim ~ '...' %}

--- a/templates/paragraphs/paragraph--newsletter-section.html.twig
+++ b/templates/paragraphs/paragraph--newsletter-section.html.twig
@@ -34,6 +34,7 @@
 			{% endfor %}
 		{% endif %}
 		{% if paragraph.field_newsletter_section_style.value is same as("0") %}
+      <p>feature</p>
 			{% for key, item in paragraph.field_newsletter_section_select %}
 				{%  if key|first != '#' %}
 					<div class="ucb-newsletter-section-article {{unpublishedClass}}">
@@ -110,22 +111,24 @@
 				{% for key, item in paragraph.field_newsletter_section_select %}
 					{%  if key|first != '#' %}
 						<div class="{{paragraph.field_newsletter_section_select|length > 1 ? 'col-lg-6' : '' }} col-12 pb-4">
-							<div
-							class="teaser-article-img px-2">
-							{# Code to render selected article content (thumbnail) #}
+              {# Code to render selected article content (thumbnail) #}
 							{% if item.entity.field_newsletter_article_select.entity.field_ucb_article_thumbnail.entity.field_media_image.alt|render %}
+							  <div class="teaser-article-img px-2">
 								<img
 								src="{{ item.entity.field_newsletter_article_select.entity.field_ucb_article_thumbnail.entity.field_media_image.entity.fileuri|image_style('focal_image_square') }}" alt="{{ item.entity.field_newsletter_article_select.entity.field_ucb_article_thumbnail.entity.field_media_image.alt|render }}"/>
-
+              </div>
 								{# Code to render selected article content (!thumbnail) #}
 							{% elseif item.entity.field_newsletter_article_select.entity.field_ucb_article_content.entity.field_article_media_selection.entity.field_media.entity.field_media_image.alt|render %}
-								<img
+							<div class="teaser-article-img px-2">
+              <img
 								src="{{ item.entity.field_newsletter_article_select.entity.field_ucb_article_content.entity.field_article_media_selection.entity.field_media.entity.field_media_image.entity.fileuri|image_style('focal_image_square') }}" alt="{{ item.entity.field_newsletter_article_select.entity.field_ucb_article_content.entity.field_article_media_selection.entity.field_media.entity.field_media_image.alt|render }}"/>
-
+              </div>
 								{# Code to render user made content #}
 							{% elseif item.entity.field_newsletter_content_image.entity.field_media_image.alt|render %}
-								<img src="{{ item.entity.field_newsletter_content_image.entity.field_media_image.entity.fileuri|image_style('focal_image_square') }}" alt="{{ item.entity.field_newsletter_content_image.entity.field_media_image.alt|render }}"/>
-							{% endif %}
+							<div class="teaser-article-img px-2">
+              <img src="{{ item.entity.field_newsletter_content_image.entity.field_media_image.entity.fileuri|image_style('focal_image_square') }}" alt="{{ item.entity.field_newsletter_content_image.entity.field_media_image.alt|render }}"/>
+							</div>
+              {% endif %}
 						</div>
 
 							{# Code to render selected article title/url #}
@@ -179,11 +182,11 @@
 
 								{# Code to render user made content (content text) #}
 							{% elseif item.entity.field_newsletter_content_text.value|render %}
-								<div class="article-summary">
+								<div class="article-summary" id="teaser-article-summary-user-text--{{kkey}}">
 									{{ item.entity.field_newsletter_content_text|view }}
 								</div>
 							{% endif %}
-							
+
 						</div>
 					{% endif %}
 				{% endfor %}

--- a/templates/paragraphs/paragraph--newsletter-section.html.twig
+++ b/templates/paragraphs/paragraph--newsletter-section.html.twig
@@ -34,7 +34,6 @@
 			{% endfor %}
 		{% endif %}
 		{% if paragraph.field_newsletter_section_style.value is same as("0") %}
-      <p>feature</p>
 			{% for key, item in paragraph.field_newsletter_section_select %}
 				{%  if key|first != '#' %}
 					<div class="ucb-newsletter-section-article {{unpublishedClass}}">


### PR DESCRIPTION
### Newsletter - Node
- Centering on Newsletter pages (the page, not the email version)  was not working correctly for user-created content in Teaser, only if an image was not supplied. This has been corrected. Resolves https://github.com/CuBoulder/tiamat-theme/issues/1264

### Newsletter -  Email Version
#### Major Fixes
- Articles added to newsletters were showing `&nbsp;`  as plain text in strange places that do not appear in the original articles. This has been corrected - this would happen with Articles where no summary field is provided. The `&nbsp` was caused by how we handle generating a summary to put in place of that missing field in Twig specifically and has been adjusted
- Newsletters are limited to 600 px wide in the preview window but when sent through Marketing Cloud and opened in Windows Outlook, and always were the full width of the window, breaking formatting. This was due to how Outlook handles image styles, needs a width attribute on the element instead of css. 
- Additional updates have been made to try to force our colors to come through despite user selected light/dark modes on their email clients. This will likely be an ongoing process to iron out how every client handles styling base elements in their own way and how each handles light/dark mode user settings differently.
- An issue where Footer Social media link icons appear to be broken has been fixed, this is due to an error in the path. 

#### Minor Style Fixes
- The CU Boulder logo at the top of newsletters is extremely large in Outlook but very tiny when the same newsletter is opened on an iPhone. Same issue as above, Outlook needed specific size attributes specified in the element itself instead of handling via CSS. 

- Newsletter text appears as Arial in the preview window, but are Times New Roman when opened on Outlook. More Outlook specific styles have been applied, again this will likely be an ongoing process to dial in settings that work across the maximum number of browsers.

- The horizontal rules separating sections appear in the preview window but are missing when pasted to Marketing Cloud. This has been corrected, RGBA is not a valid style and it needed to be applied to a `<table>` element instead of a `<tr>` element. 

Resolves https://github.com/CuBoulder/tiamat-theme/issues/1254