### PR TITLE
Article Grid: Replaces styled square thumbnail image with wide image

### DIFF
--- a/css/block/ucb-article-grid-block.css
+++ b/css/block/ucb-article-grid-block.css
@@ -29,8 +29,3 @@
 .ucb-article-grid-summary {
   font-size: 85%;
 }
-
-.ucb-article-grid-card-img {
-  object-fit: cover !important;
-  aspect-ratio: 2/1;
-}

--- a/js/ucb-article-grid-block.js
+++ b/js/ucb-article-grid-block.js
@@ -68,8 +68,8 @@ class ArticleGridBlockElement extends HTMLElement {
       data.included
         .filter((item) => item.type === "file--file")
         .forEach((item) => {
-          altObj[item.id] = item.links.focal_image_square
-            ? item.links.focal_image_square.href
+          altObj[item.id] = item.links.focal_image_wide
+            ? item.links.focal_image_wide.href
             : item.attributes.uri.url;
         });
     }


### PR DESCRIPTION
Replaces the Article Grid Block's list of Article thumbnails with the `focal_image_wide` image style, which eliminates the need for applied CSS styles on the thumbnail verion, which was not consistent across browsers.

Previously the block was using a CSS styled version of the `focal_image_square` because our `UCB Focal Image Enable` module, which enables access to our variety of image styles via API, did not yet have access to the wide image style at the time of the Article Grid block's development. 

Resolves https://github.com/CuBoulder/tiamat-theme/issues/1403