### PR TITLE
body template move

### DIFF
--- a/templates/field/field--node--body--basic-page.html.twig
+++ b/templates/field/field--node--body--basic-page.html.twig
@@ -1,15 +1,14 @@
 {#
-/**
+/*
  * Theme layout to display main body copy on basic page
- * Created by jnichol on 1/11/22
  */
 #}
 
 {{ title_prefix }}
-{# % if label %}
+{# {% if label %}
       <h2{{ title_attributes }}>{{ label }}</h2>
-    {% endif % #}
+   {% endif %} #}
 {{ title_suffix }}
 <div{{attributes}} class="container bs-background-unstyled block">
-  {{ content|render }}
+  {{ items|render }}
 </div>

--- a/templates/field/field--node--body--basic-page.html.twig
+++ b/templates/field/field--node--body--basic-page.html.twig
@@ -10,5 +10,7 @@
    {% endif %} #}
 {{ title_suffix }}
 <div{{attributes}} class="container bs-background-unstyled block">
-  {{ items|render }}
+  {% for item in items %}
+    {{ item.content|render }}
+  {% endfor %}
 </div>


### PR DESCRIPTION
The basic page body block wasn't being rendered at the right level. This caused it not to be editable or removable at the layout builder level. If multiple body sections were added they couldn't be deleted and a "body" title was added to each new addition.

Closes #1280 