### PR TITLE
Adds missing regions to search pages

### DIFF
--- a/templates/layout/page--search.html.twig
+++ b/templates/layout/page--search.html.twig
@@ -47,19 +47,12 @@
  */
 #}
 
-{{ attach_library('boulder_base/ucb-search-page') }}
-
-<div class="layout-container ucb-page-container">
-  {{ block("page_header", "page.html.twig") }}
-  <div{{ create_attribute({ class: ['ucb-page-content', ucb_heading_font == 'normal' ? 'ucb-heading-font-normal'] }) }}>
-    {{ page.highlighted }}
-    {{ page.help }}
-    <main role="main">
-      <div class="ucb-content-wrapper ucb-search-page-content container">
-        <h1>Search</h1>
-        {{ page.content }}
-      </div>
-    </main>
+{% extends 'page.html.twig' %}
+{% block breadcrumb_region %}{% endblock %}
+{% block content %}
+  {{ attach_library('boulder_base/ucb-search-page') }}
+  <div class="container ucb-content-wrapper ucb-search-page-content ucb-contained-row">
+    <h1>Search</h1>
+    {{ page.content }}
   </div>
-  {{ block("page_footer", "page.html.twig") }}
-</div>
+{% endblock %}

--- a/templates/layout/page.html.twig
+++ b/templates/layout/page.html.twig
@@ -209,11 +209,13 @@
 
   {# MAIN PAGE CONTENT #}
   <div{{ create_attribute({ class: ['ucb-page-content', ucb_heading_font == 'normal' ? 'ucb-heading-font-normal'] }) }}>
-    {% if (show_breadcrumb) and (page.breadcrumb|render|striptags|trim|length > 0) %}
-      <div class="ucb-breadcrumb-region">
-        {{ page.breadcrumb }}
-      </div>
-    {% endif %}
+    {% block breadcrumb_region %}
+      {% if show_breadcrumb and page.breadcrumb|render|striptags|trim|length > 0 %}
+        <div class="ucb-breadcrumb-region">
+          {{ page.breadcrumb }}
+        </div>
+      {% endif %}
+    {% endblock %}
 
     {{ page.highlighted }}
 
@@ -254,7 +256,7 @@
                     {{ page.sidebar }}
                   </div>
                   <div class="ucb-layout-main col-12 col-lg-8 ucb-has-sidebar">
-                    {{ page.content }}
+                    {{ block('content') }}
                   </div>
                 </div>
               </div>
@@ -262,7 +264,7 @@
               <div class="ucb-layout-container ucb-sidebar-container container">
                 <div class="layout-row row">
                   <div class="ucb-layout-main col-12 col-lg-8 ucb-has-sidebar">
-                    {{ page.content }}
+                    {{ block('content') }}
                   </div>
                   <div class="ucb-left-right ucb-sidebar col-12 col-lg-4">
                     {{ page.sidebar }}
@@ -272,7 +274,9 @@
             {% endif %}
           {% else %}
             <div class="clearfix">
-              {{ page.content }}
+              {% block content %}
+                {{ page.content }}
+              {% endblock %}
             </div>
           {% endif %}
         {% endblock %}
@@ -309,8 +313,7 @@
   {% block page_footer %}
     <footer class="ucb-homepage-footer background-black">
       {% if page.footer|render or ucb_footer_menu_default_links %}
-        <div
-          class="ucb-footer-top">
+        <div class="ucb-footer-top">
           {# {% if page.footer_cta|render %}
           <div class="ucb-footer-container footer-cta-block container">
           {{ page.footer_cta }}


### PR DESCRIPTION
Previously, some regions were missing from search pages, such as the sidebar regions. This update adds those regions to search pages to match our other pages, allowing blocks to be placed in the sidebar using block layout. This fix is needed ASAP for the homepage site.

[bug] Resolves CuBoulder/tiamat-theme#1453