### PR TITLE
Remove wrap from info footer

### DIFF
--- a/css/ucb-site-contact-info-footer.css
+++ b/css/ucb-site-contact-info-footer.css
@@ -5,7 +5,6 @@
 .ucb-site-contact-info-footer {
   display: flex;
   flex-direction: column;
-  flex-wrap: wrap;
 }
 
 .ucb-site-contact-info-footer-left {


### PR DESCRIPTION
Resolves #1525.
Removes wrapping from the site info contact footer to remove the extra space.