### PR TITLE
#1618 - Fixes missing Search Icon on Mobile size screens

### DIFF
--- a/css/ucb-brand-bar.css
+++ b/css/ucb-brand-bar.css
@@ -25,10 +25,6 @@
   height: auto;
 }
 
-.ucb-home-link:has(.ucb-homepage) {
-  max-width: 320px;
-}
-
 .ucb-brand-bar img.ucb-logo {
   width: 100%;
   max-width: 200px;


### PR DESCRIPTION
Previously on www.colorado.edu,  the Search Icon could dissapear on small screen sizes. This has been corrected. 

Resolves https://github.com/CuBoulder/tiamat-theme/issues/1618