### PR TITLE
Accordions: Fixes Accordions containing Columns Overflow

### DIFF
--- a/css/ucb-accordion-styles.css
+++ b/css/ucb-accordion-styles.css
@@ -382,6 +382,13 @@
 }
 
 /*** Flush Accordion Overrides (for ckeditor columns) ***/
-.accordion-body:has(.ucb-column-container) {
-  overflow: hidden;
+.accordion-body .row.ucb-column-container {
+  margin-left: 0px;
+  margin-right: 0px;
+}
+.accordion-body .row.ucb-column-container .col.ucb-column:first-of-type{
+  padding-left: 0px;
+}
+.accordion-body .row.ucb-column-container .col.ucb-column:last-of-type{
+  padding-right: 0px;
 }

--- a/css/ucb-accordion-styles.css
+++ b/css/ucb-accordion-styles.css
@@ -380,3 +380,8 @@
 .accordion-item:last-child {
   border-bottom: 0;
 }
+
+/*** Flush Accordion Overrides (for ckeditor columns) ***/
+.accordion-body:has(.ucb-column-container) {
+  overflow: hidden;
+}


### PR DESCRIPTION
Fixes visual issue where inserting a Column into an Accordion would cause a horizontal scrollbar to appear within the Accordion body. 

Resolves https://github.com/CuBoulder/tiamat-theme/issues/1421