### PR TITLE
Article Title Background Update

### DIFF
--- a/boulder_base.theme
+++ b/boulder_base.theme
@@ -277,6 +277,7 @@ function boulder_base_preprocess_node__organization(array &$variables) {
 
 /**
  * Exposes a variable to indicate if a user can edit a node.
+ * Exposes a variable for positioning data of title background images.
  */
 function boulder_base_preprocess_node__ucb_article(array &$variables) {
   if ($node = \Drupal::routeMatch()->getParameter('node')) {
@@ -284,6 +285,31 @@ function boulder_base_preprocess_node__ucb_article(array &$variables) {
     $userCanEdit = $node->access('update', $user);
     $variables['user_can_edit'] = $userCanEdit;
   }
+
+  // Get the media image positioning
+  if ($node->hasField('field_article_title_background') && $node->get('field_article_title_background')->entity) {
+    $media_entity = $node->get('field_article_title_background')->entity;
+    $fid = $media_entity->getSource()->getSourceFieldValue($media_entity);
+    $file = \Drupal::entityTypeManager()->getStorage('file')->load($fid);
+
+  $crop = \Drupal::service('focal_point.manager')->getCropEntity($file, 'focal_point');
+  if ($crop) {
+    // Get the x and y position from the crop.
+    $fp_abs = $crop->position();
+    $x = $fp_abs['x'];
+    $y = $fp_abs['y'];
+
+    // Get the original width and height from the image.
+    $image_factory = \Drupal::service('image.factory');
+    $image = $image_factory->get($file->getFileUri());
+    $width = $image->getWidth();
+    $height = $image->getHeight();
+
+    // Convert the absolute x and y positions to relative values.
+    $fp_rel = \Drupal::service('focal_point.manager')->absoluteToRelative($x, $y, $width, $height);
+    $variables['position_vars'] =  $fp_rel['x'] . '% ' . $fp_rel['y'] . '%;';
+  }
+}
 }
 
 /**

--- a/css/ucb-article.css
+++ b/css/ucb-article.css
@@ -140,15 +140,13 @@ i.fa-regular.fa-calendar {
   position: relative;
   z-index: 0;
   object-fit: fill;
+  background-size: cover;
 }
 
 .backgroundTitleDiv .ucb-article-heading {
-  position: absolute;
-  display: block;
-  bottom: 0;
   width: 100%;
   background-color: transparent;
-  padding: 200px 20px 30px;
+  padding: 300px 20px 30px;
 }
 
 .backgroundTitleDiv.ucb-overlay-dark .ucb-article-heading {

--- a/templates/content/node--ucb-article.html.twig
+++ b/templates/content/node--ucb-article.html.twig
@@ -125,9 +125,9 @@
     <div class="ucb-article" itemscope itemtype="https://schema.org/Article">
       {# If using a Title Background img, render that #}
       {% if content.field_article_title_background.0 %}
+      {% set titleBackground = node.field_article_title_background|file_uri|image_style('section_background') %}
         <header><h1 class="visually-hidden">{{ label }}</h1></header>
-        <div class="backgroundTitleDiv {{ overlayClass }}">
-          {{ content.field_article_title_background }}
+        <div style="background-image: url('{{ titleBackground }}'); background-position: {{ position_vars }};" class="backgroundTitleDiv {{ overlayClass }}">
           <div{{ title_attributes.addClass('ucb-article-heading', 'article-header-' ~ textColor, is_front ? 'visually-hidden') }}>
             <div class="container">
               <h1>{{ label }}</h1>


### PR DESCRIPTION
Removed div displayed image and set it as a background image. Set the background image to use the `section_background` image style to avoid large image files.

Set background positioning using new preprocess in .theme Preprocess works like it does in the layout builder sections except it will update immediately if the file image's focal point is updated.

Updated css to reflect new changes. Removal of `absolute` positioning fixes the problem with the navigation being covered by the title. Everything should scale well now.

Changed the top padding to be 300px vs 200px to imitate the old version's bigger title image.

Resolves #1292 