### PR TITLE
Articles by Person Block: Fixes Infinite Spinning Load on Person Page

### DIFF
--- a/js/ucb-person-article-list.js
+++ b/js/ucb-person-article-list.js
@@ -63,7 +63,7 @@ class PersonArticleList extends HTMLElement {
         }
 
         // Have articles and want to proceed
-        if(finalArticles.length > 0 && !NEXTJSONURL ){
+        if(finalArticles.length > 0 && (!NEXTJSONURL || finalArticles.length >= count)){
           this.renderDisplay(finalArticles, bylineTerm);
         }
     }


### PR DESCRIPTION
In cases where a Person has over 10 Articles with their linked byline term set on the Articles, the logic on the Articles by Person block could cause an infinite spinning loader due to logic in how the block should handle pagination. This has been corrected to match the other Article aggregator build processes. 

Resolves #1332 