### PR TITLE
Article Feature: Fixes aspect ratio for Wide images

### DIFF
--- a/css/block/ucb-article-feature-block.css
+++ b/css/block/ucb-article-feature-block.css
@@ -92,6 +92,11 @@
   max-width: 100%;
 }
 
+.feature-img-wide{
+  aspect-ratio: 16 / 9;
+  object-fit: cover;
+}
+
 .ucb-stacked-secondary-container > .ucb-article-card {
   margin-bottom: 0px;
   border-bottom: none;


### PR DESCRIPTION
Previously Article Feature Blocks with the Image Size set to `Wide (slider image style)` would come through as 3:2 aspect ratio rather than 16:9, which is used for the slider. 

Resolves https://github.com/CuBoulder/tiamat-theme/issues/1501