### PR TITLE
Aggregators will only display error messages to Authenticated Users

### DIFF
--- a/css/block/block-styles.css
+++ b/css/block/block-styles.css
@@ -292,3 +292,13 @@
 .bs-icon-position-top + .block-title-text {
   display: block;
 }
+
+/* Block Error Message - Display to Authenticated Only */
+.ucb-anonymous.ucb-block-error{
+  display: none;
+}
+
+.block:has(.ucb-anonymous.ucb-block-error) {
+  display: none;
+}
+

--- a/css/block/block-styles.css
+++ b/css/block/block-styles.css
@@ -294,11 +294,6 @@
 }
 
 /* Block Error Message - Display to Authenticated Only */
-.ucb-anonymous.ucb-block-error{
-  display: none;
+.ucb-anonymous.ucb-block-error, .ucb-anonymous .ucb-block-error{
+  display: none !important;
 }
-
-.block:has(.ucb-anonymous.ucb-block-error) {
-  display: none;
-}
-

--- a/js/faculty-publications.js
+++ b/js/faculty-publications.js
@@ -220,6 +220,7 @@
         + '</p>';
       this.loadButtonElement.innerHTML = '<i class="fa-solid fa-rotate-right"></i> Retry';
       this.messagesElement.removeAttribute('hidden');
+      this.messagesElement.classList.add('ucb-block-error');
       this.controlsElement.removeAttribute('hidden');
       this.throbberElement.setAttribute('hidden', '');
     }
@@ -232,6 +233,7 @@
         + '<strong>There were no publications returned.</strong>'
         + '</p>';
       this.messagesElement.removeAttribute('hidden');
+      this.messagesElement.classList.add('ucb-block-error');
     }
 
   }
@@ -278,7 +280,7 @@
    *
    * @param {string} safeText
    *   The link text.
-   * @param {string|undefined} uri 
+   * @param {string|undefined} uri
    *   The URI to link to.
    * @returns
    *   The HTML link, if `uri` is valid.

--- a/js/ucb-article-feature-block.js
+++ b/js/ucb-article-feature-block.js
@@ -1,3 +1,5 @@
+(function (customElements) {
+
 class ArticleFeatureBlockElement extends HTMLElement {
   constructor() {
     super();
@@ -31,6 +33,7 @@ class ArticleFeatureBlockElement extends HTMLElement {
         console.error(Error);
         this.toggleMessage("ucb-al-loading");
         this.toggleMessage("ucb-al-api-error", "block");
+        this.classList.add("ucb-block-error");
       });
   }
 
@@ -53,6 +56,7 @@ class ArticleFeatureBlockElement extends HTMLElement {
     if (data.data.length === 0) {
       this.toggleMessage("ucb-al-loading");
       this.toggleMessage("ucb-al-error", "block");
+      this.classList.add("ucb-block-error");
       console.warn(
         "No Articles retrieved - please check your inclusion filters and try again"
       );
@@ -168,6 +172,7 @@ class ArticleFeatureBlockElement extends HTMLElement {
           console.error(Error);
           this.toggleMessage("ucb-al-loading");
           this.toggleMessage("ucb-al-api-error", "block");
+          this.classList.add("ucb-block-error");
         });
       return;
     }
@@ -179,6 +184,7 @@ class ArticleFeatureBlockElement extends HTMLElement {
       );
       this.toggleMessage("ucb-al-loading");
       this.toggleMessage("ucb-al-error", "block");
+      this.classList.add("ucb-block-error");
       return;
     }
     // Render articles if the count is met or no more articles are available
@@ -230,6 +236,7 @@ class ArticleFeatureBlockElement extends HTMLElement {
       console.error(Error);
       this.toggleMessage("ucb-al-loading");
       this.toggleMessage("ucb-al-api-error", "block");
+      this.classList.add("ucb-block-error");
       return ""; // Return an empty string in case of error
     }
   }
@@ -586,3 +593,4 @@ class ArticleFeatureBlockElement extends HTMLElement {
 }
 
 customElements.define("article-feature-block", ArticleFeatureBlockElement);
+})(window.customElements);

--- a/js/ucb-article-grid-block.js
+++ b/js/ucb-article-grid-block.js
@@ -1,3 +1,5 @@
+(function (customElements) {
+
 class ArticleGridBlockElement extends HTMLElement {
   constructor() {
     super();
@@ -27,6 +29,7 @@ class ArticleGridBlockElement extends HTMLElement {
         console.error(Error);
         this.toggleMessage("ucb-al-loading");
         this.toggleMessage("ucb-al-api-error", "block");
+        this.classList.add("ucb-block-error");
       });
   }
 
@@ -48,6 +51,7 @@ class ArticleGridBlockElement extends HTMLElement {
     if (data.data.length === 0) {
       this.toggleMessage("ucb-al-loading");
       this.toggleMessage("ucb-al-error", "block");
+      this.classList.add("ucb-block-error");
       console.warn(
         "No Articles retrieved - please check your inclusion filters and try again"
       );
@@ -150,6 +154,7 @@ class ArticleGridBlockElement extends HTMLElement {
       console.error(error);
       this.toggleMessage("ucb-al-loading");
       this.toggleMessage("ucb-al-api-error", "block");
+      this.classList.add("ucb-block-error");
     }
     return;
   }
@@ -161,6 +166,7 @@ class ArticleGridBlockElement extends HTMLElement {
     );
     this.toggleMessage("ucb-al-loading");
     this.toggleMessage("ucb-al-error", "block");
+    this.classList.add("ucb-block-error");
     return;
   }
 
@@ -213,6 +219,7 @@ async getArticleParagraph(id) {
     console.error(Error);
     this.toggleMessage("ucb-al-loading");
     this.toggleMessage("ucb-al-api-error", "block");
+    this.classList.add("ucb-block-error");
     return ""; // Return an empty string in case of error
   }
 }
@@ -300,3 +307,4 @@ async getArticleParagraph(id) {
 }
 
 customElements.define("article-grid-block", ArticleGridBlockElement);
+})(window.customElements);

--- a/js/ucb-article-list-block.js
+++ b/js/ucb-article-list-block.js
@@ -1,3 +1,4 @@
+(function (customElements) {
 class ArticleListBlockElement extends HTMLElement {
   constructor() {
     super();
@@ -23,6 +24,7 @@ class ArticleListBlockElement extends HTMLElement {
         console.error(Error);
         this.toggleMessage("ucb-al-loading");
         this.toggleMessage("ucb-al-api-error", "block");
+        this.classList.add("ucb-block-error");
       });
   }
 
@@ -43,6 +45,7 @@ class ArticleListBlockElement extends HTMLElement {
     if (data.data.length === 0) {
       this.toggleMessage("ucb-al-loading");
       this.toggleMessage("ucb-al-error", "block");
+      this.classList.add("ucb-block-error");
       console.warn(
         "No Articles retrieved - please check your inclusion filters and try again"
       );
@@ -170,6 +173,7 @@ class ArticleListBlockElement extends HTMLElement {
       );
       this.toggleMessage("ucb-al-loading");
       this.toggleMessage("ucb-al-error", "block");
+      this.classList.add("ucb-block-error");
       return;
     }
 
@@ -222,6 +226,7 @@ class ArticleListBlockElement extends HTMLElement {
       console.error(Error);
       this.toggleMessage("ucb-al-loading");
       this.toggleMessage("ucb-al-api-error", "block");
+      this.classList.add("ucb-block-error");
       return ""; // Return an empty string in case of error
     }
   }
@@ -590,3 +595,4 @@ class ArticleListBlockElement extends HTMLElement {
 }
 
 customElements.define('article-list-block', ArticleListBlockElement);
+})(window.customElements);

--- a/js/ucb-article-list.js
+++ b/js/ucb-article-list.js
@@ -138,6 +138,7 @@
         this._nextURL = data['links']?.next?.href || null;
         return { data: articles, included: included };
       } catch (error) {
+        this.classList.add("ucb-block-error", this.getAttribute('logged-in'));
         console.error(ArticleListProvider.errorMessage);
         throw error;
       }
@@ -223,13 +224,13 @@
       // Error
       this._errorElement = document.createElement('div');
       this._errorElement.innerText = ArticleListProvider.errorMessage;
-      this._errorElement.className = 'ucb-list-msg ucb-error';
+      this._errorElement.className = 'ucb-list-msg ucb-block-error';
       this._errorElement.id = 'ucb-al-error'
       this._errorElement.style.display = 'none';
       this.appendChild(this._errorElement);
       // No Results Found
       this._noResultsElement = document.createElement('div');
-      this._noResultsElement.className = 'ucb-list-msg ucb-no-results';
+      this._noResultsElement.className = 'ucb-list-msg ucb-no-results ucb-block-error';
       this._noResultsElement.innerText = 'No results found.';
       this._noResultsElement.style.display = 'none';
       this.appendChild(this._noResultsElement);
@@ -254,6 +255,7 @@
         this.generateFilterForm();
         this.loadArticles();
       } catch (error) {
+        this.classList.add("ucb-block-error");
         console.error('Error fetching taxonomies:', error);
       }
     }
@@ -711,6 +713,7 @@
         }
         return trimmedString + "...";
       } catch (Error) {
+        this.classList.add("ucb-block-error", this.getAttribute('logged-in'));
         console.error(
           "There was an error fetching Article Paragraph from the API - Please try again later."
         );

--- a/js/ucb-article-slider-block.js
+++ b/js/ucb-article-slider-block.js
@@ -1,3 +1,4 @@
+(function (customElements) {
 class ArticleSliderBlockElement extends HTMLElement {
 	constructor() {
 		super();
@@ -18,7 +19,8 @@ class ArticleSliderBlockElement extends HTMLElement {
               console.error('There was an error fetching data from the API - Please try again later.')
               console.error(Error)
               this.toggleMessage('ucb-al-loading')
-              this.toggleMessage('ucb-al-api-error', "block")
+              this.toggleMessage('ucb-al-api-error', "block");
+              this.classList.add("ucb-block-error");
             });
     }
 
@@ -36,6 +38,7 @@ class ArticleSliderBlockElement extends HTMLElement {
         if(data.data.length == 0){
             this.toggleMessage('ucb-al-loading')
             this.toggleMessage('ucb-al-error',"block")
+            this.classList.add("ucb-block-error");
             console.warn('No Articles retrieved - please check your inclusion filters and try again')
         } else {
         // Below objects are needed to match images with their corresponding articles. There are two endpoints => data.data (article) and data.included (incl. media), both needed to associate a media library image with its respective article
@@ -125,7 +128,8 @@ class ArticleSliderBlockElement extends HTMLElement {
               console.error('There was an error fetching data from the API - Please try again later.')
               console.error(Error)
               this.toggleMessage('ucb-al-loading')
-              this.toggleMessage('ucb-al-api-error', "block")
+              this.toggleMessage('ucb-al-api-error', "block");
+              this.classList.add("ucb-block-error");
             });
         }
 
@@ -133,7 +137,8 @@ class ArticleSliderBlockElement extends HTMLElement {
         if(finalArticles.length === 0 && !NEXTJSONURL){
           console.error('There are no available Articles that match the selected filters. Please adjust your filters and try again.')
           this.toggleMessage('ucb-al-loading')
-          this.toggleMessage('ucb-al-error', "block")
+          this.toggleMessage('ucb-al-error', "block");
+          this.classList.add("ucb-block-error");
         }
 
         // Case for Too many articles
@@ -230,3 +235,4 @@ class ArticleSliderBlockElement extends HTMLElement {
 }
 
 customElements.define('article-slider-block', ArticleSliderBlockElement);
+})(window.customElements);

--- a/js/ucb-category-cloud.js
+++ b/js/ucb-category-cloud.js
@@ -1,3 +1,5 @@
+(function (customElements) {
+
 class CategoryCloudElement extends HTMLElement {
 	constructor() {
 		super();
@@ -39,6 +41,7 @@ class CategoryCloudElement extends HTMLElement {
 }
 
     handleError(Error, ErrorMsg = 'Error Fetching Categories - Check the console'){
+        this.classList.add("ucb-block-error");
         const container = document.createElement('div');
         container.className = 'ucb-category-cloud-container';
         const span = document.createElement('span')
@@ -56,9 +59,10 @@ class CategoryCloudElement extends HTMLElement {
 
         this.appendChild(container)
         // Log error
-            console.error(Error)
+        console.error(Error)
 
     }
 }
 
 customElements.define('category-cloud-block', CategoryCloudElement);
+})(window.customElements);

--- a/js/ucb-current-issue-block.js
+++ b/js/ucb-current-issue-block.js
@@ -1,3 +1,4 @@
+(function (customElements) {
 class CurrentIssueElement extends HTMLElement {
 	constructor() {
 		super();
@@ -15,13 +16,13 @@ class CurrentIssueElement extends HTMLElement {
             .then((data) => this.build(data))
             .catch(Error=> {
                 this.toggleMessage('ucb-al-loading');
-                this.handleError(Error)
+                this.handleError(Error);
             });
     }
 
     build(data){
         if(data.data.length == 0){
-            this.handleError({name : "No Issues Retrieved", message : "There are no Issues created"} , 'No Issues Found')
+            this.handleError({name : "No Issues Retrieved", message : "There are no Issues created"} , 'No Issues Found');
         } else {
             const title = data.data[0].attributes.title
             let imgURL
@@ -92,6 +93,8 @@ class CurrentIssueElement extends HTMLElement {
     }
 
     handleError(Error, ErrorMsg = 'Error Fetching issues - Check the console'){
+        this.classList.add("ucb-block-error");
+        this.toggleMessage('ucb-al-loading');
         const container = document.createElement('div');
         container.className = 'ucb-current-issue-block-content';
         const span = document.createElement('span')
@@ -128,3 +131,4 @@ class CurrentIssueElement extends HTMLElement {
 
 
 customElements.define('current-issue-block', CurrentIssueElement);
+})(window.customElements);

--- a/js/ucb-latest-issue-block.js
+++ b/js/ucb-latest-issue-block.js
@@ -1,3 +1,4 @@
+(function (customElements) {
 class LatestIssueElement extends HTMLElement {
 	constructor() {
 		super();
@@ -110,6 +111,8 @@ class LatestIssueElement extends HTMLElement {
     }
 
     handleError(Error, ErrorMsg = 'Error Fetching issues - Check the console'){
+        this.classList.add("ucb-block-error");
+        this.toggleMessage('ucb-al-loading');
         const container = document.createElement('div');
         container.className = 'ucb-current-issue-block-content';
         const span = document.createElement('span')
@@ -145,3 +148,4 @@ class LatestIssueElement extends HTMLElement {
 
 
 customElements.define('latest-issue-block', LatestIssueElement);
+})(window.customElements);

--- a/js/ucb-newsletter-list-block.js
+++ b/js/ucb-newsletter-list-block.js
@@ -207,6 +207,7 @@
     }
 
     toggleError(show) {
+      this.classList.add("ucb-block-error");
       this._errorElement.style.display = show ? 'block' : 'none';
     }
   }

--- a/js/ucb-people-list-block.js
+++ b/js/ucb-people-list-block.js
@@ -61,6 +61,7 @@
         // Warn if no results are returned in the 'data' section
         if (!data['data'] || data['data'].length === 0) {
           console.warn('PeopleListProvider: ' + PeopleListProvider.noResultsMessage);
+          this.classList.add("ucb-block-error");
         } else {
           aggregatedData.push(...data['data']);
         }
@@ -78,6 +79,7 @@
         return { data: aggregatedData, included: aggregatedIncluded };
       } catch (error) {
         console.error('PeopleListProvider: ' + PeopleListProvider.errorMessage);
+        this.classList.add("ucb-block-error");
         throw error;
       }
     }
@@ -199,9 +201,10 @@
       peopleListProvider.fetchAllPeople(baseURI + peopleListProvider.nextPath).then(response => {
         this._contentElement.innerText = '';
         const results = response['data'];
-        if (!results.length)
+        if (!results.length){
           this.toggleMessageDisplay(this._messageElement, 'block', 'ucb-list-msg ucb-end-of-results', PeopleListProvider.noResultsMessage);
-        else {
+          this.classList.add("ucb-block-error");
+        } else {
           if (groupBy != 'none') { // Build person -> term mapping
             const groupedPeople = this._groupedPeople = new Map();
             results.forEach(person => {
@@ -643,6 +646,7 @@
     }
 
     onFatalError(reason) {
+      this.classList.add("ucb-block-error");
       this.toggleMessageDisplay(this._messageElement, 'block', 'ucb-list-msg ucb-error', PeopleListProvider.errorMessage);
       this.toggleMessageDisplay(this._loadingElement, 'none', null, null);
       throw reason;

--- a/js/ucb-people-list.js
+++ b/js/ucb-people-list.js
@@ -207,6 +207,7 @@
           // Taxonomy data required for grouping is missing, can't group by!
           console.error(`Grouping by ${groupBy} is requested, but taxonomy data is missing. Please adjust your page's 'Group By' setting or make sure taxonomy data exists for that term.`);
           this.toggleMessageDisplay(this._messageElement, 'block', 'ucb-list-msg ucb-error', `Cannot group by ${groupBy} because taxonomy data is missing.`);
+          this._messageElement.classList.add('ucb-block-error')
           this.toggleMessageDisplay(this._loadingElement, 'none', null, null);
           return;
         }
@@ -227,9 +228,10 @@
       peopleListProvider.fetchAllPeople(baseURI + peopleListProvider.nextPath).then(response => {
         this._contentElement.innerText = '';
         const results = response['data'];
-        if (!results.length)
+        if (!results.length){
           this.toggleMessageDisplay(this._messageElement, 'block', 'ucb-list-msg ucb-end-of-results', PeopleListProvider.noResultsMessage);
-        else {
+          this._messageElement.classList.add('ucb-block-error')
+        } else {
           if (groupBy != 'none') { // Build person -> term mapping
             const groupedPeople = this._groupedPeople = new Map();
             let hasGroupingTaxonomy = false;
@@ -254,6 +256,7 @@
             });
             if (!hasGroupingTaxonomy) {
               this.toggleMessageDisplay(this._messageElement, 'block', 'ucb-list-msg', `No results found for the '${groupBy}' grouping.`);
+              this._messageElement.classList.add('ucb-block-error');
               this.toggleMessageDisplay(this._loadingElement, 'none', null, null);
               return;
             }
@@ -760,6 +763,7 @@
 
     onFatalError(reason) {
       this.toggleMessageDisplay(this._messageElement, 'block', 'ucb-list-msg ucb-error', PeopleListProvider.errorMessage);
+      this._messageElement.classList.add('ucb-block-error');
       this.toggleMessageDisplay(this._loadingElement, 'none', null, null);
       throw reason;
     }

--- a/js/ucb-tag-cloud.js
+++ b/js/ucb-tag-cloud.js
@@ -1,8 +1,8 @@
+(function (customElements) {
 class TagCloudElement extends HTMLElement {
 	constructor() {
 		super();
     this._baseURI = this.getAttribute("base-uri");
-    console.log(this._baseURI)
         const handleError = response => {
             if (!response.ok) {
                throw new Error;
@@ -39,6 +39,7 @@ class TagCloudElement extends HTMLElement {
 }
 
     handleError(Error, ErrorMsg = 'Error Fetching Tags - Check the console'){
+        this.classList.add("ucb-block-error");
         const container = document.createElement('div');
         container.className = 'ucb-tag-cloud-container';
         const span = document.createElement('span')
@@ -62,3 +63,4 @@ class TagCloudElement extends HTMLElement {
 }
 
 customElements.define('tag-cloud-block', TagCloudElement);
+})(window.customElements);

--- a/templates/block/block--article-list-block.html.twig
+++ b/templates/block/block--article-list-block.html.twig
@@ -12,6 +12,10 @@
   view_mode ? 'block--view-mode-' ~ view_mode|clean_class,
 ] %}
 
+{# Logged In - Used for showing errors to only authenticated #}
+{% set logged_in_class = logged_in ? 'ucb-authenticated' : 'ucb-anonymous' %}
+
+
 {# Base Url #}
 {% set baseurlJSON = url('<front>')|render|trim('/') %}
 
@@ -177,6 +181,7 @@
   {{ content.body }}
   {# Article List Main Block#}
   <article-list-block
+    class="{{logged_in_class}}"
     base-uri="{{ baseurlJSON }}"
     jsonapi="{{ articlesJSON }}{{ IncludeFilter }}{{ pageCountFilter }}{{ sortFilter }}"
     exCats="{{ excludeCategories }}"

--- a/templates/block/block--faculty-publications.html.twig
+++ b/templates/block/block--faculty-publications.html.twig
@@ -12,6 +12,10 @@
   view_mode ? 'block--view-mode-' ~ view_mode|clean_class,
   'ucb-faculty-publications'
 ] %}
+
+{# Logged In - Used for showing errors to only authenticated #}
+{% set logged_in_class = logged_in ? 'ucb-authenticated' : 'ucb-anonymous' %}
+
 {% set blockContent = content['#block_content'] %}
 {% set fieldFrom = blockContent.field_faculty_publications_from.value %}
 {% set fieldTo = blockContent.field_faculty_publications_to.value %}
@@ -23,6 +27,7 @@
 {% block content %}
   {{ attach_library('boulder_base/ucb-faculty-publications') }}
   <faculty-publications{{ create_attribute({
+    class: logged_in_class,
     from: fieldFrom ? fieldFrom|date('Y-m-d') : null,
     to: fieldTo ? fieldTo|date('Y-m-d') : null,
     department: fieldDpt ? fieldDpt|trim : null,

--- a/templates/block/block--ucb-article-feature.html.twig
+++ b/templates/block/block--ucb-article-feature.html.twig
@@ -12,6 +12,9 @@
   view_mode ? 'block--view-mode-' ~ view_mode|clean_class
 ] %}
 
+{# Logged In - Used for showing errors to only authenticated #}
+{% set logged_in_class = logged_in ? 'ucb-authenticated' : 'ucb-anonymous' %}
+
 {# Base Url #}
 {% set baseurlJSON = url('<front>')|render|trim('/') %}
 
@@ -173,6 +176,7 @@
   {{ attach_library('boulder_base/ucb-article-feature-block') }}
   {# Article Feature Main Block#}
   <article-feature-block
+    class="{{logged_in_class}}"
     base-uri="{{ baseurlJSON }}"
     jsonapi="{{ articlesJSON }}{{ IncludeFilter }}{{ pageCountFilter }}{{ sortFilter }}"
     exCats="{{ excludeCategories }}"

--- a/templates/block/block--ucb-article-grid.html.twig
+++ b/templates/block/block--ucb-article-grid.html.twig
@@ -12,6 +12,9 @@
   view_mode ? 'block--view-mode-' ~ view_mode|clean_class
 ] %}
 
+{# Logged In - Used for showing errors to only authenticated #}
+{% set logged_in_class = logged_in ? 'ucb-authenticated' : 'ucb-anonymous' %}
+
 {# This block mirrors the Article List Node - constructs a JSON endpoint in TWIG using include filters #}
 {# JSON API Endpoint information #}
 {% set articlesJSON = (url('<front>')|render|trim('/'))
@@ -174,6 +177,7 @@
   {{ content.body }}
   {# Article Grid Main Block#}
   <article-grid-block
+    class="{{logged_in_class}}"
     base-uri="{{ baseurlJSON }}"
     jsonapi="{{ articlesJSON }}{{ IncludeFilter }}{{ pageCountFilter }}{{ sortFilter }}"
     exCats="{{ excludeCategories }}"

--- a/templates/block/block--ucb-article-slider.html.twig
+++ b/templates/block/block--ucb-article-slider.html.twig
@@ -12,6 +12,9 @@
   view_mode ? 'block--view-mode-' ~ view_mode|clean_class
 ] %}
 
+{# Logged In - Used for showing errors to only authenticated #}
+{% set logged_in_class = logged_in ? 'ucb-authenticated' : 'ucb-anonymous' %}
+
 {# Unique Id #}
 {% set id = ''|clean_unique_id %}
 
@@ -176,7 +179,7 @@
   {{ attach_library('boulder_base/ucb-article-slider-block') }}
   {{ content.body }}
   {# Article Slider Main Block#}
-  <article-slider-block id="{{id}}" base-uri="{{ baseurlJSON }}" jsonapi="{{ articlesJSON }}{{ IncludeFilter }}{{ pageCountFilter }}{{ sortFilter }}" excats="{{ excludeCategories }}" extags="{{ excludeTags }}">
+  <article-slider-block id="{{id}}" class="{{logged_in_class}}" base-uri="{{ baseurlJSON }}" jsonapi="{{ articlesJSON }}{{ IncludeFilter }}{{ pageCountFilter }}{{ sortFilter }}" excats="{{ excludeCategories }}" extags="{{ excludeTags }}">
     <div id="ucb-al-loading" class="ucb-list-msg ucb-loading-data">
       <i class="fa-solid fa-spinner fa-3x fa-spin-pulse"></i>
     </div>

--- a/templates/block/block--ucb-category-cloud.html.twig
+++ b/templates/block/block--ucb-category-cloud.html.twig
@@ -15,9 +15,12 @@
 {# Base Url #}
 {% set baseurlJSON = url('<front>')|render|trim('/') %}
 
+{# Logged In - Used for showing errors to only authenticated #}
+{% set logged_in_class = logged_in ? 'ucb-authenticated' : 'ucb-anonymous' %}
+
 {% extends '@boulder_base/block/styled-block.html.twig' %}
 {% block content %}
   {{ attach_library('boulder_base/ucb-category-cloud') }}
   {{ content.body }}
-  <category-cloud-block base-uri="{{ baseurlJSON }}"></category-cloud-block>
+  <category-cloud-block class={{logged_in_class}} base-uri="{{ baseurlJSON }}"></category-cloud-block>
 {% endblock %}

--- a/templates/block/block--ucb-current-issue-block.html.twig
+++ b/templates/block/block--ucb-current-issue-block.html.twig
@@ -15,10 +15,13 @@
 {# Base Url #}
 {% set baseurlJSON = url('<front>')|render|trim('/') %}
 
+{# Logged In - Used for showing errors to only authenticated #}
+{% set logged_in_class = logged_in ? 'ucb-authenticated' : 'ucb-anonymous' %}
+
 {% extends '@boulder_base/block/styled-block.html.twig' %}
 {% block content %}
   {{ attach_library('boulder_base/ucb-current-issue') }}
-  <current-issue-block base-uri="{{ baseurlJSON }}">
+  <current-issue-block class="{{logged_in_class}}" base-uri="{{ baseurlJSON }}">
     <div id="ucb-al-loading" class="ucb-list-msg ucb-loading-data">
       <i class="fa-solid fa-spinner fa-3x fa-spin-pulse"></i>
     </div>

--- a/templates/block/block--ucb-latest-issues-block.html.twig
+++ b/templates/block/block--ucb-latest-issues-block.html.twig
@@ -14,10 +14,13 @@
 
 {% set baseurlJSON = (url('<front>')|render|trim('/'))%}
 
+{# Logged In - Used for showing errors to only authenticated #}
+{% set logged_in_class = logged_in ? 'ucb-authenticated' : 'ucb-anonymous' %}
+
 {% extends '@boulder_base/block/styled-block.html.twig' %}
 {% block content %}
   {{ attach_library('boulder_base/ucb-latest-issue') }}
-  <latest-issue-block baseURL="{{baseurlJSON}}" siteName="{{ site_name|lower|replace({ ' ': '-', '_': '-' }) }}">
+  <latest-issue-block class="{{logged_in_class}}" baseURL="{{baseurlJSON}}" siteName="{{ site_name|lower|replace({ ' ': '-', '_': '-' }) }}">
     <div id="ucb-al-loading" class="ucb-list-msg ucb-loading-data">
       <i class="fa-solid fa-spinner fa-3x fa-spin-pulse"></i>
     </div>

--- a/templates/block/block--ucb-newsletter-list-block.html.twig
+++ b/templates/block/block--ucb-newsletter-list-block.html.twig
@@ -11,10 +11,14 @@
 
 {% set baseurlJSON = url('<front>')|render|trim('/') %}
 
+{# Logged In - Used for showing errors to only authenticated #}
+{% set logged_in_class = logged_in ? 'ucb-authenticated' : 'ucb-anonymous' %}
+
 {% block content %}
 {{ attach_library('boulder_base/ucb-newsletter-list-block') }}
   {{ content.body }}
   <ucb-newsletter-list
+    class="{{logged_in_class}}"
     baseURI="{{baseurlJSON}}"
     count="{{content.field_ucb_newsletter_list_count|render|striptags|trim}}"
     newsletter-type="{{content.field_select_newsletter_lis_type|render|striptags|trim}}"

--- a/templates/block/block--ucb-people-list-block.html.twig
+++ b/templates/block/block--ucb-people-list-block.html.twig
@@ -3,6 +3,10 @@
  * @file Contains the template to display the People List block.
  */
 #}
+
+{# Logged In - Used for showing errors to only authenticated #}
+{% set logged_in_class = logged_in ? 'ucb-authenticated' : 'ucb-anonymous' %}
+
 {% set classes = [
   'block',
   'container',
@@ -60,6 +64,7 @@
   {{ attach_library('boulder_base/ucb-people-list-block') }}
   {# People List Block - Main Block#}
   <people-list-block
+    class="{{logged_in_class}}"
     site-base= "{{ url('<front>')|render|trim('/') }}"
     base-uri="{{ url('<front>')|render|trim('/') }}/jsonapi"
     config="{{ config|json_encode }}"

--- a/templates/block/block--ucb-tag-cloud.html.twig
+++ b/templates/block/block--ucb-tag-cloud.html.twig
@@ -12,6 +12,9 @@
   view_mode ? 'block--view-mode-' ~ view_mode|clean_class
 ] %}
 
+{# Logged In - Used for showing errors to only authenticated #}
+{% set logged_in_class = logged_in ? 'ucb-authenticated' : 'ucb-anonymous' %}
+
 {# Base Url #}
 {% set baseurlJSON = url('<front>')|render|trim('/') %}
 
@@ -19,5 +22,5 @@
 {% block content %}
   {{ attach_library('boulder_base/ucb-tag-cloud') }}
   {{ content.body }}
-  <tag-cloud-block base-uri="{{ baseurlJSON }}"></tag-cloud-block>
+  <tag-cloud-block class="{{logged_in_class}}" base-uri="{{ baseurlJSON }}"></tag-cloud-block>
 {% endblock %}

--- a/templates/content/node--ucb-article-list.html.twig
+++ b/templates/content/node--ucb-article-list.html.twig
@@ -72,6 +72,9 @@
 {# Base Url #}
 {% set baseurlJSON = url('<front>')|render|trim('/') %}
 
+{# Logged In - Used for showing errors to only authenticated #}
+{% set logged_in_class = logged_in ? 'ucb-authenticated' : 'ucb-anonymous' %}
+
 {# Show/Hide Date #}
 {% set global_date_format = drupal_config('ucb_site_configuration.settings', 'article_date_format') %}
 
@@ -144,8 +147,9 @@
     </div>
     <article-list{{ create_attribute({
       id: 'ucb-article-listing',
-      class: 'ucb-article-list-container',
+      class: ['ucb-article-list-container', logged_in_class],
       'base-uri' : baseurlJSON,
+      'logged-in' : logged_in_class,
       'include-categories' : includeCategories,
       'include-tags' : includeTags,
       'exclude-categories': excludeCategories,

--- a/templates/content/node--ucb-people-list-page.html.twig
+++ b/templates/content/node--ucb-people-list-page.html.twig
@@ -2,13 +2,16 @@
 /**
  * Theme layout to display a People List Page.
  *
- * TODO: 
+ * TODO:
  *  - Image styles (try : https://www.drupal.org/project/consumer_image_styles )
- *  - Display filters on rendered page 
+ *  - Display filters on rendered page
  */
 #}
 
 {{ attach_library('boulder_base/ucb-people-list-page') }}
+
+{# Logged In - Used for showing errors to only authenticated #}
+{% set logged_in_class = logged_in ? 'ucb-authenticated' : 'ucb-anonymous' %}
 
 {% set classes = [
   'node',
@@ -76,6 +79,7 @@
   </div>
   {% endif %}
   <ucb-people-list{{ create_attribute({
+    'class' : logged_in_class,
     'site-base': url('<front>')|render|trim('/'),
     'base-uri': url('<front>')|render|trim('/') ~ '/jsonapi',
     config: config|json_encode,

--- a/templates/field/field--block-content--field-calendar-code.html.twig
+++ b/templates/field/field--block-content--field-calendar-code.html.twig
@@ -3,6 +3,8 @@
  * Theme layout to display a CU Events Calendar
  **
 #}
+{# Logged In - Used for showing errors to only authenticated #}
+{% set logged_in_class = logged_in ? 'ucb-authenticated' : 'ucb-anonymous' %}
 
 {% for item in items %}
   {% if ('text/javascript' in item.content['#context'].value) and ('src="https://calendar.colorado.edu/widget' in item.content['#context'].value) %}
@@ -14,6 +16,6 @@
       <script type="text/javascript" src="https://calendar.colorado.edu/widget/{{widgetType}}?{{ queryParams }}"></script>
     </div>
   {% else %}
-    <strong>Error: Only calendar.colorado.edu events embed code is allowed.</strong>
+    <strong class="{{logged_in_class}} ucb-block-error">Error: Only calendar.colorado.edu events embed code is allowed.</strong>
   {% endif %}
 {% endfor %}


### PR DESCRIPTION
Previously Aggregator/ API-driven content would show various Error messaging to reflect Content-Aggregator blocks failure to display results, such as No Results found, API errors, overly aggressive filtering, etc. intended to prompt site-editors to take action and intervene to fix the content to display properly. These errors would show indiscriminately of a user's role. 

This has been adjusted so Anonymous users don't see the Error messaging and only show it to Authenticated users. This includes pages such as the Article List Page, the People List Page as well as blocks such as Article aggregator blocks, People List block, taxonomy clouds, and more. 

Resolves https://github.com/CuBoulder/tiamat-theme/issues/1392