### PR TITLE
Replaces deprecated function call on sites with a custom logo image

### DIFF
--- a/boulder_base.theme
+++ b/boulder_base.theme
@@ -175,8 +175,9 @@ function boulder_base_preprocess_page(array &$variables) {
   $variables['ucb_heading_font'] = theme_get_setting('ucb_heading_font');
   $useCustomLogo = theme_get_setting('ucb_use_custom_logo');
   if ($useCustomLogo) {
-    $logoDarkURL = file_create_url(theme_get_setting('ucb_custom_logo_dark_path'));
-    $logoLightURL = file_create_url(theme_get_setting('ucb_custom_logo_light_path'));
+    $fileUrlGenerator = \Drupal::service('file_url_generator');
+    $logoDarkURL = $fileUrlGenerator->generateAbsoluteString(theme_get_setting('ucb_custom_logo_dark_path'));
+    $logoLightURL = $fileUrlGenerator->generateAbsoluteString(theme_get_setting('ucb_custom_logo_light_path'));
     $variables['ucb_custom_logo'] = [
       'dark_url' => $logoDarkURL,
       'light_url' => $logoLightURL,


### PR DESCRIPTION
[bug, severity:moderate] An issue existed where a site would crash if it contained a custom logo. This was due to the use of a [deprecated function call removed in newer versions of Drupal](https://www.drupal.org/node/2940031). This update resolves the issue by replacing the deprecated function call with the correct call. Resolves CuBoulder/tiamat-theme#1342