### PR TITLE
#1562 - Mega Menu: fix Button color being over-written

### DIFF
--- a/css/block/ucb-mega-menu.css
+++ b/css/block/ucb-mega-menu.css
@@ -78,7 +78,7 @@
 }
 
 .ucb-main-nav-container .ucb-main-menu-mega-menu .menu-item .ucb-mega-menu-column-wrapper a{
-  color: #0277bd !important;
+  color: #0277bd;
 }
 
 .ucb-main-nav-container .ucb-main-menu-mega-menu .menu-item .ucb-mega-menu-column-wrapper a:hover{


### PR DESCRIPTION
CU Buttons placed in a Mega Menu could have their text color overwritten to the default link blue due to overly aggressive css rules. This has been corrected so menu links retain their intended colors and Buttons receive their expected styles

Resolves https://github.com/CuBoulder/tiamat-theme/issues/1562