### PR TITLE
Newsletter List Block: fixes pathing of linked Newsletters

### DIFF
--- a/js/ucb-newsletter-list-block.js
+++ b/js/ucb-newsletter-list-block.js
@@ -170,7 +170,7 @@
         newsletterElement.classList.add('ucb-newsletter-row');
 
         const linkElement = document.createElement('a');
-        linkElement.href = newsletter.path;
+        linkElement.href = this._baseURI + newsletter.path;
         linkElement.classList.add('ucb-newsletter-list-link');
 
 


### PR DESCRIPTION
Previously the Newsletter List Block would just use the path returned via the API, which presented an issue on multisite. This has been corrected

Resolves https://github.com/CuBoulder/tiamat-theme/issues/1556