### PR TITLE
Places first name and last name on the same line to prevent trimming of the space between them

### DIFF
--- a/templates/content/node--ucb-person.html.twig
+++ b/templates/content/node--ucb-person.html.twig
@@ -14,11 +14,13 @@
 ] %}
 
 {% set baseurlJSON = url('<front>')|render|trim('/') %}
+{% set firstName = content.field_ucb_person_first_name['#items'].0.value|trim %}
+{% set lastName = content.field_ucb_person_last_name['#items'].0.value|trim %}
 
 <article{{ attributes.addClass(classes) }} itemscope itemtype="https://schema.org/Person">
   <div class="container ucb-person-header">
     <h1 class="ucb-person-name">
-      <span itemprop="givenName">{{ content.field_ucb_person_first_name.0 }}</span> <span itemprop="familyName">{{ content.field_ucb_person_last_name.0 }}</span>
+      <span itemprop="givenName">{{ firstName }}</span>&nbsp;<span itemprop="familyName">{{ lastName }}</span>
     </h1>
     {{ content.field_ucb_person_pronouns }}
     {% if content.field_ucb_person_title.0 or content.field_ucb_person_department.0 %}
@@ -74,7 +76,7 @@
     <div class="ucb-articles-by-person-block">
       <person-article-list base-uri="{{ baseurlJSON }}" nodeid="{{ node.id }}">
         <div id="ucb-person-article-block-title" style="display:none">
-          <h2>Articles by {{ content.field_ucb_person_first_name.0 }} {{ content.field_ucb_person_last_name.0 }}</h2>
+          <h2>Articles by {{ firstName }} {{ lastName }}</h2>
         </div>
         <div id="ucb-al-loading" style="display:none" class="ucb-list-msg ucb-loading-data">
           <i class="fa-solid fa-spinner fa-3x fa-spin-pulse"></i>

--- a/templates/content/node--ucb-person.html.twig
+++ b/templates/content/node--ucb-person.html.twig
@@ -18,7 +18,7 @@
 <article{{ attributes.addClass(classes) }} itemscope itemtype="https://schema.org/Person">
   <div class="container ucb-person-header">
     <h1 class="ucb-person-name">
-      {{ content.field_ucb_person_first_name }} {{ content.field_ucb_person_last_name }}
+      <span itemprop="givenName">{{ content.field_ucb_person_first_name.0 }}</span> <span itemprop="familyName">{{ content.field_ucb_person_last_name.0 }}</span>
     </h1>
     {{ content.field_ucb_person_pronouns }}
     {% if content.field_ucb_person_title.0 or content.field_ucb_person_department.0 %}

--- a/templates/field/field--field-ucb-person-first-name.html.twig
+++ b/templates/field/field--field-ucb-person-first-name.html.twig
@@ -1,6 +1,0 @@
-{#
-/**
- * @file Contains the template to display the Person node's First name field.
- */
-#}
-{% if items.0 %}<span itemprop="givenName">{{ items.0.content['#context'].value|trim }}</span>{% endif %}

--- a/templates/field/field--field-ucb-person-last-name.html.twig
+++ b/templates/field/field--field-ucb-person-last-name.html.twig
@@ -1,6 +1,0 @@
-{#
-/**
- * @file Contains the template to display the Person node's Last name field.
- */
-#}
-{% if items.0 %}<span itemprop="familyName">{{ items.0.content['#context'].value|trim }}</span>{% endif %}


### PR DESCRIPTION
[bug] An issue existed where a space was trimmed between the first name and last name on person pages due to the names being separated by a newline. This update resolves the issue. Resolves CuBoulder/tiamat-theme#1304