### PR TITLE
Update block--events-calendar.html.twig

### DIFF
--- a/templates/block/block--events-calendar.html.twig
+++ b/templates/block/block--events-calendar.html.twig
@@ -17,9 +17,9 @@
   {{ attach_library('boulder_base/ucb-events-calendar') }}
   {{ content.field_calendar_code }}
   {# Events Link #}
-  <div class="ucb-calendar-block-link-container">
+  <events-calendar-block class="ucb-calendar-block-link-container">
     {% for item in content['#block_content'].field_additional_events_link.value %}
       {{ link(item.title, item.uri, {'class': ['ucb-calendar-button']} ) }}
     {% endfor %}
-  </div>
+  </events-calendar-block>
 {% endblock %}


### PR DESCRIPTION
Switching the block container to a web component name to handle the block being stripped from columns before loading content.

Sister PR: https://github.com/CuBoulder/ucb_bootstrap_layouts/pull/71

Resolves #1574 