### PR TITLE
Adds Article Syndication "read more" article list

### DIFF
--- a/js/ucb-article-list.js
+++ b/js/ucb-article-list.js
@@ -163,7 +163,10 @@
       // Adds the functionality for a "read more" page in article syndication.
       if (pathname[pathname.length - 1] === 'syndicate') {
         const params = new URL(window.location.href).searchParams;
-        this._initialIncludeCategories = stringToTermIds(params.get('category'), ' ');
+        const categories = stringToTermIds(params.get('category'), ' ');
+        if (categories.length > 0) {
+          this._initialIncludeCategories = categories;
+        }
         this._includeSyndicationAudiences = stringToTermIds(params.get('audience'), ' ');
         this._includeSyndicationUnits = stringToTermIds(params.get('unit'), ' ');
       } else {

--- a/js/ucb-article-list.js
+++ b/js/ucb-article-list.js
@@ -26,7 +26,7 @@
   /**
    * Converts a string to an array of term ids.
    *
-   * @param {string} input
+   * @param {string | null} input
    *   The input string of term ids separated by a delimiter.
    * @param {string} delimiter
    *   The delimiter.
@@ -34,10 +34,7 @@
    *   The term ids.
    */
   function stringToTermIds(input, delimiter = ',') {
-    if (input) {
-      return input.split(delimiter).map(Number);
-    }
-    return [];
+    return input ? input.split(delimiter).map(Number) : [];
   }
 
   // Handles construction of endpoints, and fetching of articles and taxonomies

--- a/js/ucb-article-list.js
+++ b/js/ucb-article-list.js
@@ -163,9 +163,9 @@
       // Adds the functionality for a "read more" page in article syndication.
       if (pathname[pathname.length - 1] === 'syndicate') {
         const params = new URL(window.location.href).searchParams;
-        this._initialIncludeCategories = stringToTermIds(params.get('category', ' '));
-        this._includeSyndicationAudiences = stringToTermIds(params.get('audience', ' '));
-        this._includeSyndicationUnits = stringToTermIds(params.get('unit', ' '));
+        this._initialIncludeCategories = stringToTermIds(params.get('category'), ' ');
+        this._includeSyndicationAudiences = stringToTermIds(params.get('audience'), ' ');
+        this._includeSyndicationUnits = stringToTermIds(params.get('unit'), ' ');
       } else {
         this._includeSyndicationAudiences = [];
         this._includeSyndicationUnits = [];


### PR DESCRIPTION
This update adds the Article Syndication "read more" article list, for use with the Campus News block. The article list is automatically created on sites using the CU Boulder Article Syndication module (if it doesn't already exist) and aliased to `/syndicate`. It allows URL parameters to specify category, audience, and unit filters.

[new] CuBoulder/ucb_article_syndication#3

Sister PR in: [ucb_article_syndication](https://github.com/CuBoulder/ucb_article_syndication/pull/6)