### PR TITLE
Fix for alignment of floated images with long captions

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -709,6 +709,11 @@ article .align-left .media-image-caption p {
   font-size: 85%;
 }
 
+/* Center image above caption that has been floated */
+.align-left .imageMediaStyle, .align-right .imageMediaStyle {
+  text-align: center;
+}
+
 .align-right.image_style-large_image_style,
 .align-left.image_style-large_image_style {
   max-width: 100%;

--- a/css/style.css
+++ b/css/style.css
@@ -710,8 +710,16 @@ article .align-left .media-image-caption p {
 }
 
 /* Center image above caption that has been floated */
-.align-left .imageMediaStyle, .align-right .imageMediaStyle {
+.align-center .imageMediaStyle {
   text-align: center;
+}
+
+.align-left .imageMediaStyle{
+  text-align: left;
+}
+
+.align-right .imageMediaStyle {
+  text-align: right;
 }
 
 .align-right.image_style-large_image_style,


### PR DESCRIPTION
Add proper alignment on floated images.
 Should only affect images with large amounts of caption text.

Resolves #1314 
Resolves #1249