### PR TITLE
Update ucb-brand-bar.css

### DIFF
--- a/css/ucb-brand-bar.css
+++ b/css/ucb-brand-bar.css
@@ -3,7 +3,7 @@
   flex-direction: row;
   justify-content: space-between;
   align-items: center;
-  padding: 0;
+  padding: 0!important;
 }
 
 .ucb-brand-bar.ucb-brand-bar-white {


### PR DESCRIPTION
Updated padding to be `0!important` for the brand bar to avoid styleguide interference.

Resolves #1570 