### PR TITLE
Colorbox Image Styles: Allows 'alt' tag fallback for Caption, Fixes Floats

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -682,6 +682,22 @@ article .align-left .media-image-caption p {
   padding-right: 1em;
 }
 
+/**** Colorbox Image Overrides, these need some snowflake css because of how different they are ******/
+article .align-left .ucb-colorbox-small-square,
+article .align-left .ucb-colorbox-small-thumbnail,
+article .align-left .ucb-colorbox-small,
+article .align-left .ucb-colorbox-square{
+  margin-right: 1em;
+  padding-right: 0em;
+}
+article .align-right .ucb-colorbox-small-square,
+article .align-right .ucb-colorbox-small-thumbnail,
+article .align-right .ucb-colorbox-small,
+article .align-right .ucb-colorbox-square{
+  margin-left: 1em;
+  padding-left: 0em;
+}
+
 /* Adjusts list elements when a left-floated image (.align-left) is a preceeding sibling, aligns list indicators with other elements  */
 .align-left+ol,
 .align-left+ul {

--- a/templates/media/media--image--colorbox-small-square.html.twig
+++ b/templates/media/media--image--colorbox-small-square.html.twig
@@ -1,9 +1,9 @@
 {{ attach_library('boulder_base/colorbox-image') }}
 
-{% set imageStyle = 'image_style-default' %}
+{# {% set imageStyle = 'image_style-default' %}
 {% if content.field_media_image.0['#image_style']|render %}
   {% set imageStyle = 'image_style-' ~ content.field_media_image.0['#image_style']|render %}
-{% endif %}
+{% endif %} #}
 
 {# Retrieve the image URL #}
 {% set image_url = file_url(content.field_media_image.0['#item'].entity.uri.value) %}
@@ -22,12 +22,10 @@
 {% endif %}
 
 {# Manually add alignment classes if they are not being applied automatically #}
-{% set alignment_class = attributes.hasClass('align-left') or attributes.hasClass('align-right') ? '' : 'align-left' %}
+{% set alignment_class = alignment is defined and alignment in ['align-left', 'align-right'] ? alignment : 'align-left' %}
 
-{% if attributes != "" %}
 <div {{ attributes.addClass(alignment_class, 'col', 'gallery-item') }}>
   <a href="{{ image_url }}" class="glightbox ucb-gallery-lightbox" data-gallery="gallery{{ content['#block_content'].id() }}" data-glightbox="description: {{ photoDescription }} ">
     <img class="ucb-colorbox-small-square" src="{{ image_url }}" alt="{{ photoDescription }}" />
   </a>
 </div>
-{% endif %}

--- a/templates/media/media--image--colorbox-small-square.html.twig
+++ b/templates/media/media--image--colorbox-small-square.html.twig
@@ -1,10 +1,5 @@
 {{ attach_library('boulder_base/colorbox-image') }}
 
-{# {% set imageStyle = 'image_style-default' %}
-{% if content.field_media_image.0['#image_style']|render %}
-  {% set imageStyle = 'image_style-' ~ content.field_media_image.0['#image_style']|render %}
-{% endif %} #}
-
 {# Retrieve the image URL #}
 {% set image_url = file_url(content.field_media_image.0['#item'].entity.uri.value) %}
 

--- a/templates/media/media--image--colorbox-small-square.html.twig
+++ b/templates/media/media--image--colorbox-small-square.html.twig
@@ -8,16 +8,26 @@
 {# Retrieve the image URL #}
 {% set image_url = file_url(content.field_media_image.0['#item'].entity.uri.value) %}
 
+{# Retrieve the alt attribute #}
+{% set alt_text = content.field_media_image.0['#item'].alt %}
+
 {# Access the photo description directly from content #}
 {% set field_items = content.field_media_image_caption['#items'] %}
 {% if field_items %}
   {% set photoDescription = field_items.0.value|render|striptags|trim %}
+{% elseif alt_text %}
+  {% set photoDescription = alt_text %}
 {% else %}
-  {% set photoDescription = '' %}
+  {% set photoDescription = "" %}
 {% endif %}
 
-<div class="col gallery-item">
+{# Manually add alignment classes if they are not being applied automatically #}
+{% set alignment_class = attributes.hasClass('align-left') or attributes.hasClass('align-right') ? '' : 'align-left' %}
+
+{% if attributes != "" %}
+<div {{ attributes.addClass(alignment_class, 'col', 'gallery-item') }}>
   <a href="{{ image_url }}" class="glightbox ucb-gallery-lightbox" data-gallery="gallery{{ content['#block_content'].id() }}" data-glightbox="description: {{ photoDescription }} ">
     <img class="ucb-colorbox-small-square" src="{{ image_url }}" alt="{{ photoDescription }}" />
   </a>
 </div>
+{% endif %}

--- a/templates/media/media--image--colorbox-small-thumbnail.html.twig
+++ b/templates/media/media--image--colorbox-small-thumbnail.html.twig
@@ -1,9 +1,9 @@
 {{ attach_library('boulder_base/colorbox-image') }}
 
-{% set imageStyle = 'image_style-default' %}
+{# {% set imageStyle = 'image_style-default' %}
 {% if content.field_media_image.0['#image_style']|render %}
   {% set imageStyle = 'image_style-' ~ content.field_media_image.0['#image_style']|render %}
-{% endif %}
+{% endif %} #}
 
 {# Retrieve the image URL #}
 {% set image_url = file_url(content.field_media_image.0['#item'].entity.uri.value) %}
@@ -22,12 +22,10 @@
 {% endif %}
 
 {# Manually add alignment classes if they are not being applied automatically #}
-{% set alignment_class = attributes.hasClass('align-left') or attributes.hasClass('align-right') ? '' : 'align-left' %}
+{% set alignment_class = alignment is defined and alignment in ['align-left', 'align-right'] ? alignment : 'align-left' %}
 
-{% if attributes != "" %}
 <div {{ attributes.addClass(alignment_class, 'col', 'gallery-item') }}>
   <a href="{{ image_url }}" class="glightbox ucb-gallery-lightbox" data-gallery="gallery{{ content['#block_content'].id() }}" data-glightbox="description: {{ photoDescription }} ">
     <img class="ucb-colorbox-small-thumbnail" src="{{ image_url }}" alt="{{ photoDescription }}" />
   </a>
 </div>
-{% endif %}

--- a/templates/media/media--image--colorbox-small-thumbnail.html.twig
+++ b/templates/media/media--image--colorbox-small-thumbnail.html.twig
@@ -1,10 +1,5 @@
 {{ attach_library('boulder_base/colorbox-image') }}
 
-{# {% set imageStyle = 'image_style-default' %}
-{% if content.field_media_image.0['#image_style']|render %}
-  {% set imageStyle = 'image_style-' ~ content.field_media_image.0['#image_style']|render %}
-{% endif %} #}
-
 {# Retrieve the image URL #}
 {% set image_url = file_url(content.field_media_image.0['#item'].entity.uri.value) %}
 

--- a/templates/media/media--image--colorbox-small-thumbnail.html.twig
+++ b/templates/media/media--image--colorbox-small-thumbnail.html.twig
@@ -8,16 +8,26 @@
 {# Retrieve the image URL #}
 {% set image_url = file_url(content.field_media_image.0['#item'].entity.uri.value) %}
 
+{# Retrieve the alt attribute #}
+{% set alt_text = content.field_media_image.0['#item'].alt %}
+
 {# Access the photo description directly from content #}
 {% set field_items = content.field_media_image_caption['#items'] %}
 {% if field_items %}
   {% set photoDescription = field_items.0.value|render|striptags|trim %}
+{% elseif alt_text %}
+  {% set photoDescription = alt_text %}
 {% else %}
-  {% set photoDescription = '' %}
+  {% set photoDescription = "" %}
 {% endif %}
 
-<div class="col gallery-item">
+{# Manually add alignment classes if they are not being applied automatically #}
+{% set alignment_class = attributes.hasClass('align-left') or attributes.hasClass('align-right') ? '' : 'align-left' %}
+
+{% if attributes != "" %}
+<div {{ attributes.addClass(alignment_class, 'col', 'gallery-item') }}>
   <a href="{{ image_url }}" class="glightbox ucb-gallery-lightbox" data-gallery="gallery{{ content['#block_content'].id() }}" data-glightbox="description: {{ photoDescription }} ">
     <img class="ucb-colorbox-small-thumbnail" src="{{ image_url }}" alt="{{ photoDescription }}" />
   </a>
 </div>
+{% endif %}

--- a/templates/media/media--image--colorbox-small.html.twig
+++ b/templates/media/media--image--colorbox-small.html.twig
@@ -8,16 +8,26 @@
 {# Retrieve the image URL #}
 {% set image_url = file_url(content.field_media_image.0['#item'].entity.uri.value) %}
 
+{# Retrieve the alt attribute #}
+{% set alt_text = content.field_media_image.0['#item'].alt %}
+
 {# Access the photo description directly from content #}
 {% set field_items = content.field_media_image_caption['#items'] %}
 {% if field_items %}
   {% set photoDescription = field_items.0.value|render|striptags|trim %}
+{% elseif alt_text %}
+  {% set photoDescription = alt_text %}
 {% else %}
-  {% set photoDescription = '' %}
+  {% set photoDescription = "" %}
 {% endif %}
 
-<div class="col gallery-item">
+{# Manually add alignment classes if they are not being applied automatically #}
+{% set alignment_class = attributes.hasClass('align-left') or attributes.hasClass('align-right') ? '' : 'align-left' %}
+
+{% if attributes != "" %}
+<div {{ attributes.addClass(alignment_class, 'col', 'gallery-item') }}>
   <a href="{{ image_url }}" class="glightbox ucb-gallery-lightbox" data-gallery="gallery{{ content['#block_content'].id() }}" data-glightbox="description: {{ photoDescription }} ">
     <img class="ucb-colorbox-small" src="{{ image_url }}" alt="{{ photoDescription }}" />
   </a>
 </div>
+{% endif %}

--- a/templates/media/media--image--colorbox-small.html.twig
+++ b/templates/media/media--image--colorbox-small.html.twig
@@ -1,10 +1,5 @@
 {{ attach_library('boulder_base/colorbox-image') }}
 
-{# {% set imageStyle = 'image_style-default' %}
-{% if content.field_media_image.0['#image_style']|render %}
-  {% set imageStyle = 'image_style-' ~ content.field_media_image.0['#image_style']|render %}
-{% endif %} #}
-
 {# Retrieve the image URL #}
 {% set image_url = file_url(content.field_media_image.0['#item'].entity.uri.value) %}
 

--- a/templates/media/media--image--colorbox-small.html.twig
+++ b/templates/media/media--image--colorbox-small.html.twig
@@ -1,9 +1,9 @@
 {{ attach_library('boulder_base/colorbox-image') }}
 
-{% set imageStyle = 'image_style-default' %}
+{# {% set imageStyle = 'image_style-default' %}
 {% if content.field_media_image.0['#image_style']|render %}
   {% set imageStyle = 'image_style-' ~ content.field_media_image.0['#image_style']|render %}
-{% endif %}
+{% endif %} #}
 
 {# Retrieve the image URL #}
 {% set image_url = file_url(content.field_media_image.0['#item'].entity.uri.value) %}
@@ -22,12 +22,10 @@
 {% endif %}
 
 {# Manually add alignment classes if they are not being applied automatically #}
-{% set alignment_class = attributes.hasClass('align-left') or attributes.hasClass('align-right') ? '' : 'align-left' %}
+{% set alignment_class = alignment is defined and alignment in ['align-left', 'align-right'] ? alignment : 'align-left' %}
 
-{% if attributes != "" %}
 <div {{ attributes.addClass(alignment_class, 'col', 'gallery-item') }}>
   <a href="{{ image_url }}" class="glightbox ucb-gallery-lightbox" data-gallery="gallery{{ content['#block_content'].id() }}" data-glightbox="description: {{ photoDescription }} ">
     <img class="ucb-colorbox-small" src="{{ image_url }}" alt="{{ photoDescription }}" />
   </a>
 </div>
-{% endif %}

--- a/templates/media/media--image--colorbox-square.html.twig
+++ b/templates/media/media--image--colorbox-square.html.twig
@@ -1,9 +1,9 @@
 {{ attach_library('boulder_base/colorbox-image') }}
 
-{% set imageStyle = 'image_style-default' %}
+{# {% set imageStyle = 'image_style-default' %}
 {% if content.field_media_image.0['#image_style']|render %}
   {% set imageStyle = 'image_style-' ~ content.field_media_image.0['#image_style']|render %}
-{% endif %}
+{% endif %} #}
 
 {# Retrieve the image URL #}
 {% set image_url = file_url(content.field_media_image.0['#item'].entity.uri.value) %}
@@ -22,12 +22,10 @@
 {% endif %}
 
 {# Manually add alignment classes if they are not being applied automatically #}
-{% set alignment_class = attributes.hasClass('align-left') or attributes.hasClass('align-right') ? '' : 'align-left' %}
+{% set alignment_class = alignment is defined and alignment in ['align-left', 'align-right'] ? alignment : 'align-left' %}
 
-{% if attributes != "" %}
 <div {{ attributes.addClass(alignment_class, 'col', 'gallery-item') }}>
   <a href="{{ image_url }}" class="glightbox ucb-gallery-lightbox" data-gallery="gallery{{ content['#block_content'].id() }}" data-glightbox="description: {{ photoDescription }} ">
     <img class="ucb-colorbox-square" src="{{ image_url }}" alt="{{ photoDescription }}" />
   </a>
 </div>
-{% endif %}

--- a/templates/media/media--image--colorbox-square.html.twig
+++ b/templates/media/media--image--colorbox-square.html.twig
@@ -1,10 +1,5 @@
 {{ attach_library('boulder_base/colorbox-image') }}
 
-{# {% set imageStyle = 'image_style-default' %}
-{% if content.field_media_image.0['#image_style']|render %}
-  {% set imageStyle = 'image_style-' ~ content.field_media_image.0['#image_style']|render %}
-{% endif %} #}
-
 {# Retrieve the image URL #}
 {% set image_url = file_url(content.field_media_image.0['#item'].entity.uri.value) %}
 

--- a/templates/media/media--image--colorbox-square.html.twig
+++ b/templates/media/media--image--colorbox-square.html.twig
@@ -8,16 +8,26 @@
 {# Retrieve the image URL #}
 {% set image_url = file_url(content.field_media_image.0['#item'].entity.uri.value) %}
 
+{# Retrieve the alt attribute #}
+{% set alt_text = content.field_media_image.0['#item'].alt %}
+
 {# Access the photo description directly from content #}
 {% set field_items = content.field_media_image_caption['#items'] %}
 {% if field_items %}
   {% set photoDescription = field_items.0.value|render|striptags|trim %}
+{% elseif alt_text %}
+  {% set photoDescription = alt_text %}
 {% else %}
-  {% set photoDescription = '' %}
+  {% set photoDescription = "" %}
 {% endif %}
 
-<div class="col gallery-item">
+{# Manually add alignment classes if they are not being applied automatically #}
+{% set alignment_class = attributes.hasClass('align-left') or attributes.hasClass('align-right') ? '' : 'align-left' %}
+
+{% if attributes != "" %}
+<div {{ attributes.addClass(alignment_class, 'col', 'gallery-item') }}>
   <a href="{{ image_url }}" class="glightbox ucb-gallery-lightbox" data-gallery="gallery{{ content['#block_content'].id() }}" data-glightbox="description: {{ photoDescription }} ">
     <img class="ucb-colorbox-square" src="{{ image_url }}" alt="{{ photoDescription }}" />
   </a>
 </div>
+{% endif %}


### PR DESCRIPTION
These changes affect `Colorbox Small - Square`, `Colorbox Small - Thumbnail`, `Colorbox Square`, and `Colorbox Small` image styles.

1. Previously the 4 Colorbox image styles would only use a caption for the lower description of the click to zoom functionality  that appears when zoomed. We have enabled a fallback such that if no caption is added, it will use the alt tag of the image. If no alt tag exists either, it will be blank. Resolves #1393 
2. The Colorbox Image float left and float right were not being applied due to these being 'snowflake' images using a different template to enable the click to zoom functionality. This has been corrected and should float left or right as expected. Resolves #1379 