### PR TITLE
Video Reveal and Hero Fix

### DIFF
--- a/templates/block/block--video-hero-unit.html.twig
+++ b/templates/block/block--video-hero-unit.html.twig
@@ -88,7 +88,7 @@
           </div>
         </div>
       </div>
-      <script type="text/javascript">
+      <script type="text/javascript" defer>
         window.addEventListener('DOMContentLoaded', () => enableVideoHero('{{ videoURL }}', '{{ blockId }}'));
       </script>
     {% endif %}

--- a/templates/block/block--video-hero-unit.html.twig
+++ b/templates/block/block--video-hero-unit.html.twig
@@ -89,7 +89,7 @@
         </div>
       </div>
       <script type="text/javascript">
-        window.addEventListener('load', () => enableVideoHero('{{ videoURL }}', '{{ blockId }}'));
+        window.addEventListener('DOMContentLoaded', () => enableVideoHero('{{ videoURL }}', '{{ blockId }}'));
       </script>
     {% endif %}
     {% set linkColor = content['#block_content'].field_link_color.value %}

--- a/templates/block/block--video-reveal.html.twig
+++ b/templates/block/block--video-reveal.html.twig
@@ -1,16 +1,16 @@
 {#
-/**
- * @file Contains the template to display the Video Reveal block type.
- */
-#}
+  /**
+  * @file Contains the template to display the Video Reveal block type.
+  */
+  #}
 {% set classes = [
-  'ucb-video-reveal',
-  'block',
-  'block-' ~ configuration.provider|clean_class,
-  'block-' ~ plugin_id|clean_class,
-  bundle ? 'block--type-' ~ bundle|clean_class,
-  view_mode ? 'block--view-mode-' ~ view_mode|clean_class
-] %}
+    'ucb-video-reveal',
+    'block',
+    'block-' ~ configuration.provider|clean_class,
+    'block-' ~ plugin_id|clean_class,
+    bundle ? 'block--type-' ~ bundle|clean_class,
+    view_mode ? 'block--view-mode-' ~ view_mode|clean_class
+  ] %}
 
 {% set blockId = 'reveal'|clean_unique_id %}
 {% if content['#block_content'].field_video_reveal_video.entity.field_media_oembed_video is defined %}
@@ -26,21 +26,21 @@
 {% block content %}
   {{ attach_library('boulder_base/ucb-video-reveal') }}
   <div id="ucb-video-block-{{ blockId }}" class="ucb-video-text-div">
-      <div hidden class="ucb-video-reveal-close">
-        <button aria-label="Hide video" class="ucb-video-reveal-close-button">
-          <i class="fa-solid fa-circle-xmark ucb-video-reveal-close-button"></i>
-        </button>
-      </div>
-      <div class="ucb-video-reveal-video-wrapper" id="ucb-video-reveal-video-wrapper-{{ blockId }}">
-        <script type="text/javascript">
-          window.addEventListener('load', () => enableVideoReveal('{{ videoURL }}', 'ucb-video-reveal-video-wrapper-{{ blockId }}'));
-        </script>
-      </div>
-      <div role="button" aria-label="Play video" class="ucb-video-reveal-controls" style = 'background-image: url("{{imageURL}}")' >
-        <span class="ucb-video-reveal-icon">
-          <i class="fa-solid fa-circle-play"></i>
-        </span>
-        <span class="ucb-video-reveal-text">{{ content.field_video_reveal_text_overlay }}</span>
-      </div>
+    <div hidden class="ucb-video-reveal-close">
+      <button aria-label="Hide video" class="ucb-video-reveal-close-button">
+        <i class="fa-solid fa-circle-xmark ucb-video-reveal-close-button"></i>
+      </button>
+    </div>
+    <div class="ucb-video-reveal-video-wrapper" id="ucb-video-reveal-video-wrapper-{{ blockId }}" data-video-url="{{ videoURL }}">
+      <script type="text/javascript">
+        window.addEventListener('DOMContentLoaded', () => enableVideoReveal('{{ videoURL }}', 'ucb-video-reveal-video-wrapper-{{ blockId }}'));
+      </script>
+    </div>
+    <div role="button" aria-label="Play video" class="ucb-video-reveal-controls" style='background-image: url("{{imageURL}}")'>
+      <span class="ucb-video-reveal-icon">
+        <i class="fa-solid fa-circle-play"></i>
+      </span>
+      <span class="ucb-video-reveal-text">{{ content.field_video_reveal_text_overlay }}</span>
+    </div>
   </div>
 {% endblock content %}

--- a/templates/block/block--video-reveal.html.twig
+++ b/templates/block/block--video-reveal.html.twig
@@ -32,7 +32,7 @@
       </button>
     </div>
     <div class="ucb-video-reveal-video-wrapper" id="ucb-video-reveal-video-wrapper-{{ blockId }}" data-video-url="{{ videoURL }}">
-      <script type="text/javascript">
+      <script type="text/javascript" defer>
         window.addEventListener('DOMContentLoaded', () => enableVideoReveal('{{ videoURL }}', 'ucb-video-reveal-video-wrapper-{{ blockId }}'));
       </script>
     </div>


### PR DESCRIPTION
Both the video reveal and hero unit needed to have the `load` option changed to `DOMContentLoaded` because of GTM scripts interfering with the normal functions of our video scripts. 

This fixes the loading errors that both of them had for youtube. Vimeo is still working as intended. The change I had asked David to test didn't seem to work so this is the current fix for the issue other than fully removing the social trackers that are breaking it. Unfortunately not an option currently.

When testing the Video Hero Unit seems to be overriding the Video Reveal's functionality so they cannot be on the same page. This looks to be happening even with the current version so it's not a new bug. I'm going to create a new ticket for that issue. I haven't been able to figure out what is actually causing the problem but I think it has to do with the youtube iframe api being loaded twice.

Resolves #1250 