### PR TITLE
Resolves special characters not rendering correctly in article title image captions

### DIFF
--- a/templates/content/node--ucb-article.html.twig
+++ b/templates/content/node--ucb-article.html.twig
@@ -145,8 +145,10 @@
             {{ label }}
           </h1>
         {% endif %}
-        {% if content.field_article_header_image_text|render %}
-          <p class="ucb-article-supplemental-text">{{ content.field_article_header_image_text|render|striptags|trim }}</p>
+        {% if content.field_article_header_image_text %}
+          <p class="ucb-article-supplemental-text">
+            {{ content.field_article_header_image_text.0['#context'].value }}
+          </p>
         {% endif %}
         <div role="contentinfo" class="ucb-article-meta">
           {% if showDate %}


### PR DESCRIPTION
This update:

- Removes instance of `render|striptags|trim` from article title image caption template.

[bug, severity:minor] Resolves CuBoulder/tiamat-theme#1459