### PR TITLE
Hide hamburger menu when there are no menus

### DIFF
--- a/js/ucb-menu.js
+++ b/js/ucb-menu.js
@@ -1,4 +1,12 @@
 document.addEventListener("DOMContentLoaded", () => {
+  const checkMenuExistence = document.getElementsByClassName("ucb-main-nav-container")[0];
+  if (checkMenuExistence != null) {
+    const quantityMenus = checkMenuExistence.getElementsByClassName("menu-item");
+    if(quantityMenus.length < 1) {
+      document.getElementById("ucb-mobile-menu-toggle").style.display = "none";
+    }
+  }
+
   const sectionCheck = document.getElementsByClassName("ucb-main-nav-section")[0];
   if (sectionCheck != null) {
     const menuCheck = sectionCheck.getElementsByClassName("ucb-main-nav-container")[0];

--- a/js/ucb-menu.js
+++ b/js/ucb-menu.js
@@ -2,7 +2,7 @@ document.addEventListener("DOMContentLoaded", () => {
   const checkMenuExistence = document.getElementsByClassName("ucb-main-nav-container")[0];
   if (checkMenuExistence != null) {
     const quantityMenus = checkMenuExistence.getElementsByClassName("menu-item");
-    if(quantityMenus.length < 1) {
+    if(quantityMenus.length < 1 && document.getElementById("ucb-mobile-menu-toggle") != null) {
       document.getElementById("ucb-mobile-menu-toggle").style.display = "none";
     }
   }

--- a/js/ucb-menu.js
+++ b/js/ucb-menu.js
@@ -1,22 +1,25 @@
 document.addEventListener("DOMContentLoaded", () => {
+  let quantityMenusLength = 0;
   const checkMenuExistence = document.getElementsByClassName("ucb-main-nav-container")[0];
   if (checkMenuExistence != null) {
     const quantityMenus = checkMenuExistence.getElementsByClassName("menu-item");
+    quantityMenusLength = quantityMenus.length;
     if(quantityMenus.length < 1 && document.getElementById("ucb-mobile-menu-toggle") != null) {
       document.getElementById("ucb-mobile-menu-toggle").style.display = "none";
     }
   }
-
-  const sectionCheck = document.getElementsByClassName("ucb-main-nav-section")[0];
-  if (sectionCheck != null) {
-    const menuCheck = sectionCheck.getElementsByClassName("ucb-main-nav-container")[0];
-    if (menuCheck != null) {
-      const mobileMenu = new AccessibleMenu.DisclosureMenu({
-        menuElement: menuCheck,
-        controllerElement: document.querySelector("#ucb-mobile-menu-toggle"),
-        containerElement: sectionCheck,
-        openClass: "open",
-      });
+  if(quantityMenusLength > 0) {
+    const sectionCheck = document.getElementsByClassName("ucb-main-nav-section")[0];
+    if (sectionCheck != null) {
+      const menuCheck = sectionCheck.getElementsByClassName("ucb-main-nav-container")[0];
+      if (menuCheck != null) {
+        const mobileMenu = new AccessibleMenu.DisclosureMenu({
+          menuElement: menuCheck,
+          controllerElement: document.querySelector("#ucb-mobile-menu-toggle"),
+          containerElement: sectionCheck,
+          openClass: "open",
+        });
+      }
     }
   }
 });


### PR DESCRIPTION
Resolves #1290.
Adds a secondary check in the case where the menus exist but there are no menu links within them.