### PR TITLE
Newsletter: Re-add domain to Article Thumbnails (Wide and Teaser) referenced in a Newsletter

### DIFF
--- a/templates/paragraphs/paragraph--newsletter-section--email-html.html.twig
+++ b/templates/paragraphs/paragraph--newsletter-section--email-html.html.twig
@@ -36,7 +36,7 @@
                     'node': item.entity.field_newsletter_article_select.target_id
                   }, {'absolute': true}) }}">
                   <img
-                  src="{{
+                  src="{{base_url}}{{
                     request.schemeAndHttpHost ~ file_url(
                       item.entity.field_newsletter_article_select.entity.field_ucb_article_thumbnail.entity.field_media_image.entity.fileuri
                       | image_style('focal_image_wide')
@@ -55,7 +55,7 @@
                     'node': item.entity.field_newsletter_article_select.target_id
                   }, {'absolute': true}) }}">
                   <img
-                  src="{{
+                  src="{{base_url}}{{
                     request.schemeAndHttpHost ~ file_url(
                       item.entity.field_newsletter_article_select.entity.field_ucb_article_content.entity.field_article_media_selection.entity.field_media.entity.field_media_image.entity.fileuri
                       | image_style('focal_image_wide')
@@ -71,7 +71,7 @@
 								{% elseif item.entity.field_newsletter_content_image.entity.field_media_image.alt|render %}
 								<td align="center" style="text-align: left; padding-right:10px; padding-left:10px;padding-bottom:20px;">
                   <img
-                  src="{{
+                  src="{{base_url}}{{
                     request.schemeAndHttpHost ~ file_url(
                       item.entity.field_newsletter_content_image.entity.field_media_image.entity.fileuri
                       | image_style('focal_image_wide')
@@ -178,7 +178,7 @@
 											{# Code to render selected article content (thumbnail) #}
 											{% if item.entity.field_newsletter_article_select.entity.field_ucb_article_thumbnail.entity.field_media_image %}
                       <img
-                      src="{{
+                      src="{{base_url}}{{
                         request.schemeAndHttpHost ~ file_url(
                           item.entity.field_newsletter_article_select.entity.field_ucb_article_thumbnail.entity.field_media_image.entity.fileuri
                           | image_style('focal_image_square')
@@ -191,7 +191,7 @@
 												{# Code to render selected article content (!thumbnail) #}
 											{% elseif item.entity.field_newsletter_article_select.entity.field_ucb_article_content.entity.field_article_media_selection.entity.field_media.entity.field_media_image %}
                       <img
-                      src="{{
+                      src="{{base_url}}{{
                         request.schemeAndHttpHost ~ file_url(
                           item.entity.field_newsletter_article_select.entity.field_ucb_article_content.entity.field_article_media_selection.entity.field_media.entity.field_media_image.entity.fileuri
                           | image_style('focal_image_square')
@@ -204,7 +204,7 @@
 												{# Code to render user made content #}
 											{% elseif item.entity.field_newsletter_content_image.entity.field_media_image %}
                       <img
-                      src="{{
+                      src="{{base_url}}{{
                         request.schemeAndHttpHost ~ file_url(
                           item.entity.field_newsletter_content_image.entity.field_media_image.entity.fileuri
                           | image_style('focal_image_square')


### PR DESCRIPTION
We changed how Newsletter Article images are referenced for better generation on multi-site domains in particular. With this change the primary (www.colorado.edu) domain was dropped. This has been re-added. 

Resolves https://github.com/CuBoulder/tiamat-theme/issues/1561