### PR TITLE
Newsletter: Adjust Relative to Absolute pathing of WYSIWYG Images

### DIFF
--- a/js/ucb-newsletter.js
+++ b/js/ucb-newsletter.js
@@ -23,32 +23,37 @@
             }
         }
 
-      // Images in the intro - make absolute
-      var introBody = document.getElementById('newsletter-intro-body');
-      if (introBody) {
-          var images = introBody.getElementsByClassName('imageMediaStyle');
+        // Intro images - make absolute
+        const introBody = document.getElementById('newsletter-intro-body');
+        if (introBody) {
+          const images = introBody.getElementsByClassName('imageMediaStyle');
           for (let imgContainer of images) {
-              var img = imgContainer.children[0];
-              var endurl = img.getAttribute('src');
-              img.setAttribute('src', `${baseURL}${endurl}`);
-              // Ensure the image fits within 600px while maintaining proportions
-              img.setAttribute('style', 'max-width: 600px; width: 100%; height: auto; display: block;');
-          }
-      }
+            const img = imgContainer.children[0];
+            if (!img) continue;
+            let endurl = img.getAttribute('src');
+            if (!endurl) continue;
+            endurl = stripBasePath(baseURL, endurl);
 
-      // Images in the blocks -- make absolute
-            var blockSection = document.getElementById('ucb-newsletter-block-table');
-            if (blockSection) {
-                var images = blockSection.getElementsByClassName('imageMediaStyle');
-                for (let imgContainer of images) {
-                    var img = imgContainer.children[0];
-                    var endurl = img.getAttribute('src');
-                    img.setAttribute('src', `${baseURL}${endurl}`);
-                    // Ensure the image fits within 300/600px while maintaining proportions
-                    var imgSize = document.getElementById('ucb-single-newsletter-block') ? '600px' : '300px'
-                    img.setAttribute('style', `max-width: ${imgSize}; width: 100%; height: auto; display: block;`);
-                }
-            }
+            img.setAttribute('src', `${baseURL.replace(/\/$/, '')}/${endurl.replace(/^\//, '')}`);
+            img.setAttribute('style', 'max-width: 600px; width: 100%; height: auto; display: block;');
+          }
+        }
+
+        // Block images - make absolute
+        const blockSection = document.getElementById('ucb-newsletter-block-table');
+        if (blockSection) {
+          const images = blockSection.getElementsByClassName('imageMediaStyle');
+          for (let imgContainer of images) {
+            const img = imgContainer.children[0];
+            if (!img) continue;
+            let endurl = img.getAttribute('src');
+            if (!endurl) continue;
+            endurl = stripBasePath(baseURL, endurl);
+            img.setAttribute('src', `${baseURL.replace(/\/$/, '')}/${endurl.replace(/^\//, '')}`);
+            const imgSize = document.getElementById('ucb-single-newsletter-block') ? '600px' : '300px';
+            img.setAttribute('style', `max-width: ${imgSize}; width: 100%; height: auto; display: block;`);
+          }
+        }
 
         // Section Link - make blue (gets overridden by user agent style)
         var moreLinks = document.getElementsByClassName('article-link')

--- a/js/ucb-newsletter.js
+++ b/js/ucb-newsletter.js
@@ -23,8 +23,9 @@
             }
         }
 
+        // Used to normalize relative to absolute pathing
         function stripBasePath(baseURL, endurl) {
-          const basePath = new URL(baseURL).pathname.replace(/\/$/, ''); // e.g. "/center/altec"
+          const basePath = new URL(baseURL).pathname.replace(/\/$/, '');
           return endurl.startsWith(basePath) ? endurl.slice(basePath.length) : endurl;
         }
 

--- a/js/ucb-newsletter.js
+++ b/js/ucb-newsletter.js
@@ -23,6 +23,11 @@
             }
         }
 
+        function stripBasePath(baseURL, endurl) {
+          const basePath = new URL(baseURL).pathname.replace(/\/$/, ''); // e.g. "/center/altec"
+          return endurl.startsWith(basePath) ? endurl.slice(basePath.length) : endurl;
+        }
+
         // Intro images - make absolute
         const introBody = document.getElementById('newsletter-intro-body');
         if (introBody) {


### PR DESCRIPTION
Previously the helper functionality to try to mitigate broken image src paths due to relative links in WYSIWYG fields could cause sites like `colorado.edu/<sub>/<addtl-sub>` to duplicate pathing information in the transition into absolute paths, leading to broken absolute links and images. This functionality has been adjusted and refined. 

Resolves https://github.com/CuBoulder/tiamat-theme/issues/1626