### PR TITLE
Webform: Adjusts max width at different column widths

### DIFF
--- a/css/ucb-form-page.css
+++ b/css/ucb-form-page.css
@@ -12,9 +12,14 @@
 }
 
 form .form-required::after {
-  display: inline-block; 
-  margin-inline: 0.15em; 
-  content: "*"; 
-  color: #f00; 
-  font-size: 0.875rem; 
-} 
+  display: inline-block;
+  margin-inline: 0.15em;
+  content: "*";
+  color: #f00;
+  font-size: 0.875rem;
+}
+
+/* Max sizing for full column, 50/50 and 33/66 use full width */
+.ucb-bootstrap-layout__row-width--12 .ucb-form-body{
+  max-width: 66.66%;
+}

--- a/templates/block/block--ucb-form.html.twig
+++ b/templates/block/block--ucb-form.html.twig
@@ -21,7 +21,7 @@
 		{{ title_suffix }}
 	<div class="container mb-4">
 		<div class="row">
-			<div class="col-sm-8">
+			<div class="ucb-form-body">
 				{{ content.body }}
 				<div class="form-page-webform">
 					{{ content.field_ucb_form_block }}


### PR DESCRIPTION
Fixes issue where webform blocks placed in Sections with column width 50/50 or 33/66 were too narrow. This was due to styles applied so the form would not span the full width on a single column container. 

Adjusted so that one column layout will continue to span the 66% of the container but smaller multi-column layouts span the entire width.

Resolves https://github.com/CuBoulder/tiamat-theme/issues/1440