### PR TITLE
Remove striptags render from mega menu desc

### DIFF
--- a/templates/field/field--field_mega_menu_links_desc.html.twig
+++ b/templates/field/field--field_mega_menu_links_desc.html.twig
@@ -1,3 +1,3 @@
 {% for item in items %}
-  {{ item.content}}
+  {{ item.content }}
 {% endfor %}

--- a/templates/field/field--field_mega_menu_links_desc.html.twig
+++ b/templates/field/field--field_mega_menu_links_desc.html.twig
@@ -1,3 +1,3 @@
 {% for item in items %}
-  {{ item.content|render|striptags}}
+  {{ item.content}}
 {% endfor %}


### PR DESCRIPTION
Resolves #1372.
Removes the render and strip tags from the mega menu link description