### PR TITLE
Articles by Person: On/off toggle

### DIFF
--- a/templates/content/node--ucb-person.html.twig
+++ b/templates/content/node--ucb-person.html.twig
@@ -87,6 +87,7 @@
        </div>
     {% endif %}
     </div>
+    {% if content.field_ucb_articles_by_person[0]['#markup'] == '1' %}
     <div class="ucb-articles-by-person-block">
       <person-article-list base-uri="{{ baseurlJSON }}" nodeid="{{ node.id }}">
         <div id="ucb-person-article-block-title" style="display:none">
@@ -104,5 +105,6 @@
         </div>
       </person-article-list>
     </div>
+    {% endif %}
   </div>
 </article>


### PR DESCRIPTION
Adds an on / off toggle to make the Articles by Person block on a Person page optional.

Includes:
- theme => https://github.com/CuBoulder/tiamat-theme/pull/1437
- custom_entities => https://github.com/CuBoulder/tiamat-custom-entities/pull/186

Resolves https://github.com/CuBoulder/tiamat-theme/issues/1398