### PR TITLE
Newsletters: Bug Fixes, Layout Adjustments

### DIFF
--- a/templates/content/node--newsletter--email-html.html.twig
+++ b/templates/content/node--newsletter--email-html.html.twig
@@ -130,6 +130,9 @@
             <meta name="supported-color-schemes" content="light">
             <meta name="color-scheme" content="only">
             <meta name="supported-color-scheme" content="only">
+            {# This should override image issues on IOS #}
+            <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+            <meta name="x-apple-disable-message-reformatting">
             {# This should override Outlook on Mac #}
             <style type="text/css">
               .body, .darkmode, .darkmode div { /* With class body on the body tag, and all elements represented here that have a background color */

--- a/templates/content/node--newsletter--email-html.html.twig
+++ b/templates/content/node--newsletter--email-html.html.twig
@@ -483,7 +483,7 @@
                                 <tr>
                                   <td style="width:50%;padding: 20px;padding-left:10px; text-align:left; font-family: Helvetica, Arial, sans-serif; font-weight: normal; line-height: 12px; margin: 0; font-size: 12px; width: 50%; {{boxBackground}}">{{ node.created.value|date("M. j, Y") }}</td>
                                   <td style="line-height: 12px; margin: 0; font-size: 12px; width:50%;padding-right:10px;text-align:right;">
-                                    <a style="text-wrap:nowrap{{aStyles}}" href="https://www.colorado.edu/cwa/cwa/newsletter/cwanews/september-newsletter">View on website</a>
+                                    <a style="text-wrap:nowrap{{aStyles}}" href="{{base_url}}{{ path('entity.node.canonical', {'node': node.id}) }}">View on website</a>
                                   </td>
                                 </tr>
                               </table>

--- a/templates/content/node--newsletter--email-html.html.twig
+++ b/templates/content/node--newsletter--email-html.html.twig
@@ -86,7 +86,7 @@
     {% set divStyles = 'background-color: black; color: #fff;margin:auto;' %}
     {% set aStyles = 'color: #cfb87b;;' %}
     {% set pStyles = 'color:#222330;' %}
-    {% set headerStyles = 'width:100%; color:white;margin-bottom:50px;' %}
+    {% set headerStyles = 'width:100%; color:white;' %}
     {# padding: 15px 25px; #}
     {% set footerStyles = 'color:white;border-top: solid 1px #cccccc;' %}
     {% set cuLogoSrc = cuLogoLight %}
@@ -147,6 +147,10 @@
             .ucb-email-header-darkbox a,
             .ucb-email-footer-darkbox a {
               color: #cfb87b;
+            }
+            .ucb-email-footer-lightbox a,
+            .ucb-email-footer-minimal {
+              color: #0277BD;
             }
             .ucb-email-header-classic a:hover,
             .ucb-email-footer-classic a:hover,
@@ -501,11 +505,12 @@
                 <tbody>
                     <td>
                         <td>
+                          {% if content.field_newsletter_intro_image|render or content.field_newsletter_intro_body|render%}
                             <table role="presentation" border="0" width="600" cellspacing="0" style="text-align: left; vertical-align: top; width: 100%; color: #222222; font-family: Helvetica, Arial, sans-serif; padding-bottom:20px;font-weight: normal; margin: 0; font-size: 14px; background-color: white;{{classicTableOffset}}">
+                              {% if content.field_newsletter_intro_image|render %}
                                 <tr>
                                   <td align="center">
                                 <!-- Intro Img -->
-                                    {% if content.field_newsletter_intro_image|render %}
                                     <table role="presentation" border="0" cellspacing="0" cellpadding="0" style="border-collapse: collapse; width: 600px;">
                                       <tr>
                                         <td style="padding: 0; text-align: center; width: 600px;">
@@ -518,18 +523,19 @@
                                         </td>
                                       </tr>
                                     </table>
-                                    {% endif %}
-                                    </td>
+                                  </td>
                                 </tr>
+                                {% endif %}
+                                {% if content.field_newsletter_intro_body|render %}
                                 <tr>
                                     <td>
                                     <!-- Intro Text-->
-                                    {% if content.field_newsletter_intro_body|render %}
                                     <div id="newsletter-intro-body">{{ content.field_newsletter_intro_body }}</div>
-                                    {% endif %}
-                                    </td>
+                                  </td>
                                 </tr>
+                                {% endif %}
                             </table>
+                          {% endif %}
                         <!--Second table-->
                         {% if content.field_newsletter_section_block|render %}
                         <!--Newsletter Section-->
@@ -716,7 +722,7 @@
                             <table align="center" width="600" style="max-width:600px;{{boxBackground}}">
                                 <tbody style="max-width:600px;{{boxBackground}}">
                                     <tr style="max-width:600px;{{boxBackground}}">
-                                    <td style="max-width:600px;{{boxBackground}} text-align:center;">
+                                    <td class="ucb-email-footer-content" style="max-width:600px;{{boxBackground}} text-align:center;">
                                         {{node.field_newsletter_type.entity.field_newsletter_footer.0.processed}}
                                     </td>
                                 </tr>

--- a/templates/content/node--newsletter--email-html.html.twig
+++ b/templates/content/node--newsletter--email-html.html.twig
@@ -50,6 +50,8 @@
 {% set addtlPad = '' %}
 {% set classicStyle = "margin-bottom: 20px; width:95%" %}
 {% set classicTableOffset = 'border-collapse: collapse; border-spacing: 0; padding: 0;' %}
+{% set addtlPadding = '' %}
+{% set addtlImgPadding = '' %}
 
 {# CU LOGO #}
 {% set cuLogoDark = base_url ~ '/' ~  base_path ~ directory ~ '/images/cu-boulder-logo-text-black.gif' %}
@@ -64,8 +66,8 @@
 {% set pStyles = 'color:black;' %}
 {% set headerStyles = 'width:100%;background-color: black; padding-bottom:10px;' %}
 {% set classicTableOffset = 'margin-top: -50px;padding:10px;' %}
+{% set addtlPadding = 'padding-bottom:50px;'%}
 {% set footerStyles = 'border-top: solid 1px #cccccc;'%}
-{# padding: 15px 25px; #}
 {% set footerStyles = 'background-color: black !important; padding-top:20px;border-top: solid 1px #cccccc;' %}
 {% set cuLogoSrc = cuLogoLight %}
 {% set classicImgOffset = 'width:100%'%}
@@ -76,7 +78,7 @@
     {% set divStyles = 'background-color: #FFFFFF;margin:auto;' %}
     {% set aStyles = 'color: #0277BD;text-decoration: none;' %}
     {% set pStyles = 'color:black;' %}
-    {% set headerStyles = 'width:100%; color:black;padding-bottom:20px;' %}
+    {% set headerStyles = 'width:100%; color:black;' %}
     {# padding: 15px 25px; #}
     {% set footerStyles = 'color:black;border-top: solid 1px #cccccc;' %}
     {% set cuLogoSrc = cuLogoDark %}
@@ -92,7 +94,7 @@
     {% set cuLogoSrc = cuLogoLight %}
     {% set emailBackground = 'background-color:white;' %}
     {% set boxBackground = 'background-color:black;'%}
-    {% set addtlPad = 'padding-top:20px;' %}
+    {% set addtlPad = 'padding-top:10px;' %}
 
 {# Lightbox #}
 {% elseif designType == 'lightbox' %}
@@ -105,20 +107,22 @@
     {% set cuLogoSrc = cuLogoDark %}
     {% set emailBackground = 'background-color:white;' %}
     {% set boxBackground = 'background-color:white;'%}
-    {% set addtlPad = 'padding-top:20px;' %}
+    {% set addtlPad = 'padding-top:10px;' %}
 
 {# Simple #}
 {% else %}
 {% set divStyles = 'background-color: #fff; color: #fff;' %}
 {% set aStyles = 'color: #cfb87b;text-decoration: none;' %}
 {% set pStyles = 'color:black;' %}
-{% set headerStyles = 'width:100%;background-color: black;padding-bottom:20px;' %}
+{% set headerStyles = 'width:100%;background-color: black;' %}
 {# padding: 15px 25px; #}
 {% set footerStyles = 'background-color: black; padding-top:20px;border-top: solid 1px #cccccc;' %}
 {% set cuLogoSrc = cuLogoLight %}
 {% set boxBackground = 'background-color:black;'%}
 {% set classicImgOffset = 'padding: 10px; background: white;'%}
 {% set emailBackground = 'background-color:black;' %}
+{% set addtlPad = 'padding-top:10px;' %}
+
 
 {% endif %}
 
@@ -141,6 +145,11 @@
               .darkmode p { /* Add other selectors for other text elements */
                   -webkit-text-fill-color: #000000 !important;
               }
+
+            body {
+              margin: 0;
+            }
+
             </style>
             <style>
             .ucb-email-header-classic a,
@@ -180,9 +189,6 @@
 
             #email .ucb-email-body-content.ucb-email-body-content-td a{
               text-decoration: none !important;
-            }
-
-            #ucb-email-body center center a{
               color: #0277BD !important;
             }
 
@@ -470,7 +476,7 @@
                     <td style='{{headerStyles}}'>
                       {# NEW #}
                       <center>
-                        <table width="600" style="width:100%;{{boxBackground}};{{headerStyles}}; padding-bottom:50px;">
+                        <table width="600" style="width:100%;{{boxBackground}}{{headerStyles}}{{addtlPadding}}">
                           <tr>
                             <td style="width:100%;{{boxBackground}};">
                               <table width="600" role="presentation" align="center" style="max-width:600px;">
@@ -524,7 +530,7 @@
                                 <!-- Intro Img -->
                                     <table role="presentation" border="0" cellspacing="0" cellpadding="0" style="border-collapse: collapse; width: 600px;">
                                       <tr>
-                                        <td style="padding: 0; text-align: center; width: 600px;">
+                                        <td style="padding: 0; text-align: center; width: 600px;{{addtlImgPadding}}">
                                           <img
                                             id="newsletter-email-intro-img"
                                             src="{{base_domain}}{{file_url(node.field_newsletter_intro_image.entity.field_media_image.entity.fileuri)}}"

--- a/templates/content/node--newsletter--email-html.html.twig
+++ b/templates/content/node--newsletter--email-html.html.twig
@@ -60,7 +60,7 @@
 {% if designType == 'classic' %}
 {% set classicStyle = 'background: white;margin-top: -50px;'%}
 {% set divStyles = 'background-color: #fff; color: #fff;' %}
-{% set aStyles = 'color: #cfb87b;' %}
+{% set aStyles = 'color: #cfb87b;text-decoration: none;' %}
 {% set pStyles = 'color:black;' %}
 {% set headerStyles = 'width:100%;background-color: black; padding-bottom:10px;' %}
 {% set classicTableOffset = 'margin-top: -50px;padding:10px;' %}
@@ -74,7 +74,7 @@
 {# Minimal #}
 {% elseif designType == 'minimal' %}
     {% set divStyles = 'background-color: #FFFFFF;margin:auto;' %}
-    {% set aStyles = 'color: #0277BD;' %}
+    {% set aStyles = 'color: #0277BD;text-decoration: none;' %}
     {% set pStyles = 'color:black;' %}
     {% set headerStyles = 'width:100%; color:black;padding-bottom:20px;' %}
     {# padding: 15px 25px; #}
@@ -84,7 +84,7 @@
 {# Darkbox #}
 {% elseif designType == 'darkbox' %}
     {% set divStyles = 'background-color: black; color: #fff;margin:auto;' %}
-    {% set aStyles = 'color: #cfb87b;;' %}
+    {% set aStyles = 'color: #cfb87b;text-decoration: none;' %}
     {% set pStyles = 'color:#222330;' %}
     {% set headerStyles = 'width:100%; color:white;' %}
     {# padding: 15px 25px; #}
@@ -97,7 +97,7 @@
 {# Lightbox #}
 {% elseif designType == 'lightbox' %}
     {% set divStyles = 'background-color: #E9E9E9;margin:auto;' %}
-    {% set aStyles = 'color: #0277BD;' %}
+    {% set aStyles = 'color: #0277BD;text-decoration: none;' %}
     {% set pStyles = ' color: #222330;' %}
     {% set headerStyles = 'width:100%; color:black;' %}
     {# padding: 15px 25px; #}
@@ -110,7 +110,7 @@
 {# Simple #}
 {% else %}
 {% set divStyles = 'background-color: #fff; color: #fff;' %}
-{% set aStyles = 'color: #cfb87b;' %}
+{% set aStyles = 'color: #cfb87b;text-decoration: none;' %}
 {% set pStyles = 'color:black;' %}
 {% set headerStyles = 'width:100%;background-color: black;padding-bottom:20px;' %}
 {# padding: 15px 25px; #}
@@ -176,6 +176,14 @@
 
             #email h2{
               font-size: 20px;
+            }
+
+            #email .ucb-email-body-content.ucb-email-body-content-td a{
+              text-decoration: none !important;
+            }
+
+            #ucb-email-body center center a{
+              color: #0277BD !important;
             }
 
             a[x-apple-data-detectors] {
@@ -490,7 +498,7 @@
                                 <tr>
                                   <td style="width:50%;padding: 20px;padding-left:10px; text-align:left; font-family: Helvetica, Arial, sans-serif; font-weight: normal; line-height: 12px; margin: 0; font-size: 12px; width: 50%; {{boxBackground}}">{{ node.created.value|date("M. j, Y") }}</td>
                                   <td style="line-height: 12px; margin: 0; font-size: 12px; width:50%;padding-right:10px;text-align:right;">
-                                    <a style="text-wrap:nowrap{{aStyles}}" href="{{base_url}}{{ path('entity.node.canonical', {'node': node.id}) }}">View on website</a>
+                                    <a style="text-wrap:nowrap;text-decoration: none;{{aStyles}}" href="{{base_url}}{{ path('entity.node.canonical', {'node': node.id}) }}">View on website</a>
                                   </td>
                                 </tr>
                               </table>
@@ -507,7 +515,7 @@
             <table width="600" style="max-width:600px;" align="center">
                 <tbody>
                     <td>
-                        <td>
+                        <td class="ucb-email-body-content ucb-email-body-content-td">
                           {% if content.field_newsletter_intro_image|render or content.field_newsletter_intro_body|render%}
                             <table role="presentation" border="0" width="600" cellspacing="0" style="text-align: left; vertical-align: top; width: 100%; color: #222222; font-family: Helvetica, Arial, sans-serif; padding-bottom:20px;font-weight: normal; margin: 0; font-size: 14px; background-color: white;{{classicTableOffset}}">
                               {% if content.field_newsletter_intro_image|render %}
@@ -716,7 +724,7 @@
          <!--Site Link-->
                   <tr style="{{boxBackground}}">
                     <td style="text-align: center">
-                      <a style="font-family: Helvetica, Arial, sans-serif;line-height: 19px; margin: 0; font-size: 18px; font-weight:bold;text-align: center;{{aStyles}}" href="{{base_domain}}">{{ site_name }}
+                      <a style="font-family: Helvetica, Arial, sans-serif;line-height: 19px; margin: 0; font-size: 18px; font-weight:bold;text-align: center;text-decoration:none;{{aStyles}}" href="{{base_domain}}">{{ site_name }}
                       </a>
                     </td>
                   </tr>

--- a/templates/content/node--newsletter--email-html.html.twig
+++ b/templates/content/node--newsletter--email-html.html.twig
@@ -619,56 +619,71 @@
                                 {% endif %}
                             {% endfor %}
 
-                            {# Render the blocks side by side #}
-                            {# Check if there are blocks to render #}
-                            {% if blocksToRender %}
-                                <table role="presentation" border="0" cellspacing="0" cellpadding="0" width="100%" style="border-collapse: collapse; margin: 0 auto; width: 100%; max-width: 600px; text-align: center; font-family: Helvetica, Arial, sans-serif; font-size: 14px; background-color: white;" class="row row-content ucb-newsletter-blocks">
-                                    <tbody>
-                                        <tr>
-                                            <td align="center" valign="top" style="padding: 0;">
+{# Render the blocks side by side #}
+{# Check if there are blocks to render #}
+{% if blocksToRender %}
+    <table role="presentation" border="0" cellspacing="0" cellpadding="0" width="100%" style="border-collapse: collapse; margin: 0 auto; width: 100%; max-width: 600px; text-align: center; font-family: Helvetica, Arial, sans-serif; font-size: 14px; background-color: white;" class="row row-content ucb-newsletter-blocks">
+        <tbody>
+            <tr>
+                <td align="center" valign="top" style="padding: 0;">
+                    {# Wrapper table for layout #}
+                    <table role="presentation" border="0" cellspacing="0" cellpadding="0" style="border-collapse: collapse; width: 100%; max-width: 600px; table-layout: fixed;">
+                        <tbody>
+                            {% for i in 0..(blocksToRender|length - 1) %}
+                                {# If there's only one block, make it take up the full width #}
+                                {% if blocksToRender|length == 1 %}
+                                    <tr>
+                                        <td align="left" valign="top" style="width: 100%; padding: 10px; box-sizing: border-box; vertical-align: top;">
+                                            <table role="presentation" border="0" cellspacing="0" cellpadding="0" style="border-collapse: collapse; width: 100%; table-layout: fixed;">
+                                                <tr>
+                                                    <td style="vertical-align: top; color: #000000;">
+                                                        {{ blocksToRender[i] }}
+                                                    </td>
+                                                </tr>
+                                            </table>
+                                        </td>
+                                    </tr>
+                                {% else %}
+                                    {% if loop.index is odd %}
+                                    <tr>
+                                    {% endif %}
 
-                                                {# Wrapper table for layout #}
-                                                <table role="presentation" border="0" cellspacing="0" cellpadding="0" style="border-collapse: collapse; width: 100%; max-width: 600px; table-layout: fixed;">
-                                                    <tbody>
-                                                        {% for i in 0..(blocksToRender|length - 1) %}
-                                                            {% if loop.index is odd %}
-                                                            <tr>
-                                                            {% endif %}
+                                    <td align="left" valign="top" style="width: 50%; padding: 10px; box-sizing: border-box; vertical-align: top;">
+                                        <table role="presentation" border="0" cellspacing="0" cellpadding="0" style="border-collapse: collapse; width: 100%; table-layout: fixed;">
+                                            <tr>
+                                                <td style="padding: 10px; vertical-align: top; color: #000000;">
+                                                    {{ blocksToRender[i] }}
+                                                </td>
+                                            </tr>
+                                        </table>
+                                    </td>
 
-                                                            <td align="left" valign="top" style="width: 50%; padding: 10px; box-sizing: border-box; vertical-align: top;">
-                                                                <table role="presentation" border="0" cellspacing="0" cellpadding="0" style="border-collapse: collapse; width: 100%; table-layout: fixed;">
-                                                                    <tr>
-                                                                        <td style="padding: 10px; vertical-align: top; color: #000000;">
-                                                                            {{ blocksToRender[i] }}
-                                                                        </td>
-                                                                    </tr>
-                                                                </table>
-                                                            </td>
+                                    {# Add filler block if it's the last block in an odd-numbered list #}
+                                    {% if loop.last and loop.index is odd %}
+                                    <td align="left" valign="top" style="width: 50%; padding: 10px; box-sizing: border-box; vertical-align: top;">
+                                        <table role="presentation" border="0" cellspacing="0" cellpadding="0" style="border-collapse: collapse; width: 100%; table-layout: fixed;">
+                                            <tr>
+                                                <td style="padding: 10px; vertical-align: top; color: #000000;">
+                                                    &nbsp; {# Empty filler block #}
+                                                </td>
+                                            </tr>
+                                        </table>
+                                    </td>
+                                    {% endif %}
 
-                                                            {# Add filler block if it's the last block in an odd-numbered list #}
-                                                            {% if loop.last and loop.index is odd %}
-                                                            <td align="left" valign="top" style="width: 50%; padding: 10px; box-sizing: border-box; vertical-align: top;">
-                                                                <table role="presentation" border="0" cellspacing="0" cellpadding="0" style="border-collapse: collapse; width: 100%; table-layout: fixed;">
-                                                                    <tr>
-                                                                        <td style="padding: 10px; vertical-align: top; color: #000000;">
-                                                                            &nbsp; {# Empty filler block #}
-                                                                        </td>
-                                                                    </tr>
-                                                                </table>
-                                                            </td>
-                                                            {% endif %}
+                                    {% if loop.index is even or loop.last %}
+                                    </tr>
+                                    {% endif %}
+                                {% endif %}
+                            {% endfor %}
+                        </tbody>
+                    </table>
+                </td>
+            </tr>
+        </tbody>
+    </table>
+{% endif %}
 
-                                                            {% if loop.index is even or loop.last %}
-                                                            </tr>
-                                                            {% endif %}
-                                                        {% endfor %}
-                                                    </tbody>
-                                                </table>
-                                            </td>
-                                        </tr>
-                                    </tbody>
-                                </table>
-                            {% endif %}
 
 
 
@@ -723,7 +738,7 @@
                 <tbody style="{{boxBackground}}">
          <!--Site Link-->
                   <tr style="{{boxBackground}}">
-                    <td style="text-align: center">
+                    <td style="text-align: center; text-align: center; padding-top:10px;">
                       <a style="font-family: Helvetica, Arial, sans-serif;line-height: 19px; margin: 0; font-size: 18px; font-weight:bold;text-align: center;text-decoration:none;{{aStyles}}" href="{{base_domain}}">{{ site_name }}
                       </a>
                     </td>

--- a/templates/paragraphs/paragraph--newsletter-section--email-html.html.twig
+++ b/templates/paragraphs/paragraph--newsletter-section--email-html.html.twig
@@ -9,7 +9,7 @@
 #}
 
 
-{% set base_url = url('<front>', {'absolute': true})|trim('/') %}
+{% set base_url = url('<front>')|render|split('/', -1)|join('/') %}
 <table role="presentation"  border="0" width="600" cellspacing="0" style="border-collapse: collapse; border-spacing: 0; text-align: left; vertical-align: top; width: 100%; color: #222222; font-family: Helvetica, Arial, sans-serif; font-weight: normal; line-height: 19px; margin: 0; font-size: 14px; background-color: white;">
 	<tbody>
   		<tr>
@@ -78,7 +78,7 @@
 					<tr id="feature-article-title-email-{{key}}">
 						<td align="center" style="font-size:18px;text-align: left; padding-right:10px; padding-left:10px"align="center" style="text-align: left; padding-right:10px; padding-left:10px">
 							<h3>
-								<a href="{{base_url}}{{ path('entity.node.canonical', {'node': item.entity.field_newsletter_article_select.target_id}) }}">
+								<a style="text-decoration: none;" href="{{base_url}}{{ path('entity.node.canonical', {'node': item.entity.field_newsletter_article_select.target_id}) }}">
 									{{ item.entity.field_newsletter_article_select.entity.title.value|render|striptags|trim }}
 								</a>
 							</h3>
@@ -94,7 +94,7 @@
 							<tr id="feature-article-user-title-email-{{ key }}">
 								<td align="center" style="text-align: left; padding-right:10px; padding-left:10px">
 									<h3>
-										<a class="ucb-newsletter-content-title" href="{{ final_url }}">
+										<a style="text-decoration: none;" class="ucb-newsletter-content-title" href="{{ final_url }}">
 											{{ item.entity.field_newsletter_content_title|view }}
 										</a>
 									</h3>
@@ -206,7 +206,7 @@
 													{% if item.entity.field_newsletter_article_select.entity.title.value|render %}
 													<td>
 														<h3 style="font-size: 18px;">
-														<a href="{{base_url}}{{ path('entity.node.canonical', {'node': item.entity.field_newsletter_article_select.target_id}) }}">
+														<a style="text-decoration: none;" href="{{base_url}}{{ path('entity.node.canonical', {'node': item.entity.field_newsletter_article_select.target_id}) }}">
 															{{ item.entity.field_newsletter_article_select.entity.title.value|render|striptags|trim }}
 														</a>
 													</h3>
@@ -219,7 +219,7 @@
 														{% set is_absolute = (actual_url starts with 'http://' or actual_url starts with 'https://') %}
 														{% set final_url = is_absolute ? actual_url : (base_url ~ actual_url) %}
 														<h3 style="font-size: 18px;">
-															<a class="ucb-newsletter-content-title" href="{{ final_url }}">
+															<a style="text-decoration: none;" class="ucb-newsletter-content-title" href="{{ final_url }}">
 																{{ item.entity.field_newsletter_content_title|view }}
 															</a>
 														</h3>

--- a/templates/paragraphs/paragraph--newsletter-section--email-html.html.twig
+++ b/templates/paragraphs/paragraph--newsletter-section--email-html.html.twig
@@ -9,7 +9,7 @@
 #}
 
 
-{% set base_url = url('<front>')|render|split('/', -1)|join('/') %}
+{% set base_url = url('<front>', {'absolute': true})|trim('/') %}
 <table role="presentation"  border="0" width="600" cellspacing="0" style="border-collapse: collapse; border-spacing: 0; text-align: left; vertical-align: top; width: 100%; color: #222222; font-family: Helvetica, Arial, sans-serif; font-weight: normal; line-height: 19px; margin: 0; font-size: 14px; background-color: white;">
 	<tbody>
   		<tr>
@@ -42,7 +42,7 @@
 								<td align="center" style="text-align: left; padding-right:10px; padding-left:10px; padding-bottom:20px">
 									<a href="{{base_url}}{{ path('entity.node.canonical', {'node': item.entity.field_newsletter_article_select.target_id}) }}">
                     <img
-                    src="{{base_url}}{{file_url(item.entity.field_newsletter_article_select.entity.field_ucb_article_thumbnail.entity.field_media_image.entity.fileuri|image_style('focal_image_wide'))}}"
+                    src="{{base_url}}{{file_url(item.entity.field_newsletter_article_select.entity.field_ucb_article_thumbnail.entity.field_media_image.entity.fileuri|image_style('focal_image_wide'))|replace({'//': '/'})}}"
                     width="600"
                     height="300"
                     style="display: block !important; width: 600px !important; height: 300px !important; object-fit: cover !important; border: 0 !important; outline: none !important;"
@@ -54,7 +54,7 @@
 								<td align="center" style="text-align: left; padding-right:10px; padding-left:10px;padding-bottom:20px">
 									<a href="{{base_url}}{{ path('entity.node.canonical', {'node': item.entity.field_newsletter_article_select.target_id}) }}">
                     <img
-                    src="{{base_url}}{{file_url(item.entity.field_newsletter_article_select.entity.field_ucb_article_content.entity.field_article_media_selection.entity.field_media.entity.field_media_image.entity.fileuri|image_style('focal_image_wide'))}}"
+                    src="{{base_url}}{{file_url(item.entity.field_newsletter_article_select.entity.field_ucb_article_content.entity.field_article_media_selection.entity.field_media.entity.field_media_image.entity.fileuri|image_style('focal_image_wide'))|replace({'//': '/'})}}"
                     width="600"
                     height="300"
                     style="display: block !important; width: 600px !important; height: 300px !important; object-fit: cover !important; border: 0 !important; outline: none !important;"
@@ -65,7 +65,7 @@
 								{% elseif item.entity.field_newsletter_content_image.entity.field_media_image.alt|render %}
 								<td align="center" style="text-align: left; padding-right:10px; padding-left:10px;padding-bottom:20px;">
                   <img
-                  src="{{base_url}}{{file_url(item.entity.field_newsletter_content_image.entity.field_media_image.entity.fileuri|image_style('focal_image_wide'))}}"
+                  src="{{base_url}}{{file_url(item.entity.field_newsletter_content_image.entity.field_media_image.entity.fileuri|image_style('focal_image_wide'))|replace({'//': '/'})}}"
                   width="600"
                   height="300"
                   style="display: block !important; width: 600px !important; height: 300px !important; object-fit: cover !important; border: 0 !important; outline: none !important;"
@@ -172,7 +172,7 @@
 											{# Code to render selected article content (thumbnail) #}
 											{% if item.entity.field_newsletter_article_select.entity.field_ucb_article_thumbnail.entity.field_media_image %}
                       <img
-                      src="{{base_url}}{{ item.entity.field_newsletter_article_select.entity.field_ucb_article_thumbnail.entity.field_media_image.entity.fileuri|image_style('focal_image_square') }}"
+                      src="{{base_url}}{{ item.entity.field_newsletter_article_select.entity.field_ucb_article_thumbnail.entity.field_media_image.entity.fileuri|image_style('focal_image_square')|replace({'//': '/'}) }}"
                       width="130"
                       height="130"
                       style="display: block !important; width: 130px !important; height: 130px !important; object-fit: cover !important; border: 0 !important; outline: none !important;"
@@ -180,7 +180,7 @@
 												{# Code to render selected article content (!thumbnail) #}
 											{% elseif item.entity.field_newsletter_article_select.entity.field_ucb_article_content.entity.field_article_media_selection.entity.field_media.entity.field_media_image %}
                       <img
-                      src="{{base_url}}{{ item.entity.field_newsletter_article_select.entity.field_ucb_article_content.entity.field_article_media_selection.entity.field_media.entity.field_media_image.entity.fileuri|image_style('focal_image_square') }}"
+                      src="{{base_url}}{{ item.entity.field_newsletter_article_select.entity.field_ucb_article_content.entity.field_article_media_selection.entity.field_media.entity.field_media_image.entity.fileuri|image_style('focal_image_square')|replace({'//': '/'}) }}"
                       width="130"
                       height="130"
                       style="display: block !important; width: 130px !important; height: 130px !important; object-fit: cover !important; border: 0 !important; outline: none !important;"
@@ -188,7 +188,7 @@
 												{# Code to render user made content #}
 											{% elseif item.entity.field_newsletter_content_image.entity.field_media_image %}
                       <img
-                      src="{{base_url}}{{ item.entity.field_newsletter_content_image.entity.field_media_image.entity.fileuri|image_style('focal_image_square') }}"
+                      src="{{base_url}}{{ item.entity.field_newsletter_content_image.entity.field_media_image.entity.fileuri|image_style('focal_image_square')|replace({'//': '/'}) }}"
                       width="130"
                       height="130"
                       style="display: block !important; width: 130px !important; height: 130px !important; object-fit: cover !important; border: 0 !important; outline: none !important;"
@@ -264,7 +264,7 @@
 								{# Code to render user made content (content text) #}
 							{% elseif item.entity.field_newsletter_content_text.value|render %}
 								<tr>
-									<td style="padding-left: 0px;">{{ item.entity.field_newsletter_content_text|view }}</td>
+									<td>{{ item.entity.field_newsletter_content_text|view }}</td>
 								</tr>
 							{% endif %}
 											</tbody>

--- a/templates/paragraphs/paragraph--newsletter-section--email-html.html.twig
+++ b/templates/paragraphs/paragraph--newsletter-section--email-html.html.twig
@@ -45,7 +45,7 @@
                     src="{{base_url}}{{file_url(item.entity.field_newsletter_article_select.entity.field_ucb_article_thumbnail.entity.field_media_image.entity.fileuri|image_style('focal_image_wide'))}}"
                     width="600"
                     height="300"
-                    style="display: block; width: 600px; height: 300px; object-fit: cover; border: 0; outline: none;"
+                    style="display: block !important; width: 600px !important; height: 300px !important; object-fit: cover !important; border: 0 !important; outline: none !important;"
                     alt="{{ item.entity.field_newsletter_article_select.entity.field_ucb_article_thumbnail.entity.field_media_image.alt|render }}" />
                   </a>
 								</td>
@@ -57,7 +57,7 @@
                     src="{{base_url}}{{file_url(item.entity.field_newsletter_article_select.entity.field_ucb_article_content.entity.field_article_media_selection.entity.field_media.entity.field_media_image.entity.fileuri|image_style('focal_image_wide'))}}"
                     width="600"
                     height="300"
-                    style="display: block; width: 600px; height: 300px; object-fit: cover; border: 0; outline: none;"
+                    style="display: block !important; width: 600px !important; height: 300px !important; object-fit: cover !important; border: 0 !important; outline: none !important;"
                     alt="{{ item.entity.field_newsletter_article_select.entity.field_ucb_article_content.entity.field_article_media_selection.entity.field_media.entity.field_media_image.alt|render }}" />
                   </a>
 								</td>
@@ -68,7 +68,7 @@
                   src="{{base_url}}{{file_url(item.entity.field_newsletter_content_image.entity.field_media_image.entity.fileuri|image_style('focal_image_wide'))}}"
                   width="600"
                   height="300"
-                  style="display: block; width: 600px; height: 300px; object-fit: cover; border: 0; outline: none;"
+                  style="display: block !important; width: 600px !important; height: 300px !important; object-fit: cover !important; border: 0 !important; outline: none !important;"
                   alt="{{ item.entity.field_newsletter_content_image.entity.field_media_image.alt|render }}" />
                 </td>
 								{% endif %}
@@ -175,7 +175,7 @@
                       src="{{base_url}}{{ item.entity.field_newsletter_article_select.entity.field_ucb_article_thumbnail.entity.field_media_image.entity.fileuri|image_style('focal_image_square') }}"
                       width="130"
                       height="130"
-                      style="display: block; width: 130px; height: 130px; object-fit: cover; border: 0; outline: none;"
+                      style="display: block !important; width: 130px !important; height: 130px !important; object-fit: cover !important; border: 0 !important; outline: none !important;"
                       alt="{{ item.entity.field_newsletter_article_select.entity.field_ucb_article_thumbnail.entity.field_media_image.alt|render }}" />
 												{# Code to render selected article content (!thumbnail) #}
 											{% elseif item.entity.field_newsletter_article_select.entity.field_ucb_article_content.entity.field_article_media_selection.entity.field_media.entity.field_media_image %}
@@ -183,7 +183,7 @@
                       src="{{base_url}}{{ item.entity.field_newsletter_article_select.entity.field_ucb_article_content.entity.field_article_media_selection.entity.field_media.entity.field_media_image.entity.fileuri|image_style('focal_image_square') }}"
                       width="130"
                       height="130"
-                      style="display: block; width: 130px; height: 130px; object-fit: cover; border: 0; outline: none;"
+                      style="display: block !important; width: 130px !important; height: 130px !important; object-fit: cover !important; border: 0 !important; outline: none !important;"
                       alt="{{ item.entity.field_newsletter_article_select.entity.field_ucb_article_content.entity.field_article_media_selection.entity.field_media.entity.field_media_image.alt|render }}" />
 												{# Code to render user made content #}
 											{% elseif item.entity.field_newsletter_content_image.entity.field_media_image %}
@@ -191,7 +191,7 @@
                       src="{{base_url}}{{ item.entity.field_newsletter_content_image.entity.field_media_image.entity.fileuri|image_style('focal_image_square') }}"
                       width="130"
                       height="130"
-                      style="display: block; width: 130px; height: 130px; object-fit: cover; border: 0; outline: none;"
+                      style="display: block !important; width: 130px !important; height: 130px !important; object-fit: cover !important; border: 0 !important; outline: none !important;"
                       alt="{{ item.entity.field_newsletter_content_image.entity.field_media_image.alt|render }}" />
 											{% endif %}
 									</td>


### PR DESCRIPTION
### Bug Fixes
- Removed the hard-coded "View on Website" link. This will link correctly to the Newsletter page it is generated from. The hard-coded link was due to a completely re-written header and was left in unintentionally from development.  
- Added stricter styling rules to force iOS devices to show images at the proper width. Previously they would all take on the same width on iPhones only. 
- The blue link color should now be consistent across the Newsletter, along with removing the underline link decoration. 
- Missing images should be fixed for complex site urls, but will need to be tested in production. 

### Layout Fixes
- Adjusts spacing on the top of the newsletter. Previously there could be a large gap in between the header and the content if you intentionally left out fields such as the Intro Image or Intro Text. The conditional spacing has been tightened up to include for this case.
- Text blocks will display at full width if there is only one in the section. Previously they would only take up 50% even if there was only one

Resolves https://github.com/CuBoulder/tiamat-theme/issues/1515
Resolves https://github.com/CuBoulder/tiamat-theme/issues/1514
Resolves https://github.com/CuBoulder/tiamat-theme/issues/1511
Resolves https://github.com/CuBoulder/tiamat-theme/issues/1508
Resolves https://github.com/CuBoulder/tiamat-theme/issues/1507
Resolves https://github.com/CuBoulder/tiamat-theme/issues/1528
Resolves https://github.com/CuBoulder/tiamat-theme/issues/1510
Resolves https://github.com/CuBoulder/tiamat-theme/issues/1522

