### PR TITLE
People List Page: Selecting 'Group by Job Type or Department' with Filters applied to that term, only shows allowed groupings

### DIFF
--- a/js/ucb-people-list.js
+++ b/js/ucb-people-list.js
@@ -95,6 +95,7 @@
       let config = {};
       try {
         config = this._config = JSON.parse(this.getAttribute('config')) || config;
+        console.log(config)
       } catch (e) { }
       this._baseURI = this.getAttribute('base-uri');
       const
@@ -229,16 +230,19 @@
               if (groupingData && groupingData.length) {
                 hasGroupingTaxonomy = true;
               }
-              ((person['relationships']['field_ucb_person_' + groupBy] || {})['data'] || []).forEach(
-                termData => {
-                  const termId = termData['meta']['drupal_internal__target_id'];
+
+              ((person['relationships']['field_ucb_person_' + groupBy] || {})['data'] || []).forEach(termData => {
+                const termId = termData['meta']['drupal_internal__target_id'];
+                // If there are filters applied to the current groupBy field (e.g., job_type), apply them so unwanted groups don't show up
+                if (!this._filters[groupBy] || this._filters[groupBy].includes.length === 0 || this._filters[groupBy].includes.map(Number).includes(termId)) {
                   let termPeople = groupedPeople.get(termId);
                   if (!termPeople) {
                     termPeople = [];
                     groupedPeople.set(termId, termPeople);
                   }
                   termPeople.push(person);
-                });
+                }
+              });
             });
             if (!hasGroupingTaxonomy) {
               this.toggleMessageDisplay(this._messageElement, 'block', 'ucb-list-msg', `No results found for the '${groupBy}' grouping.`);

--- a/js/ucb-people-list.js
+++ b/js/ucb-people-list.js
@@ -95,7 +95,6 @@
       let config = {};
       try {
         config = this._config = JSON.parse(this.getAttribute('config')) || config;
-        console.log(config)
       } catch (e) { }
       this._baseURI = this.getAttribute('base-uri');
       const


### PR DESCRIPTION
Previously if you had a People List Page with `Group by` set to Department or Job Type, and had filter on that term, you could possibly see groupings of people for terms not selected in the filter, if the Person pages had multiple terms.

For example: on [https://www.colorado.edu/alc/our-people/undergraduate-advising](https://www.colorado.edu/alc/our-people/undergraduate-advising), the Faculty group should not show up as it is a term applied to every Person Page, but NOT included in the filters.

This has been corrected so only the filtered groups in the `Includes` for that term show up as a Group.

Resolves https://github.com/CuBoulder/tiamat-theme/issues/1259