### PR TITLE
Update Homepage Footer

### DIFF
--- a/templates/regions/region--site-information.html.twig
+++ b/templates/regions/region--site-information.html.twig
@@ -37,11 +37,10 @@
         <div class="ucb-footer" style="width: 100%;">
           <p><a href="https://www.colorado.edu"><img alt="Be Boulder." class="ucb-footer-be-boulder" src="https://cdn.colorado.edu/static/brand-assets/live/images/be-boulder-white.svg" style="max-width:320px; height:auto;"></a></p>
           {{ content }}
-          <p><a class="ucb-home-link" href="https://www.colorado.edu">University of Colorado Boulder</a></p>
           <p>&copy; Regents of the University of Colorado</p>
           <p class="ucb-info-footer-links"><a href="https://www.colorado.edu/compliance/policies/privacy-statement">Privacy</a> &bull; <a href="https://www.colorado.edu/about/legal-trademarks">Legal &amp; Trademarks</a> &bull; <a href="https://www.colorado.edu/map">Campus Map</a></p>
-          <p class="ucb-info-footer-links mb-3"><a href="https://www.colorado.edu/accessibility" class="">Accessibility</a>&nbsp;•&nbsp;<a href="https://www.colorado.edu/about/your-right-know">Student Consumer Information</a>&nbsp;• <a href="https://www.colorado.edu/land-acknowledgment">Land Acknowledgement</a> •&nbsp;<a href="https://www.colorado.edu/policies">Policies</a>&nbsp;• <a href="https://www.colorado.edu/jobs">CU Boulder Jobs</a></p>
-          <p>Download the&nbsp;<strong><a href="https://www.colorado.edu/node/5273/attachment">Clery Act Annual Security &amp;&nbsp;Fire safety report</a></strong>,&nbsp;or&nbsp;<strong><a href="https://www.colorado.edu/police/clery">request a paper&nbsp;copy</a></strong>&nbsp;from&nbsp;the CU&nbsp;Boulder&nbsp;<strong><a href="https://www.colorado.edu/police/">Police Department</a></strong>. &nbsp;</p>
+          <p class="ucb-info-footer-links mb-3"><a href="https://www.colorado.edu/accessibility" class="">Accessibility</a>&nbsp;•&nbsp;<a href="https://www.colorado.edu/your-right-know">Student Consumer Information</a>&nbsp;• <a href="https://www.colorado.edu/about/land-acknowledgment">Land Acknowledgement</a> •&nbsp;<a href="https://www.colorado.edu/policies">Policies</a>&nbsp;• <a href="https://www.colorado.edu/jobs">CU Boulder Jobs</a></p>
+          <p>Download the&nbsp;<strong><a href="https://www.colorado.edu/clery/annual-security-fire-safety-report-asfsr">Clery Act Annual Security &amp;&nbsp;Fire safety report</a></strong>,&nbsp;or&nbsp;<strong><a href="https://www.colorado.edu/police/data-dashboards">request a paper&nbsp;copy</a></strong>&nbsp;from&nbsp;the CU&nbsp;Boulder&nbsp;<strong><a href="https://www.colorado.edu/police/">Police Department</a></strong>. &nbsp;</p>
         </div>
       </div>
         <div class="ucb-footer-print">


### PR DESCRIPTION
Removal of the `ucb-home-link` as the `{{ content }}` generates that link properly for the homepage.

This also means we do not hide the Site Contact Info Footer in the Block Layout. The homepage is currently configured this way so that's no worry there. When they add social media links they'll just need to make sure that it is the first item in the Site Information region to stack properly.

Updated various links to the new ones provided by Wendy

Resolves #1493 