### PR TITLE
Related Articles: Will Not Include Self

### DIFF
--- a/js/ucb-related-articles.js
+++ b/js/ucb-related-articles.js
@@ -174,15 +174,14 @@ class RelatedArticles extends HTMLElement {
   rankArticles(articles) {
     return articles
       .map((article) => {
+        // Filter out self
         const urlCheck = article.attributes.path.alias
-          ? article.attributes.path.alias
-          : `/node/${article.attributes.drupal_internal__nid}`;
+        ? this._baseURL + article.attributes.path.alias
+        : `${this._baseURL}/node/${article.attributes.drupal_internal__nid}`;
 
-        // Exclude the current article
-        if (urlCheck === window.location.pathname) {
+      if (urlCheck === window.location.origin + window.location.pathname) {
           return null;
-        }
-
+      }
         const categories = article.relationships?.field_ucb_article_categories?.data.map(
           (cat) => cat.meta.drupal_internal__target_id
         ) || [];


### PR DESCRIPTION
Fixes an issue with v2 of the Related Articles block where it could include itself in Related display.
Resolves https://github.com/CuBoulder/tiamat-theme/issues/1549