### PR TITLE
Add class to body block for video reveal fix

### DIFF
--- a/templates/field/field--node--body--basic-page.html.twig
+++ b/templates/field/field--node--body--basic-page.html.twig
@@ -1,0 +1,5 @@
+{% for item in items %}
+<div class = "ucb-basic-page-body">
+    {{ item }}
+</div>
+{% endfor %}


### PR DESCRIPTION
Resolves #1313.
Adds a new field template for the body in a basic page to prevent overlap in the situation of floated images extending outside the block