### PR TITLE
Only footer menu in the mobile menu fix.

### DIFF
--- a/css/ucb-menu.css
+++ b/css/ucb-menu.css
@@ -28,6 +28,7 @@
 .ucb-mobile-footer-menu,
 .ucb-mobile-social-media-menu {
   display: none;
+  width: 100%;
 }
 
 @media only screen and (max-width: 575px) {
@@ -135,6 +136,8 @@
   .ucb-main-nav-container .ucb-primary-menu-region li.menu-item.active a.nav-link.is-active,
   .ucb-main-nav-container.ucb-secondary-menu-position-above .ucb-secondary-menu-region li.menu-item a.nav-link,
   .ucb-main-nav-container.ucb-secondary-menu-position-inline .ucb-secondary-menu-region li.menu-item a.nav-link,
+  .ucb-main-nav-container .ucb-mobile-footer-menu li.menu-item a.nav-link,
+  .ucb-main-nav-container .ucb-mobile-social-media-menu li.menu-item a.nav-link,
   .ucb-main-menu li.menu-item a.nav-link:hover,
   .ucb-main-menu li.menu-item a.nav-link.is-active,
   .ucb-main-menu li.menu-item.active a.nav-link:first-of-type {
@@ -151,6 +154,8 @@
     background-color: var(--ucb-gold);
   }
 
+  .ucb-main-nav-container .ucb-mobile-footer-menu li.menu-item a.nav-link:hover,
+  .ucb-main-nav-container .ucb-mobile-social-media-menu li.menu-item a.nav-link:hover,
   .ucb-main-nav-container.ucb-secondary-menu-position-above .ucb-secondary-menu-region li.menu-item:not(.active) a.nav-link,
   .ucb-main-nav-container.ucb-secondary-menu-position-inline .ucb-secondary-menu-region li.menu-item:not(.active) a.nav-link {
     background-color: transparent;

--- a/templates/layout/page.html.twig
+++ b/templates/layout/page.html.twig
@@ -186,6 +186,12 @@
         <div class="ucb-main-nav-container ucb-secondary-menu-position-{{ ucb_secondary_menu_position == 'above' ? 'above' : 'inline container' }} ucb-button-{{ menu_button_color }}">
           {{ page.primary_menu }}
           {{ page.secondary_menu }}
+          <div class="ucb-mobile-footer-menu">
+            {{ drupal_menu('footer') }}
+          </div>
+          <div class="ucb-mobile-social-media-menu">
+            {{ drupal_menu('social-media-menu') }}
+          </div>
         </div>
       </section>
     </div>

--- a/templates/regions/region--secondary-menu.html.twig
+++ b/templates/regions/region--secondary-menu.html.twig
@@ -18,10 +18,4 @@
     {% if ucb_secondary_menu_default_links %}{% include "@boulder_base/includes/ucb-header-secondary-menu.html.twig" %}{% endif %}
     {{ content }}
   </div>
-  <div class="ucb-mobile-footer-menu">
-    {{ drupal_menu('footer') }}
-  </div>
-  <div class="ucb-mobile-social-media-menu">
-    {{ drupal_menu('social-media-menu') }}
-  </div>
 </div>


### PR DESCRIPTION
Resolves #1336.
Adds the ability to use footer menus while using no other menus and have them show up in the mobile menu.