### PR TITLE
People Lists: Fix short body fields not displaying. Refines Alphabetical sorting of lists

### DIFF
--- a/js/ucb-people-list-block.js
+++ b/js/ucb-people-list-block.js
@@ -471,6 +471,8 @@
                   )
                 );
                 thisPerson.body = `${trimmedString}...`;
+              } else {
+                thisPerson.body = trimmedString;
               }
             }
         }

--- a/js/ucb-people-list-block.js
+++ b/js/ucb-people-list-block.js
@@ -480,9 +480,9 @@
                   )
                 );
 
-                thisPerson.body = `${PeopleListBlockElement.decodeHtmlEntities(trimmedString)}...`;
+                thisPerson.body = `${trimmedString}...`;
               } else {
-                thisPerson.body = PeopleListBlockElement.decodeHtmlEntities(trimmedString);
+                thisPerson.body = trimmedString;
               }
             }
         }

--- a/js/ucb-people-list-block.js
+++ b/js/ucb-people-list-block.js
@@ -90,6 +90,15 @@
      */
     static escapeHTML(raw) { return raw ? raw.replace(/\&/g, '&amp;').replace(/"/g, '&quot;').replace(/</g, '&lt;').replace(/>/g, '&gt;') : ''; }
     static get observedAttributes() { return ['user-config']; }
+    /**
+     * @param {string|null|undefined} text A raw body string
+     * @returns {string} An HTML-safe body
+     */
+    static decodeHtmlEntities(text) {
+      const parser = new DOMParser();
+      const doc = parser.parseFromString(text, "text/html");
+      return doc.documentElement.textContent;
+    }
 
     constructor() {
       super();
@@ -470,9 +479,10 @@
                     trimmedString.lastIndexOf(" ")
                   )
                 );
-                thisPerson.body = `${trimmedString}...`;
+
+                thisPerson.body = `${PeopleListBlockElement.decodeHtmlEntities(trimmedString)}...`;
               } else {
-                thisPerson.body = trimmedString;
+                thisPerson.body = PeopleListBlockElement.decodeHtmlEntities(trimmedString);
               }
             }
         }
@@ -487,7 +497,7 @@
         personLink = this.getAttribute('site-base') + person.link,
         personName = PeopleListBlockElement.escapeHTML(person.name),
         personPhoto = person.photoURI ? '<img src="' + person.photoURI + '">' : '',
-        personBody = PeopleListBlockElement.escapeHTML(person.body),
+        personBody = PeopleListBlockElement.decodeHtmlEntities(person.body),
         personEmail = PeopleListBlockElement.escapeHTML(person.email),
         personPhone = PeopleListBlockElement.escapeHTML(person.phone),
         personPrimaryLinkURI = PeopleListBlockElement.escapeHTML(person.primaryLinkURI),

--- a/js/ucb-people-list.js
+++ b/js/ucb-people-list.js
@@ -288,32 +288,43 @@
                   personAJobTypeData = personA['relationships']['field_ucb_person_job_type']['data'] || [],
                   personBJobTypeData = personB['relationships']['field_ucb_person_job_type']['data'] || [];
 
-                // Get job type names
-                const personAJobTypeName = personAJobTypeData.length
-                  ? PeopleListElement.getTaxonomyName(jobTypeTaxonomy, personAJobTypeData[0]['meta']['drupal_internal__target_id'])
-                  : '';
-                const personBJobTypeName = personBJobTypeData.length
-                  ? PeopleListElement.getTaxonomyName(jobTypeTaxonomy, personBJobTypeData[0]['meta']['drupal_internal__target_id'])
-                  : '';
+                // Handle cases where one or both people have no job type
+                if (!personAJobTypeData.length || !personBJobTypeData.length) {
+                  return personAJobTypeData.length ? -1 : 1; // Push people without job type to the bottom
+                }
 
-                // Primary sort: Alphabetical by Job Type
+                // Get job type weights
+                const personAJobTypeWeight = PeopleListElement.getTaxonomyWeight(jobTypeTaxonomy, personAJobTypeData[0]['meta']['drupal_internal__target_id']);
+                const personBJobTypeWeight = PeopleListElement.getTaxonomyWeight(jobTypeTaxonomy, personBJobTypeData[0]['meta']['drupal_internal__target_id']);
+
+                // Primary sort: By Job Type Weight (lower weight = higher priority)
+                if (personAJobTypeWeight !== personBJobTypeWeight) {
+                  return personAJobTypeWeight - personBJobTypeWeight;
+                }
+
+                // Get job type names
+                const personAJobTypeName = PeopleListElement.getTaxonomyName(jobTypeTaxonomy, personAJobTypeData[0]['meta']['drupal_internal__target_id']) || '';
+                const personBJobTypeName = PeopleListElement.getTaxonomyName(jobTypeTaxonomy, personBJobTypeData[0]['meta']['drupal_internal__target_id']) || '';
+
+                // Secondary sort: Alphabetical by Job Type Name
                 if (personAJobTypeName !== personBJobTypeName) {
                   return personAJobTypeName < personBJobTypeName ? -1 : 1;
                 }
 
-                // Secondary sort: Alphabetical by Last Name
+                // Tertiary sort: Alphabetical by Last Name
                 const lastNameA = (personA['attributes']['field_ucb_person_last_name'] || '').toLowerCase();
                 const lastNameB = (personB['attributes']['field_ucb_person_last_name'] || '').toLowerCase();
                 if (lastNameA !== lastNameB) {
                   return lastNameA < lastNameB ? -1 : 1;
                 }
 
-                // Tertiary sort: Alphabetical by First Name (optional)
+                // Final sort: Alphabetical by First Name (optional)
                 const firstNameA = (personA['attributes']['field_ucb_person_first_name'] || '').toLowerCase();
                 const firstNameB = (personB['attributes']['field_ucb_person_first_name'] || '').toLowerCase();
                 return firstNameA < firstNameB ? -1 : firstNameA > firstNameB ? 1 : 0;
               }), photoUrls, photoData, groupContainerElement);
-            } else {
+            }
+             else {
               this.displayPeople(format, peopleInGroup.sort((personA, personB) => {
                 const lastNameA = personA['attributes']['field_ucb_person_last_name'] || '';
                 const lastNameB = personB['attributes']['field_ucb_person_last_name'] || '';

--- a/js/ucb-people-list.js
+++ b/js/ucb-people-list.js
@@ -89,6 +89,15 @@
      */
     static escapeHTML(raw) { return raw ? raw.replace(/\&/g, '&amp;').replace(/"/g, '&quot;').replace(/</g, '&lt;').replace(/>/g, '&gt;') : ''; }
     static get observedAttributes() { return ['user-config']; }
+    /**
+     * @param {string|null|undefined} text A raw body string
+     * @returns {string} An HTML-safe body
+     */
+    static decodeHtmlEntities(text) {
+      const parser = new DOMParser();
+      const doc = parser.parseFromString(text, "text/html");
+      return doc.documentElement.textContent;
+    }
 
     constructor() {
       super();
@@ -567,7 +576,7 @@
         personLink = this.getAttribute('site-base') + person.link,
         personName = PeopleListElement.escapeHTML(person.name),
         personPhoto = person.photoUrl ? '<img src="' + person.photoUrl + '" alt="' + PeopleListElement.escapeHTML(person.photoAlt) + '">' : '',
-        personBody = PeopleListElement.escapeHTML(person.body),
+        personBody = PeopleListElement.decodeHtmlEntities(person.body),
         personEmail = PeopleListElement.escapeHTML(person.email),
         personPhone = PeopleListElement.escapeHTML(person.phone),
         personPrimaryLinkURI = PeopleListElement.escapeHTML(person.primaryLinkURI),


### PR DESCRIPTION
- On the People List Page and People List Block, previously Person pages with a short body field would not show that in these aggregator displays due to a logic bug which would only trigger if the Person page returned had to generate a summary, in cases where the body was too long. This would lead to short Person page body fields not displaying. This bug has been corrected. Resolves https://github.com/CuBoulder/tiamat-theme/issues/1572
- Previously on the People List Page  if the People were sorted by Last Name but some People shared a Last Name, it would display them in order of creation. This has been corrected so that it will sort by Last Name, and then First Name in cases of shared last names. Resolves https://github.com/CuBoulder/tiamat-theme/issues/1573