### PR TITLE
Modify Image Styles in Content Rows

### DIFF
--- a/templates/block/block--content-row.html.twig
+++ b/templates/block/block--content-row.html.twig
@@ -197,7 +197,7 @@
               <img alt="{{ item.entity.field_row_layout_content_image.entity.field_media_image.alt }}" class="ucb-content-row-img-lg" src="{{ item.entity.field_row_layout_content_image.entity.field_media_image.entity.fileuri|image_style('focal_image_teaser_wide') }}"></img>
             </a>
           {% else %}
-            {{ image|view }}
+            <img alt="{{ item.entity.field_row_layout_content_image.entity.field_media_image.alt }}" class="ucb-content-row-img-lg" src="{{ item.entity.field_row_layout_content_image.entity.field_media_image.entity.fileuri|image_style('focal_image_teaser_wide') }}"></img>
           {% endif %}
         </div>
         {% endif %}

--- a/templates/block/block--content-row.html.twig
+++ b/templates/block/block--content-row.html.twig
@@ -68,10 +68,10 @@
           <div class="col-sm-5 col-xs-12 row-image-container-lg">
             {% if rowLink %}
               <a role="presentation" aria-hidden="true" href="{{ rowLink }} ">
-                <img alt="{{ item.entity.field_row_layout_content_image.entity.field_media_image.alt }}" class="ucb-content-row-img-lg" src="{{ item.entity.field_row_layout_content_image.entity.field_media_image.entity.fileuri|image_style('focal_image_wide') }}"></img>
+                <img alt="{{ item.entity.field_row_layout_content_image.entity.field_media_image.alt }}" class="ucb-content-row-img-lg" src="{{ item.entity.field_row_layout_content_image.entity.field_media_image.entity.fileuri|image_style('focal_image_teaser_wide') }}"></img>
               </a>
             {% else %}
-              <img alt="{{ item.entity.field_row_layout_content_image.entity.field_media_image.alt }}" class="ucb-content-row-img-lg" src="{{ item.entity.field_row_layout_content_image.entity.field_media_image.entity.fileuri|image_style('focal_image_wide') }}"></img>
+              <img alt="{{ item.entity.field_row_layout_content_image.entity.field_media_image.alt }}" class="ucb-content-row-img-lg" src="{{ item.entity.field_row_layout_content_image.entity.field_media_image.entity.fileuri|image_style('focal_image_teaser_wide') }}"></img>
             {% endif %}
           </div>
           {% else %}
@@ -194,7 +194,7 @@
         <div class="col-lg-4 col-md-6 col-sm-12 row-image-container-lg">
           {% if rowLink %}
             <a role="presentation" aria-hidden="true" href="{{ rowLink }} ">
-              <img alt="{{ item.entity.field_row_layout_content_image.entity.field_media_image.alt }}" class="ucb-content-row-img-lg" src="{{ item.entity.field_row_layout_content_image.entity.field_media_image.entity.fileuri|image_style('focal_image_wide') }}"></img>
+              <img alt="{{ item.entity.field_row_layout_content_image.entity.field_media_image.alt }}" class="ucb-content-row-img-lg" src="{{ item.entity.field_row_layout_content_image.entity.field_media_image.entity.fileuri|image_style('focal_image_teaser_wide') }}"></img>
             </a>
           {% else %}
             {{ image|view }}


### PR DESCRIPTION
Updated content rows so that teasers are using the correct image style with the right 2:1 ratio.
A new image style was created to support this update. 
There was also a bug with the code in which the large teasers would display as squares if the rows were unlinked. That has been updated to show correctly as wide.

Sister PR: https://github.com/CuBoulder/tiamat-custom-entities/pull/196

Resolves #1503 