### PR TITLE
Related Articles: Refactors block for better relatedness scoring, faster generation

### DIFF
--- a/css/ucb-related-articles.css
+++ b/css/ucb-related-articles.css
@@ -1,8 +1,8 @@
 .ucb-related-articles-block {
   display: none;
 	margin-top: 20px;
-  --bs-gutter-x: 1.5rem;
-  --bs-gutter-y: 0;
+  --bs-gutter-x: 0 !important;
+  --bs-gutter-y: 0 !important;
 }
 
 .ucb-article-card-img {

--- a/css/ucb-related-articles.css
+++ b/css/ucb-related-articles.css
@@ -1,22 +1,24 @@
 .ucb-related-articles-block {
   display: none;
 	margin-top: 20px;
+  --bs-gutter-x: 1.5rem;
+  --bs-gutter-y: 0;
 }
 
 .ucb-article-card-img {
-    max-width: 100%;
-    height: auto;
+  max-width: 100%;
+  height: auto;
 }
 
 .ucb-article-card-data {
-    display: flex;
-    flex-direction: column;
+  display: flex;
+  flex-direction: column;
 }
 
 .ucb-article-card {
-    margin-bottom: 2em;
+  margin-bottom: 2em;
 }
 
 .ucb-related-article-card-body{
-    font-size: 85%;
+  font-size: 85%;
 }

--- a/css/ucb-related-articles.css
+++ b/css/ucb-related-articles.css
@@ -1,5 +1,5 @@
 .ucb-related-articles-block {
-    display: none;
+  display: none;
 	margin-top: 20px;
 }
 

--- a/js/ucb-related-articles.js
+++ b/js/ucb-related-articles.js
@@ -1,538 +1,308 @@
-const relatedArticlesBlock = document.querySelector(".ucb-related-articles-block");
-const baseURL = relatedArticlesBlock ? relatedArticlesBlock.getAttribute('data-baseurl') : '';
+class RelatedArticles extends HTMLElement {
+  static get observedAttributes() {
+    return [
+      'baseurl',
+      'loggedin',
+      'related-shown',
+      'categories',
+      'tags',
+      'category-exclude',
+      'tag-exclude',
+    ];
+  }
 
-(function(relatedArticlesBlock) {
-	if (!relatedArticlesBlock) return;
-	const loggedIn = relatedArticlesBlock.getAttribute('data-loggedin') == 'true' ? true : false;
-	let childCount = 0;
-  const baseURL = relatedArticlesBlock.getAttribute('data-baseurl');
+  constructor() {
+    super();
+    this._baseURL = '';
+    this._loggedIn = false;
+    this._categories = [];
+    this._tags = [];
+    this._excludeCategories = [];
+    this._excludeTags = [];
+    this._relatedShown = this.getAttribute('related-shown') !== 'Off';
 
-	const excludeCatArr = JSON.parse(relatedArticlesBlock.getAttribute('data-catexclude'))
-	const excludeTagArr = JSON.parse(relatedArticlesBlock.getAttribute('data-tagexclude'))
+    // Create container for related articles
+    this._container = document.createElement('div');
+    this._container.className = 'row related-articles-container';
+    this.style.display = this._relatedShown ? 'block' : 'none';
 
-	// Global variable to store articles that are good matches. Danger!
-	let articleArrayWithScores = []
+    // Append container only if relatedShown is true
+    if (this._relatedShown) {
+      this.appendChild(this._container);
 
-	// Related Shown?
-	const relatedShown = relatedArticlesBlock.getAttribute('data-relatedshown') != "Off" ? true : false;
+      // Loading element
+      this._loadingElement = document.createElement('div');
+      this._loadingElement.innerHTML = `<span class="visually-hidden">Loading</span><i class="fa-solid fa-spinner fa-3x fa-spin-pulse"></i>`;
+      this.appendChild(this._loadingElement);
 
-	// This function returns a total of matched categories or tags
-	function checkMatches(data, ids, privateIds = []){
-		let count = 0;
-		let numberArr = ids.map(Number)
-		// TO DO -- add in private taxonomy, dont include on counts
-		data.forEach((article)=>{
-			if(numberArr.includes(article.meta.drupal_internal__target_id) && !privateIds.includes(article.meta.drupal_internal__target_id)){
-				count++
-			}
-		})
-		return count
-	}
-	// This function takes in the tag endpoint and current array of related articles, returns the array of related articles once it has a count of 3.
-	async function getArticlesWithTags(url, array, articleTags ,numLeft, privateTags){
-		fetch(url)
-		.then(response => response.json())
-		.then(data=>{
-			let relatedArticlesDiv = document.querySelector('.related-articles-section')
-			let returnedArticles = data.data
-			let existingIds = [];
-			// create an array of existing ids
-			array.map(article=>{
-				existingIds.push(article.id)
-			})
+      // Error element
+      this._errorElement = document.createElement('div');
+      this._errorElement.textContent = 'Error fetching related articles.';
+      this._errorElement.style.display = 'none';
+      this.appendChild(this._errorElement);
+    }
+  }
 
-			// remove any articles already chosen, excluded categories, and the current article
-			let filterData = []
-			returnedArticles.map((article)=>{
+  attributeChangedCallback(name, oldValue, newValue) {
+    if (name === 'related-shown') {
+      const isShown = newValue !== 'Off';
+      if (this._relatedShown !== isShown) {
+        this._relatedShown = isShown;
+        this.style.display = this._relatedShown ? 'block' : 'none';
 
+        if (!this._relatedShown) {
+          console.log('Hiding RelatedArticles component and stopping further processing.');
+          // Cleanup or early exit logic if needed
+          this._container.innerHTML = '';
+          return;
+        }
 
+        // If related-shown becomes true, re-fetch articles
+        this.fetchAndDisplayArticles();
+      }
+    }
 
-				let thisArticleCats = article.relationships.field_ucb_article_categories.data
-					let thisArticleTags = article.relationships.field_ucb_article_tags.data
-					let urlCheck = article.attributes.path.alias ? article.attributes.path.alias : `/node/${article.attributes.drupal_internal__nid}`;
-					let toInclude = true;
-					//remove excluded category & tagss
-					if(thisArticleTags.length){ // if there are categories
-						thisArticleTags.forEach((tag)=>{
-							let id = tag.meta.drupal_internal__target_id;
-							if(excludeTagArr.includes(id)){
-								toInclude = false;
-								return
-							}
-						})
-					}
+    if (!this._relatedShown) return; // Early exit if not shown
 
-					if(article.attributes.field_ucb_article_external_url){
-						toInclude = false;
-						return
-					}
+    if (name === 'baseurl') this._baseURL = newValue || '';
+    if (name === 'loggedin') this._loggedIn = newValue === 'true';
 
-					if(thisArticleCats.length){ // if there are categories
-						thisArticleCats.forEach((category)=>{ // check each category
-							let id = category.meta.drupal_internal__target_id;
-							if(excludeCatArr.includes(id)){ // if excluded, do not proceed
-								toInclude = false;
-								return
-							}
-							if( urlCheck == window.location.pathname) { // if same article, do not proceed
-								toInclude = false
-								return;
-							}  // proceed
-								// create an object out of
-								// add to running array of possible matches
+    // Parse JSON values safely, with fallback to empty arrays
+    if (name === 'categories') this._categories = this._parseJSON(newValue);
+    if (name === 'tags') this._tags = this._parseJSON(newValue);
+    if (name === 'category-exclude') this._excludeCategories = this._parseJSON(newValue);
+    if (name === 'tag-exclude') this._excludeTags = this._parseJSON(newValue);
+  }
 
-						})
-					}
+  connectedCallback() {
+    if (!this._relatedShown) {
+      console.log('RelatedArticles not shown. Hiding component and skipping processing.');
+      this.style.display = 'none';
+      return;
+    }
+    console.log('ConnectedCallback: RelatedArticles initialized.');
+    console.log('Attributes:', {
+      baseurl: this._baseURL,
+      loggedin: this._loggedIn,
+      relatedShown: this._relatedShown,
+      categories: this._categories,
+      tags: this._tags,
+      excludeCategories: this._excludeCategories,
+      excludeTags: this._excludeTags,
+    });
 
-				if(existingIds.includes(article.id) || urlCheck == window.location.pathname ){
-					toInclude = false
-				// filter on categories
-				}
-				if(toInclude){
-					let articleObj ={}
-					articleObj.id = article.id
-					articleObj.catMatches = checkMatches(article.relationships.field_ucb_article_tags.data, articleTags, privateTags) // count the number of matches
-					articleObj.article = article
-					filterData.push(articleObj)
-				}
-				else{
-					return
-				}
-			})
+    if (this._relatedShown) {
+      this.fetchAndDisplayArticles();
+    }
+  }
 
-			let urlObj = {};
-			let idObj = {};
+  async fetchAndDisplayArticles() {
+    if (!this._baseURL) {
+      console.error('Base URL is missing.');
+      return;
+    }
 
-			if (data.included) {
-				let filteredData = data.included.filter((url) => {
-				return url.attributes.uri !== undefined;
-				})
-				// creates the urlObj, key: data id, value: url
-				filteredData.map((pair) => {
-				urlObj[pair.id] = pair.links.focal_image_square.href;
-				})
+    this.toggleLoading(true);
 
-				// removes all other included data besides images in our included media
-				let idFilterData = data.included.filter((item) => {
-				return item.type == "media--image";
-				})
-				// using the image-only data, creates the idObj =>  key: thumbnail id, value : data id
-				idFilterData.map((pair) => {
-				idObj[pair.id] = pair.relationships.thumbnail.data.id;
-				})
-			}
+    try {
+      const endpoint = this.buildEndpoint();
+      console.log('Fetching articles from:', endpoint);
 
-			// Rank based on matches (cats)
-			filterData.sort((a, b) => a.catMatches - b.catMatches).reverse();
-			filterData.length = numLeft // sets to fill in however many articles are left
+      const response = await fetch(endpoint);
+      if (!response.ok) {
+        throw new Error(`Failed to fetch articles: ${response.status}`);
+      }
 
-			filterData.map((article)=>{
-				let articleCard = document.createElement('div')
-				articleCard.classList = "ucb-article-card col-sm-12 col-md-6 col-lg-4"
-				let title = article.article.attributes.title;
-				let link = article.article.attributes.path.alias ? baseURL + article.article.attributes.path.alias : `${baseURL}/node/${article.attributes.drupal_internal__nid}`;
+      const data = await response.json();
+      console.log('Fetched data:', data);
 
-						// if no thumbnail, show no image
-						if (!article.article.relationships.field_ucb_article_thumbnail.data) {
-							image = "";
-						} else {
-							//Use the idObj as a memo to add the corresponding image url
-							let thumbId = article.article.relationships.field_ucb_article_thumbnail.data.id;
-							image = urlObj[idObj[thumbId]];
-						}
-				let body = ""
-				// if summary, use that
-				if( article.article.attributes.field_ucb_article_summary != null){
-					body = article.article.attributes.field_ucb_article_summary;
-				}
+      const { articles, thumbnails } = this.processIncludedData(data.data, data.included);
+      const rankedArticles = this.rankArticles(articles);
+      console.log('Ranked articles:', rankedArticles);
 
-				// if image, use it
-				if (!article.article.relationships.field_ucb_article_thumbnail.data) {
-					imageSrc = "";
-				} else {
-					//Use the idObj as a memo to add the corresponding image url
-					let thumbId = article.article.relationships.field_ucb_article_thumbnail.data.id;
-					imageSrc = urlObj[idObj[thumbId]];
-				}
+      this.renderArticles(rankedArticles.slice(0, 3), thumbnails);
+    } catch (error) {
+      console.error('Error fetching articles:', error);
+      this.toggleError(true);
+    } finally {
+      this.toggleLoading(false);
+      this.toggleBlockVisibility();
+    }
+  }
 
-				var artcardImgContainer = document.createElement('div');
-				artcardImgContainer.classList = 'ucb-article-card-img';
+  buildEndpoint() {
+    let endpoint = `${this._baseURL}/jsonapi/node/ucb_article?filter[status][value]=1&include=field_ucb_article_thumbnail.field_media_image&sort=-created`;
 
-				var artCardImgLink = document.createElement('a');
-				artCardImgLink.href = link;
+    // Add category filters
+    if (this._categories.length > 0) {
+      const categoryFilters = this._categories
+        .map(
+          (cat) =>
+            `&filter[cat${cat}][condition][path]=field_ucb_article_categories.meta.drupal_internal__target_id&filter[cat${cat}][condition][value]=${cat}&filter[cat${cat}][condition][memberOf]=categories`
+        )
+        .join('');
+      endpoint += `&filter[categories][group][conjunction]=OR${categoryFilters}`;
+    }
 
-				var artCardImg = document.createElement('img');
-				artCardImg.src = imageSrc;
+    // Add tag filters
+    if (this._tags.length > 0) {
+      const tagFilters = this._tags
+        .map(
+          (tag) =>
+            `&filter[tag${tag}][condition][path]=field_ucb_article_tags.meta.drupal_internal__target_id&filter[tag${tag}][condition][value]=${tag}&filter[tag${tag}][condition][memberOf]=tags`
+        )
+        .join('');
+      endpoint += `&filter[tags][group][conjunction]=OR${tagFilters}`;
+    }
 
-				var artCardDataContainer = document.createElement('div')
-				artCardDataContainer.classList = 'ucb-article-card-data'
+    console.log('Generated endpoint:', endpoint);
+    return endpoint;
+  }
 
-				var artCardDataTitle = document.createElement('span')
-				artCardDataTitle.classList= 'ucb-article-card-title'
+  processIncludedData(articles, included) {
+    const thumbnails = {};
+    if (included) {
+      const idObj = {};
+      const altObj = {};
 
-				var artCardTitleLink = document.createElement('a')
-				artCardTitleLink.href = link;
-				artCardTitleLink.innerText = title;
+      const idFilterData = included.filter((item) => item.type === 'media--image');
+      const altFilterData = included.filter((item) => item.type === 'file--file');
 
-				var artCardDataBody = document.createElement('span')
-				artCardDataBody.classList = 'ucb-related-article-card-body'
-				artCardDataBody.innerText = body;
-
-
-				if(link && imageSrc) {
-					// image = `<a href="${link}"><img src="${imageSrc}" /></a>`;
-
-					artCardImgLink.appendChild(artCardImg)
-					artcardImgContainer.appendChild(artCardImgLink)
-
-				}
-
-			artCardDataTitle.appendChild(artCardTitleLink)
-			artCardDataContainer.appendChild(artCardDataTitle)
-			artCardDataContainer.appendChild(artCardDataBody)
-
-			articleCard.appendChild(artcardImgContainer)
-			articleCard.appendChild(artCardDataContainer)
-			relatedArticlesDiv.appendChild(articleCard)
-			})
-
-			// Check to see what was rendered
-			// sets global counter of children
-			childCount = relatedArticlesDiv.childElementCount
-			// If no matches and logged in, render error message for admin
-		if(childCount == 0 && loggedIn == true){
-			let message = document.createElement('h3')
-			message.innerText = 'There are no returned article matches - check exclusion filters and try again'
-			relatedArticlesDiv.appendChild(message)
-			// If no matches and not logged in, hide section
-		} else if (relatedArticlesDiv.childElementCount == 0 && loggedIn == false){
-			let header = relatedArticlesBlock.children[0]
-			header.innerText = ''
-
-		} else if(childCount > 1 && loggedIn==true){
-			var message = document.getElementById('admin-notif-message')
-			if(message){
-				message.remove()
-			}
-		}else {
-			// last check for error message
-		}
-
-		})
-	}
-
-	// If related articles is toggled on create section, run the fetch
-	if(relatedShown){
-		// Iterate through the json data of the articles tags and categories, store the values
-		let x=0
-		let n=0
-		// Tag array - iterate through and store taxonomy ID's for fetch
-		var tagJSON = JSON.parse(relatedArticlesBlock.getAttribute('data-tagsjson'));
-		var myTagIDs = []
-
-		while(tagJSON[n]!=undefined){
-			myTagIDs.push(tagJSON[n]["#cache"].tags[0])
-			n++;
-		}
-		var myTags = myTagIDs.map((id)=> id.replace(/\D/g,'')) // remove blanks, get only the tag ID#s
-
-		// Cat array - iterate through and store taxonomy ID's for fetch
-		var catsJSON = JSON.parse(relatedArticlesBlock.getAttribute('data-catsjson'));
-		var myCatsID= [];
-		while(catsJSON[x]!=undefined){
-			myCatsID.push(catsJSON[x]["#cache"].tags[0])
-			x++;
-		}
-
-		var myCats = myCatsID.map((id)=> id.replace(/\D/g,''))// remove blanks, get only the cat ID#s
-
-		// Using tags and categories, construct an API call
-		var rootURL = `${baseURL}/jsonapi/node/ucb_article?include[node--ucb_article]=uid,title,ucb_article_content,created,field_ucb_article_summary,field_ucb_article_categories,field_ucb_article_tags,field_ucb_article_thumbnail&include=field_ucb_article_thumbnail.field_media_image&fields[file--file]=uri,url%20&filter[published][group][conjunction]=AND&filter[publish-check][condition][path]=status&filter[publish-check][condition][value]=1&filter[publish-check][condition][memberOf]=published`;
-
-		var tagQuery = buildTagFilter(myTags)
-		var catQuery = buildCatFilter(myCats)
-
-		// varructs the tag portion of the API filter
-		function buildTagFilter(array){
-			let string = `${rootURL}`
-
-			array.forEach(value => {
-				let tagFilterString = `&filter[filter-tag${value}][condition][path]=field_ucb_article_tags.meta.drupal_internal__target_id&filter[filter-tag${value}][condition][value]=${value}&filter[filter-tag${value}][condition][memberOf]=tag-include`;
-				string += tagFilterString
-			});
-			return string
-			// let tagFilterString = ``
-		}
-		// Constructs the category portion of the API filter
-		function buildCatFilter(array){
-			let string = `${rootURL}`
-			array.forEach(value=>{
-				let catFilterString = `&filter[filter-cat${value}][condition][path]=field_ucb_article_categories.meta.drupal_internal__target_id&filter[filter-cat${value}][condition][value]=${value}&filter[filter-cat${value}][condition][memberOf]=cat-include`
-				string += catFilterString
-
-			});
-			return string
-		}
-
-		var URL = `${catQuery}+&sort[sort-created][path]=created&sort[sort-created][direction]=DESC`
-
-		// Fetch
-		async function getArticles(URL){
-			const privateTags = getPrivateTags()
-			const privateCats = getPrivateCategories()
-			fetch(URL)
-				.then(response=>response.json())
-				.then(data=> {
-			// Below objects are needed to match images with their corresponding articles.
-			// There are two endpoints => data.data (article) and data.included (incl. media), both needed to associate a media library image with its respective article
-			let urlObj = {};
-			let idObj = {};
-			// Remove any blanks from our articles before map
-			if (data.included) {
-			let filteredData = data.included.filter((url) => {
-				return url.attributes.uri !== undefined;
-			})
-
-			// creates the urlObj, key: data id, value: url
-			filteredData.map((pair) => {
-				urlObj[pair.id] = pair.links.focal_image_square.href;
-			})
-
-			// removes all other included data besides images in our included media
-			let idFilterData = data.included.filter((item) => {
-				return item.type == "media--image";
-			})
-			// using the image-only data, creates the idObj =>  key: thumbnail id, value : data id
-			idFilterData.map((pair) => {
-				idObj[pair.id] = pair.relationships.thumbnail.data.id;
-			})
-			}
-				let returnedArticles = data.data
-				// Create an array of options to render with additional checks
-				returnedArticles.map((article)=> {
-					let thisArticleCats = article.relationships.field_ucb_article_categories.data;
-					let thisArticleTags = article.relationships.field_ucb_article_tags.data;
-					let urlCheck = article.attributes.path.alias ? article.attributes.path.alias : `/node/${article.attributes.drupal_internal__nid}`;
-					let toInclude = true;
-
-					// If article is external,
-					if(article.attributes.field_ucb_article_external_url){
-						toInclude = false;
-						return
-					}
-
-					//remove excluded category & tagss
-					if(thisArticleTags.length){ // if there are tags
-						thisArticleTags.forEach((tag)=>{
-							let id = tag.meta.drupal_internal__target_id;
-							if(excludeTagArr.includes(id)){
-								toInclude = false;
-								return
-							}
-						})
-					}
-
-					if(thisArticleCats.length){ // if there are categories
-						thisArticleCats.forEach((category)=>{ // check each category
-							let id = category.meta.drupal_internal__target_id;
-							if(excludeCatArr.includes(id)){ // if excluded, do not proceed
-								toInclude = false;
-								return
-							}
-							if( urlCheck == window.location.pathname) { // if same article, do not proceed
-								toInclude = false
-								return;
-							}  // proceed
-								// create an object out of
-								// add to running array of possible matches
-
-						})
-					}
-					// if it triggered any fail conditions, do not proceed with the article
-					if(toInclude){
-					let articleObj = {}
-								articleObj.id = article.id
-								articleObj.catMatches = checkMatches(article.relationships.field_ucb_article_categories.data, myCats, privateCats) // count the number of matches
-                articleObj.tagMatches = checkMatches(article.relationships.field_ucb_article_tags.data, myTags, privateTags);
-								articleObj.article = article // contain the existing article
-								articleArrayWithScores.push(articleObj)
-					}
-
-				})
-
-				// Remove current article from those availabile in the block
-
-				articleArrayWithScores.filter((article)=>{
-          let urlCheck = article.article.attributes.path.alias ? baseURL + article.article.attributes.path.alias : `${baseURL}/node/${article.article.attributes.drupal_internal__nid}`;
-          if(urlCheck == window.location.origin + window.location.pathname){
-						articleArrayWithScores.splice(articleArrayWithScores.indexOf(article),1)
-					} else {
-						return article;
-					}
-				})
-				articleArrayWithScores.sort((a, b) => {
-          // First, compare by catMatches
-          if (a.catMatches !== b.catMatches) {
-              return b.catMatches - a.catMatches;
-          }
-          // If catMatches are the same, compare by tagMatches
-          if (a.tagMatches !== b.tagMatches) {
-              return b.tagMatches - a.tagMatches;
-          }
-          // If both catMatches and tagMatches are the same, compare by created date
-          const dateA = new Date(a.article.attributes.created);
-          const dateB = new Date(b.article.attributes.created);
-          return dateB - dateA;
+      altFilterData.forEach((item) => {
+        if (item.links?.focal_image_square) {
+          altObj[item.id] = { src: item.links.focal_image_square.href };
+        } else {
+          altObj[item.id] = { src: item.attributes.uri.url };
+        }
       });
-				//Remove articles without matches from those availabile in the block
-				var finalArr = articleArrayWithScores.filter(article=> article.catMatches > 0)
-				// if more than 3 articles, take the top 3
-				if(finalArr.length>3){
-					finalArr.length = 3
-				} else if(finalArr.length<3){
-					let howManyLeft = 3 - finalArr.length
-					// if less than 3, grab the most tags
-				getArticlesWithTags(tagQuery,finalArr, myTags, howManyLeft, privateTags);
-				}
+
+      idFilterData.forEach((pair) => {
+        const thumbnailId = pair.relationships?.thumbnail?.data?.id;
+        if (thumbnailId) {
+          idObj[pair.id] = thumbnailId;
+          if (altObj[thumbnailId]) {
+            altObj[thumbnailId].alt = pair.relationships.thumbnail.data.meta.alt || 'Thumbnail';
+          }
+          thumbnails[pair.id] = altObj[thumbnailId];
+        }
+      });
+    }
+
+    return { articles, thumbnails };
+  }
+
+  rankArticles(articles) {
+    return articles
+      .map((article) => {
+        const urlCheck = article.attributes.path.alias
+          ? article.attributes.path.alias
+          : `/node/${article.attributes.drupal_internal__nid}`;
+
+        // Exclude the current article
+        if (urlCheck === window.location.pathname) {
+          console.log(`Excluding current article: ${urlCheck}`);
+          return null;
+        }
+
+        const categories = article.relationships?.field_ucb_article_categories?.data.map(
+          (cat) => cat.meta.drupal_internal__target_id
+        ) || [];
+        const tags = article.relationships?.field_ucb_article_tags?.data.map(
+          (tag) => tag.meta.drupal_internal__target_id
+        ) || [];
+
+        const categoryMatches = categories.filter((cat) => this._categories.includes(cat)).length;
+        const tagMatches = tags.filter((tag) => this._tags.includes(tag)).length;
+        console.log('excluded', this._excludeCategories)
 
 
+        const hasExcludedCategory = categories.some((cat) => this._excludeCategories.includes(cat));
+        const hasExcludedTag = tags.some((tag) => this._excludeTags.includes(tag));
+
+        if (hasExcludedCategory || hasExcludedTag) {
+          console.log(`Excluding article with excluded category or tag: ${urlCheck}`);
+          return null;
+        }
+
+        return {
+          article,
+          categoryMatches,
+          tagMatches,
+          created: new Date(article.attributes.created),
+        };
+      })
+      .filter((entry) => entry !== null)
+      .sort((a, b) => {
+        if (b.categoryMatches !== a.categoryMatches) return b.categoryMatches - a.categoryMatches;
+        if (b.tagMatches !== a.tagMatches) return b.tagMatches - a.tagMatches;
+        return b.created - a.created;
+      });
+  }
 
 
+  renderArticles(articles, thumbnails) {
+    console.log('Rendering articles:', articles);
 
+    this._container.innerHTML = '';
 
-		// Create the article cards contained within the block, assign classes
-		let relatedArticlesDiv = document.createElement('div')
-		relatedArticlesDiv.classList = "row related-articles-section"
-		relatedArticlesBlock.appendChild(relatedArticlesDiv)
+    if (articles.length === 0) {
+      this._container.innerHTML = '<p>No related articles found.</p>';
+      return;
+    }
 
-		finalArr.map((article)=>{
-			let articleCard = document.createElement('div')
-			articleCard.classList = "ucb-article-card col-sm-12 col-md-6 col-lg-4"
-			let title = article.article.attributes.title;
+    articles.forEach(({ article }) => {
+      const title = article.attributes.title;
+      const summary = article.attributes.field_ucb_article_summary || '';
+      const link = `${this._baseURL}${article.attributes.path.alias}`;
+      const thumbnail = thumbnails[article.relationships?.field_ucb_article_thumbnail?.data?.id];
 
-			let link = article.article.attributes.path.alias ? baseURL + article.article.attributes.path.alias : `${baseURL}/node/${article.article.attributes.drupal_internal__nid}`;
-					// if no thumbnail, show no image
-					if (!article.article.relationships.field_ucb_article_thumbnail.data) {
-						image = "";
-					} else {
-						//Use the idObj as a memo to add the corresponding image url
-						let thumbId = article.article.relationships.field_ucb_article_thumbnail.data.id;
-						image = urlObj[idObj[thumbId]];
-					}
-			let body = ""
-			// if summary, use that
-			if( article.article.attributes.field_ucb_article_summary != null){
-				body = article.article.attributes.field_ucb_article_summary;
-			}
+      const articleElement = document.createElement('div');
+      articleElement.className = "ucb-article-card col-sm-12 col-md-6 col-lg-4";
 
-			// if image, use it
-			if (!article.article.relationships.field_ucb_article_thumbnail.data) {
-				imageSrc = "";
-			} else {
-				//Use the idObj as a memo to add the corresponding image url
-				let thumbId = article.article.relationships.field_ucb_article_thumbnail.data.id;
-				imageSrc = urlObj[idObj[thumbId]];
-			}
+      if (thumbnail) {
+        const img = document.createElement('img');
+        img.src = thumbnail.src;
+        img.alt = thumbnail.alt;
+        articleElement.appendChild(img);
+      }
 
-			var artcardImgContainer = document.createElement('div');
-			artcardImgContainer.classList = 'ucb-article-card-img';
+      const titleElement = document.createElement('span');
+      titleElement.classList.add('ucb-article-card-title')
+      titleElement.innerHTML = `<a href="${link}">${title}</a>`;
+      articleElement.appendChild(titleElement);
 
-			var artCardImgLink = document.createElement('a');
-			artCardImgLink.href = link;
+      const summaryElement = document.createElement('p');
+      summaryElement.classList.add('ucb-article-card-data')
+      summaryElement.textContent = summary;
+      articleElement.appendChild(summaryElement);
 
-			var artCardImg = document.createElement('img');
-			artCardImg.src = imageSrc;
+      this._container.appendChild(articleElement);
+    });
+  }
 
-			var artCardDataContainer = document.createElement('div')
-			artCardDataContainer.classList = 'ucb-article-card-data'
+  toggleLoading(show) {
+    this._loadingElement.style.display = show ? 'block' : 'none';
+  }
 
-			var artCardDataTitle = document.createElement('span')
-			artCardDataTitle.classList= 'ucb-article-card-title'
+  toggleError(show) {
+    this._errorElement.style.display = show ? 'block' : 'none';
+  }
 
-			var artCardTitleLink = document.createElement('a')
-			artCardTitleLink.href = link;
-			artCardTitleLink.innerText = title;
+  toggleBlockVisibility() {
+    const block = this.closest('.ucb-related-articles-block');
+    if (block) {
+      block.style.display = this._container.innerHTML.trim() ? 'block' : 'none';
+    }
+  }
 
-			var artCardDataBody = document.createElement('span')
-			artCardDataBody.classList = 'ucb-related-article-card-body'
-			artCardDataBody.innerText = body;
-
-
-			if(link && imageSrc) {
-				// image = `<a href="${link}"><img src="${imageSrc}" /></a>`;
-
-				artCardImgLink.appendChild(artCardImg)
-				artcardImgContainer.appendChild(artCardImgLink)
-
-			}
-
-			artCardDataTitle.appendChild(artCardTitleLink)
-			artCardDataContainer.appendChild(artCardDataTitle)
-			artCardDataContainer.appendChild(artCardDataBody)
-		// 	let outputHTML = `
-		// 		<div id='img' class='ucb-article-card-img'>${image}</div>
-		// 		<div class='ucb-article-card-data'>
-		// 			<span class='ucb-article-card-title'><a href="${link}">${title}</a></span>
-		// 			<span id='body' class='ucb-related-article-card-body'>${body}</span>
-		// 		</div>
-		// `;
-		// Append
-		articleCard.appendChild(artcardImgContainer)
-		articleCard.appendChild(artCardDataContainer)
-		relatedArticlesDiv.appendChild(articleCard)
-			})
-
-		// Check to see what was rendered
-			// sets global counter of children
-			childCount = relatedArticlesDiv.childElementCount
-				// If no matches and logged in, render error message for admin
-			if(childCount == 0 && loggedIn == true){
-				let message = document.createElement('h3')
-				message.id = 'admin-notif-message'
-				message.innerText = 'There are no returned article matches - check exclusion filters and try again'
-				relatedArticlesDiv.appendChild(message)
-				// If no matches and not logged in, hide section
-			} else if (relatedArticlesDiv.childElementCount == 0 && loggedIn == false){
-				let header = relatedArticlesBlock.children[0]
-				header.innerText = ''
-
-			} else {
-				//do nothing and proceed
-			}
-		})
-	}
-
-			getArticles(URL) // init
-
-		relatedArticlesBlock.style.display = "block"
-	} else {
-		relatedArticlesBlock.style.display = "none";
-	}
-})(document.querySelector(".ucb-related-articles-block"));
-
-
-// These functions get the privated Categories and tags to not include them on the match count for their respective taxonomies
-function getPrivateCategories(){
-	let privateCats = []
-		fetch(`${baseURL}/jsonapi/taxonomy_term/category?filter[field_ucb_category_display]=false`)
-		.then(response => response.json())
-		.then(data=>{
-			data.data.forEach(cat=>{
-				privateCats.push(cat.attributes.drupal_internal__tid)
-			})
-		})
-	return privateCats
+  _parseJSON(value) {
+    try {
+      return JSON.parse(value || '[]');
+    } catch (e) {
+      console.warn(`Error parsing JSON for value: ${value}`);
+      return [];
+    }
+  }
 }
 
-function getPrivateTags(){
-	let privateTags = []
-		fetch(`${baseURL}/jsonapi/taxonomy_term/tags?filter[field_ucb_tag_display]=false`)
-		.then(response => response.json())
-		.then(data=>{
-			data.data.forEach(tag=>{
-				privateTags.push(tag.attributes.drupal_internal__tid)
-			})
-		})
-	return privateTags
-
-}
+customElements.define('related-articles', RelatedArticles);

--- a/templates/content/node--ucb-article.html.twig
+++ b/templates/content/node--ucb-article.html.twig
@@ -13,8 +13,8 @@
 {# Base Url #}
 {% set baseURL = url('<front>')|render|trim('/') %}
 
-{% set excludeCats = related_articles_exclude_categories %}
-{% set excludeTags = related_articles_exclude_tags %}
+{% set exclude_categories = related_articles_exclude_categories %}
+{% set exclude_tags = related_articles_exclude_tags %}
 
 {# DATE FORMATTER - use global setting for all, unless override in article provided #}
 {% set global_date_format = article_date_format %}
@@ -197,21 +197,12 @@
     ? '[' ~ content.field_ucb_article_tags['#items']|map(item => item.entity.id)|join(', ') ~ ']'
     : '[]' %}
 
-{% set exclude_categories = content.related_articles_exclude_categories['#items'] is defined and content.related_articles_exclude_categories['#items'] is not empty
-    ? '[' ~ content.related_articles_exclude_categories['#items']|map(item => item.entity.id)|join(', ') ~ ']'
-    : '[]' %}
-
-{% set exclude_tags = content.related_articles_exclude_tags['#items'] is defined and content.related_articles_exclude_tags['#items'] is not empty
-    ? '[' ~ content.related_articles_exclude_tags['#items']|map(item => item.entity.id)|join(', ') ~ ']'
-    : '[]' %}
-
 {# Test zone #}
         <pre>
         "this article has categories:" {{category_ids}}
         "this article has tags:"{{tag_ids}}
-        "exclude cats:" {{exclude_categories}}
-        "exclude tags:" {{exclude_tags}}
-        {{ content.field_ucb_related_articles_parag }}
+        "exclude cats:" {{exclude_cats|json_encode() }}
+        "exclude tags:" {{exclude_tags|json_encode() }}
         </pre>
 {# NEW BLOCK #}
 <related-articles
@@ -222,15 +213,15 @@
     'related-shown': showRelated|striptags|trim,
     'categories': category_ids,
     'tags': tag_ids,
-    'category-exclude': exclude_categories,
-    'tag-exclude': exclude_tags
+    'category-exclude': exclude_categories|json_encode(),
+    'tag-exclude': exclude_tags|json_encode(),
   }) }}>
   {{ content.field_ucb_related_articles_parag }}
 </related-articles>
 
 {# OLD BLOCK #}
       {# Related Articles Block #}
-      <div{{ create_attribute({
+      {# <div{{ create_attribute({
           class: ['container', 'ucb-related-articles-block'],
           'data-baseurl' : baseURL,
           'data-loggedin': logged_in ? 'true' : 'false',
@@ -242,7 +233,7 @@
           'data-tagExclude': related_articles_exclude_tags|json_encode(),
           'data-catExclude': related_articles_exclude_categories|json_encode() }) }}>
         {{ content.field_ucb_related_articles_parag }}
-      </div>
+      </div> #}
     </div>
   </article>
 {% else %}

--- a/templates/content/node--ucb-article.html.twig
+++ b/templates/content/node--ucb-article.html.twig
@@ -92,19 +92,21 @@
   'ucb-content-wrapper'
 ] %}
 
-
-{% set myTags %}
-{{ content.field_ucb_article_tags }}
-{% endset %}
-{% set myCats %}
-{{ content.field_ucb_article_categories }}
-{% endset %}
+{# Show Related - will flag "Off" or "Related Articles", controls visibility of the block #}
 {% set showRelated %}
 {{ content.field_ucb_related_articles_parag.0 }}
 {% endset %}
 
+{# Extract category and tag IDs as arrays and convert to a string format like "[1, 2, 3, 4]" #}
+{# Ensure the fields are not null before applying map and join #}
 
-{# {% set publishedDate = node.created.value|date('F d, Y') %} #}
+{% set category_ids = content.field_ucb_article_categories['#items'] is defined and content.field_ucb_article_categories['#items'] is not empty
+    ? '[' ~ content.field_ucb_article_categories['#items']|map(item => item.entity.id)|join(', ') ~ ']'
+    : '[]' %}
+
+{% set tag_ids = content.field_ucb_article_tags['#items'] is defined and content.field_ucb_article_tags['#items'] is not empty
+    ? '[' ~ content.field_ucb_article_tags['#items']|map(item => item.entity.id)|join(', ') ~ ']'
+    : '[]' %}
 
 {#Dummy variable to ensure that all content tags are set for caching purposes#}
 {% set content_render = content|render %}
@@ -184,57 +186,25 @@
           {{ content.field_appears_in_issue }}
         </div>
       {% endif %}
-
-
-{# Extract category and tag IDs as arrays and convert to a string format like "[1, 2, 3, 4]" #}
-{# Ensure the fields are not null before applying map and join #}
-
-{% set category_ids = content.field_ucb_article_categories['#items'] is defined and content.field_ucb_article_categories['#items'] is not empty
-    ? '[' ~ content.field_ucb_article_categories['#items']|map(item => item.entity.id)|join(', ') ~ ']'
-    : '[]' %}
-
-{% set tag_ids = content.field_ucb_article_tags['#items'] is defined and content.field_ucb_article_tags['#items'] is not empty
-    ? '[' ~ content.field_ucb_article_tags['#items']|map(item => item.entity.id)|join(', ') ~ ']'
-    : '[]' %}
-
-{# Test zone #}
-        <pre>
-        "this article has categories:" {{category_ids}}
-        "this article has tags:"{{tag_ids}}
-        "exclude cats:" {{exclude_cats|json_encode() }}
-        "exclude tags:" {{exclude_tags|json_encode() }}
-        </pre>
-{# NEW BLOCK #}
-<related-articles
-  {{ create_attribute({
-    class: ['container', 'ucb-related-articles-block'],
-    'baseurl': baseURL,
-    'loggedin': logged_in ? 'true' : 'false',
-    'related-shown': showRelated|striptags|trim,
-    'categories': category_ids,
-    'tags': tag_ids,
-    'category-exclude': exclude_categories|json_encode(),
-    'tag-exclude': exclude_tags|json_encode(),
-  }) }}>
-  {{ content.field_ucb_related_articles_parag }}
-</related-articles>
-
-{# OLD BLOCK #}
-      {# Related Articles Block #}
-      {# <div{{ create_attribute({
-          class: ['container', 'ucb-related-articles-block'],
-          'data-baseurl' : baseURL,
-          'data-loggedin': logged_in ? 'true' : 'false',
-          'data-catsjson': content.field_ucb_article_categories|json_encode(constant('JSON_PRETTY_PRINT')),
-          'data-tagsjson': content.field_ucb_article_tags|json_encode(constant('JSON_PRETTY_PRINT')),
-          'data-relatedshown': showRelated|striptags|trim,
-          'data-tags': myTags|render|striptags|trim|replace({"\n": "", "\r": "", "\t": ""}),
-          'data-cats': myCats|render|striptags|trim|replace({"\n": "", "\r": "", "\t": ""}),
-          'data-tagExclude': related_articles_exclude_tags|json_encode(),
-          'data-catExclude': related_articles_exclude_categories|json_encode() }) }}>
-        {{ content.field_ucb_related_articles_parag }}
-      </div> #}
-    </div>
+{% if showRelated|striptags|trim != 'Off' %}
+<div class="container">
+  {# Related Articles Block #}
+  <related-articles #}
+    {{ create_attribute({
+      class: ['container', 'ucb-related-articles-block'],
+      'baseurl': baseURL,
+      'loggedin': logged_in ? 'true' : 'false',
+      'related-shown': showRelated|striptags|trim,
+      'categories': category_ids,
+      'tags': tag_ids,
+      'category-exclude': exclude_categories|json_encode(),
+      'tag-exclude': exclude_tags|json_encode(),
+    }) }}>
+    {{ content.field_ucb_related_articles_parag }}
+  </related-articles>
+</div>
+{% endif %}
+  </div>
   </article>
 {% else %}
   <article{{attributes.addClass(classes)}}>

--- a/templates/content/node--ucb-article.html.twig
+++ b/templates/content/node--ucb-article.html.twig
@@ -185,6 +185,50 @@
         </div>
       {% endif %}
 
+
+{# Extract category and tag IDs as arrays and convert to a string format like "[1, 2, 3, 4]" #}
+{# Ensure the fields are not null before applying map and join #}
+
+{% set category_ids = content.field_ucb_article_categories['#items'] is defined and content.field_ucb_article_categories['#items'] is not empty
+    ? '[' ~ content.field_ucb_article_categories['#items']|map(item => item.entity.id)|join(', ') ~ ']'
+    : '[]' %}
+
+{% set tag_ids = content.field_ucb_article_tags['#items'] is defined and content.field_ucb_article_tags['#items'] is not empty
+    ? '[' ~ content.field_ucb_article_tags['#items']|map(item => item.entity.id)|join(', ') ~ ']'
+    : '[]' %}
+
+{% set exclude_categories = content.related_articles_exclude_categories['#items'] is defined and content.related_articles_exclude_categories['#items'] is not empty
+    ? '[' ~ content.related_articles_exclude_categories['#items']|map(item => item.entity.id)|join(', ') ~ ']'
+    : '[]' %}
+
+{% set exclude_tags = content.related_articles_exclude_tags['#items'] is defined and content.related_articles_exclude_tags['#items'] is not empty
+    ? '[' ~ content.related_articles_exclude_tags['#items']|map(item => item.entity.id)|join(', ') ~ ']'
+    : '[]' %}
+
+{# Test zone #}
+        <pre>
+        "this article has categories:" {{category_ids}}
+        "this article has tags:"{{tag_ids}}
+        "exclude cats:" {{exclude_categories}}
+        "exclude tags:" {{exclude_tags}}
+        {{ content.field_ucb_related_articles_parag }}
+        </pre>
+{# NEW BLOCK #}
+<related-articles
+  {{ create_attribute({
+    class: ['container', 'ucb-related-articles-block'],
+    'baseurl': baseURL,
+    'loggedin': logged_in ? 'true' : 'false',
+    'related-shown': showRelated|striptags|trim,
+    'categories': category_ids,
+    'tags': tag_ids,
+    'category-exclude': exclude_categories,
+    'tag-exclude': exclude_tags
+  }) }}>
+  {{ content.field_ucb_related_articles_parag }}
+</related-articles>
+
+{# OLD BLOCK #}
       {# Related Articles Block #}
       <div{{ create_attribute({
           class: ['container', 'ucb-related-articles-block'],


### PR DESCRIPTION
Previously the Related Articles block could produce results that were older than expected while more recent related Articles could be missing. The block has been completely reworked to use a modern Web Component style of the other Article List blocks we've developed as well as produce better and more recent Article matches by picking through a pool of the most 50 semi-related to find the top 3.

Resolves https://github.com/CuBoulder/tiamat-theme/issues/1526