### PR TITLE
Video Hero Unit Content Padding

### DIFF
--- a/templates/block/block--video-hero-unit.html.twig
+++ b/templates/block/block--video-hero-unit.html.twig
@@ -94,7 +94,7 @@
     {% endif %}
     {% set linkColor = content['#block_content'].field_link_color.value %}
     {# Dont let twig render the links #}
-    <div class="ucb-hero-unit-content container">
+    <div class="ucb-hero-unit-content container" style="padding-top: {{ content.field_hero_top_padding }}; padding-bottom: {{ content.field_hero_bottom_padding }};">
       <div class="row">
         {% if content['#block_content'].field_text_align.value == "text-righthalf" %}
           <div class="col-12 col-md-6"></div>

--- a/templates/field/field--block-content--field-hero-bottom-padding.html.twig
+++ b/templates/field/field--block-content--field-hero-bottom-padding.html.twig
@@ -1,0 +1,10 @@
+{#
+/**
+ * @file
+ * Theme override for Hero Unit Block Field
+ *
+ */
+#}
+{% for item in items %}
+  {{ item.content }}px
+{% endfor %}

--- a/templates/field/field--block-content--field-hero-top-padding.html.twig
+++ b/templates/field/field--block-content--field-hero-top-padding.html.twig
@@ -1,0 +1,10 @@
+{#
+/**
+ * @file
+ * Theme override for Hero Unit Block Field
+ *
+ */
+#}
+{% for item in items %}
+  {{ item.content }}px
+{% endfor %}


### PR DESCRIPTION
Adding content padding for the video hero unit to extend height more easily for users. 
Overrides css with inline style.

Options were added in the Design tab

Sister PR: https://github.com/CuBoulder/tiamat-custom-entities/pull/193

Resolves #1477 