### PR TITLE
Webform Block: Adds Required field indicator

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1029,6 +1029,15 @@ form label {
   display: inline;
 }
 
+/* Required * for Webform */
+form.webform-submission-form .form-required::after {
+  display: inline-block;
+  margin-inline: 0.15em;
+  content: "*";
+  color: #f00;
+  font-size: 0.875rem;
+}
+
 form input[type="checkbox"]+label,
 form input[type="radio"]+label {
   display: inline-block;


### PR DESCRIPTION
Previously the required field indicator (red asterisk) was missing from Forms added as a `Webform block` (not to be confused with Form blocks).  This has been corrected so they are visible.

Resolves #1321 