### PR TITLE
Remove Mega menu from Sticky menus and add default link color

### DIFF
--- a/css/block/ucb-mega-menu.css
+++ b/css/block/ucb-mega-menu.css
@@ -83,6 +83,14 @@
   flex-wrap: wrap;
 }
 
+.ucb-main-nav-container .ucb-mega-menu .menu-item .mega-menu-wrapper a{
+  color: #0277bd;
+}
+
+.ucb-main-nav-container .ucb-mega-menu .menu-item .mega-menu-wrapper a:hover{
+  color: #B71C1C;
+}
+
 @media only screen and (max-width: 767px) {
 
   .ucb-mega-menu-column-3 div,

--- a/css/ucb-sticky-menu.css
+++ b/css/ucb-sticky-menu.css
@@ -67,3 +67,8 @@
 .sticky-menu-inner .ucb-menu li.menu-item a.nav-link:hover {
 	color: var(--ucb-gold);
 }
+
+.sticky-menu-inner .ucb-mega-menu,
+.sticky-menu-inner .ucb-mega-menu-icon {
+	display: none;
+}

--- a/js/ucb-mega-menu.js
+++ b/js/ucb-mega-menu.js
@@ -27,3 +27,15 @@ const megaMenuList = [...megaMenuElementList].map(collapseEl => new bootstrap.Co
     }
   }
 })
+
+// Disable Sticky Menu Mega Menus
+const stickyMenu = document.getElementsByClassName("ucb-sticky-menu");
+for (let i = 0; i < stickyMenu.length; i++) {
+  const allMegaMenus =  stickyMenu[i].getElementsByClassName("ucb-mega-menu-outer-link");
+  for (let j = 0; j < allMegaMenus.length; j++) {
+    allMegaMenus[j].removeAttribute("data-bs-toggle");
+    allMegaMenus[j].removeAttribute("data-bs-target");
+    allMegaMenus[j].removeAttribute("aria-expanded");
+    allMegaMenus[j].removeAttribute("aria-controls");
+  }
+}


### PR DESCRIPTION
Resolves #1317 and #1316.
Removes mega menus from the sticky menu and converts them into normal links. It also adds base default colors for links in mega menus to account for site settings.