### PR TITLE
Issue Fixes: "Link to Issue" on Articles tag style, Issue page images, Latest Issues Block

### DIFF
--- a/css/block/ucb-latest-issue-block.css
+++ b/css/block/ucb-latest-issue-block.css
@@ -1,16 +1,18 @@
 .ucb-latest-issue-container{
-    display: flex;
-    flex-wrap: wrap;
-    flex-direction: row;
-    margin-bottom: 20px;
+  overflow: hidden;
+  display: flex;
+  flex-wrap: wrap;
+  flex-direction: row;
+  margin: 0 -20px;
 }
 
 .ucb-latest-issue-card{
-    max-width: 20%;
-    margin-right: 20px;
-    display: flex;
-    align-items: center;
-    flex-direction: column;
+  max-width: 25%;
+  padding: 0 20px;
+  display: flex;
+  align-items: center;
+  flex-direction: column;
+  margin-bottom: 20px;
 }
 
 .ucb-latest-issue-title{
@@ -20,8 +22,7 @@
 
 
 .ucb-latest-issue-img{
-    max-height: 200px;
-    max-width: 200px;
+  margin-bottom: 10px;
 }
 
 .ucb-latest-issue-archive-button{
@@ -33,5 +34,6 @@
 }
 
 .ucb-latest-issue-archive-container{
+    text-align: center;
     margin-bottom: 20px;
 }

--- a/css/ucb-article.css
+++ b/css/ucb-article.css
@@ -32,7 +32,7 @@ i.fa-regular.fa-calendar {
   line-height: 1em;
 }
 
-.ucb-article-category-icon, .ucb-article-tag-icon {
+.ucb-article-category-icon, .ucb-article-tag-icon, .ucb-article-issue-icon {
   background-color: #555555;
   color: #e7e7e7;
   padding: 6px;

--- a/css/ucb-issue.css
+++ b/css/ucb-issue.css
@@ -19,11 +19,6 @@
   padding-bottom: 20px;
 }
 
-img {
-  width: 100%;
-  height: 100%;
-}
-
 .teaser-article-thumbnail,
 .title-thumb-article-thumbnail {
   margin-right: 20px;

--- a/templates/content/node--ucb-article.html.twig
+++ b/templates/content/node--ucb-article.html.twig
@@ -175,7 +175,7 @@
       {{ content.field_ucb_article_tags }}
       {% if content.field_appears_in_issue|render %}
         <div role="contentinfo" class="container ucb-article-issue" itemprop="keywords">
-          <div>
+          <div class="ucb-article-issue-icon" aria-hidden="true">
             <span class="visually-hidden">Issues:</span>
             <i class="fa-solid fa-book"></i>
           </div>


### PR DESCRIPTION
### Article Page
The tag showing that an Article appears in an Issue (below Categories and Tags) on Article pages previously had the icon appearing differently than the Category and Tag icons due to missing CSS. This has been corrected. (You will need to link an existing Issue to an Article to test via the 'Link To Issue' tab)

### Issue Pages
Previously, images placed in the footer (or anywhere else for that matter) on an Issue page were showing up at 100% sizing due to not specific enough CSS being applied to all images. This has been corrected.

### Latest Issues Block
We have resized the images of Issue covers that appear in the `Latest Issue` block to a larger size, mirroring the D7 version where each card takes up 25% of the horizontal container.

Resolves #1382 
Resolves #1383 
Resolves #1384 