### PR TITLE
Newsletter: Fixes pathing and size of images within Newsletter Content Blocks 

### DIFF
--- a/js/ucb-newsletter.js
+++ b/js/ucb-newsletter.js
@@ -35,6 +35,21 @@
               img.setAttribute('style', 'max-width: 600px; width: 100%; height: auto; display: block;');
           }
       }
+
+      // Images in the blocks -- make absolute
+            var blockSection = document.getElementById('ucb-newsletter-block-table');
+            if (blockSection) {
+                var images = blockSection.getElementsByClassName('imageMediaStyle');
+                for (let imgContainer of images) {
+                    var img = imgContainer.children[0];
+                    var endurl = img.getAttribute('src');
+                    img.setAttribute('src', `${baseURL}${endurl}`);
+                    // Ensure the image fits within 300/600px while maintaining proportions
+                    var imgSize = document.getElementById('ucb-single-newsletter-block') ? '600px' : '300px'
+                    img.setAttribute('style', `max-width: ${imgSize}; width: 100%; height: auto; display: block;`);
+                }
+            }
+
         // Section Link - make blue (gets overridden by user agent style)
         var moreLinks = document.getElementsByClassName('article-link')
         for(link of moreLinks){

--- a/templates/content/node--newsletter--email-html.html.twig
+++ b/templates/content/node--newsletter--email-html.html.twig
@@ -633,7 +633,7 @@
 {# Render the blocks side by side #}
 {# Check if there are blocks to render #}
 {% if blocksToRender %}
-    <table role="presentation" border="0" cellspacing="0" cellpadding="0" width="100%" style="border-collapse: collapse; margin: 0 auto; width: 100%; max-width: 600px; text-align: center; font-family: Helvetica, Arial, sans-serif; font-size: 14px; background-color: white;" class="row row-content ucb-newsletter-blocks">
+    <table role="presentation" border="0" cellspacing="0" cellpadding="0" width="100%" style="border-collapse: collapse; margin: 0 auto; width: 100%; max-width: 600px; text-align: center; font-family: Helvetica, Arial, sans-serif; font-size: 14px; background-color: white;" class="row row-content ucb-newsletter-blocks" id="ucb-newsletter-block-table">
         <tbody>
             <tr>
                 <td align="center" valign="top" style="padding: 0;">
@@ -645,7 +645,7 @@
                                 {% if blocksToRender|length == 1 %}
                                     <tr>
                                         <td align="left" valign="top" style="width: 100%; padding: 10px; box-sizing: border-box; vertical-align: top;">
-                                            <table role="presentation" border="0" cellspacing="0" cellpadding="0" style="border-collapse: collapse; width: 100%; table-layout: fixed;">
+                                            <table role="presentation" border="0" cellspacing="0" cellpadding="0" style="border-collapse: collapse; width: 100%; table-layout: fixed;" id="ucb-single-newsletter-block">
                                                 <tr>
                                                     <td style="vertical-align: top; color: #000000;">
                                                         {{ blocksToRender[i] }}


### PR DESCRIPTION
Previously images placed in the Newsletter Blocks `Newsletter Block Text` section would show up in the Email HTML with relative pathing and no fixed style sizes, resulting in very broken images. This has been corrected so images should render at full-width of their section at both options -- one Block at full width OR multiple Blocks side by side. 

Resolves https://github.com/CuBoulder/tiamat-theme/issues/1605