### PR TITLE
Article List Page: Adds Reset button to Exposed Article List Filters and Minor Bug/QoL Fixes

### DIFF
--- a/css/ucb-article-list.css
+++ b/css/ucb-article-list.css
@@ -104,7 +104,12 @@
   align-items: center;
 }
 
-.form-submit-btn {
+.article-list-filter-form .form-submit-btn{
+  margin-right: 10px;
+}
+
+
+.article-list-filter-form .form-submit-btn, .article-list-filter-form .form-reset-btn {
   font-size: 11px;
   font-weight: 500;
   box-shadow: 0 1px 2px rgb(0 0 0 / 20%);


### PR DESCRIPTION
- Adds a Reset button to the user-accessible filters for Category and Tag on an Article List Page that will reset the component to the initial state
- Fixes a bug that could present when clicking Apply Filters with 'All Category' and 'All Tags' selected that could bring in additional outside Terms from what the component initialized with and originally filtered on. This seemed to happen if you clicked Apply Filters right as the component loaded, but has been corrected.
- Adds an error message for `No Results Found` if the provider returns any number of Articles with filters applied, but all those results get filtered out in the exclusion process. Previously there was not a case built for this with the new filters and a user could be presented with a blank component.

Resolves https://github.com/CuBoulder/tiamat-theme/issues/1406