### PR TITLE
Hero Slider Updates

### DIFF
--- a/boulder_base.libraries.yml
+++ b/boulder_base.libraries.yml
@@ -172,6 +172,8 @@ ucb-hero-slider:
   css:
     theme:
       css/block/hero-slider.css: { weight: 5 }
+  js:
+    js/block/hero-slider.js: { }
 
 ucb-text-block:
   version: 1.x

--- a/css/block/hero-slider.css
+++ b/css/block/hero-slider.css
@@ -125,23 +125,25 @@
   flex-direction: row;
   gap: 10px;
   position: absolute;
-  bottom: 20px;
-  left: 20px;
+  bottom: 2em;
+  right: 10%;
   z-index: 2;
 }
 
 .ucb-hero-slider .carousel-control-restart,
 .ucb-hero-slider .carousel-control-playpause {
-  border: none;
-  border-radius: 50%;
-  width: 40px;
-  height: 40px;
+  border: 1px solid whitesmoke;
+  border-radius: 5%;
+  width: 2em;
+  height: 2em;
   display: flex;
   align-items: center;
   justify-content: center;
   background: rgba(0, 0, 0, 0.5);
   cursor: pointer;
   transition: background-color 0.3s ease;
+  scale: 1.5;
+  margin-right: 2em;
 }
 
 .ucb-hero-slider .carousel-control-restart .fa-rotate,

--- a/css/block/hero-slider.css
+++ b/css/block/hero-slider.css
@@ -132,7 +132,7 @@
 
 .ucb-hero-slider .carousel-control-restart,
 .ucb-hero-slider .carousel-control-playpause {
-  border: 1px solid whitesmoke;
+  border: 1px solid var(--ucb-white);
   border-radius: 5%;
   width: 2em;
   height: 2em;

--- a/css/block/hero-slider.css
+++ b/css/block/hero-slider.css
@@ -5,8 +5,10 @@
 }
 
 .ucb-hero-slider .carousel {
-  height: 100vh;
-  margin-bottom: 0;
+  position: relative;
+  width: 100%;
+  aspect-ratio: 16/9;
+  max-height: 100vh;
 }
 
 .ucb-hero-slider .carousel-inner {
@@ -14,13 +16,13 @@
 }
 
 .ucb-hero-slider .carousel-item {
-  height: 100vh;
   position: relative;
+  height: 100%;
 }
 
 .ucb-hero-slider .carousel-item img {
-  height: 100%;
   width: 100%;
+  height: 100%;
   object-fit: cover;
 }
 
@@ -97,15 +99,69 @@
   text-align: right;
 }
 
-/* Hide carousel controls */
-.ucb-hero-slider .carousel-indicators,
-.ucb-hero-slider .carousel-control-prev,
-.ucb-hero-slider .carousel-control-next {
+/* Hide carousel indicators only */
+.ucb-hero-slider .carousel-indicators {
   display: none;
+}
+
+/* Carousel control styles */
+.ucb-hero-slider .carousel-control-prev,
+.ucb-hero-slider .carousel-control-next,
+.ucb-hero-slider .carousel-control-restart,
+.ucb-hero-slider .carousel-control-playpause {
+  opacity: 0.7;
+  transition: opacity 0.3s ease;
+}
+
+.ucb-hero-slider .carousel-control-prev:hover,
+.ucb-hero-slider .carousel-control-next:hover,
+.ucb-hero-slider .carousel-control-restart:hover,
+.ucb-hero-slider .carousel-control-playpause:hover {
+  opacity: 1;
+}
+
+.ucb-hero-slider .carousel-controls {
+  display: flex;
+  flex-direction: row;
+  gap: 10px;
+  position: absolute;
+  bottom: 20px;
+  left: 20px;
+  z-index: 2;
+}
+
+.ucb-hero-slider .carousel-control-restart,
+.ucb-hero-slider .carousel-control-playpause {
+  border: none;
+  border-radius: 50%;
+  width: 40px;
+  height: 40px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(0, 0, 0, 0.5);
+  cursor: pointer;
+  transition: background-color 0.3s ease;
+}
+
+.ucb-hero-slider .carousel-control-restart .fa-rotate,
+.ucb-hero-slider .carousel-control-playpause .fa-pause,
+.ucb-hero-slider .carousel-control-playpause .fa-play {
+  font-size: 18px;
+  color: var(--ucb-white);
+}
+
+.ucb-hero-slider .carousel-control-restart:hover,
+.ucb-hero-slider .carousel-control-playpause:hover {
+  background: rgba(0, 0, 0, 0.7);
 }
 
 /* Responsive adjustments */
 @media (max-width: 768px) {
+  .ucb-hero-slider .carousel {
+    aspect-ratio: 4/3;
+  }
+
   .ucb-hero-slider .carousel-caption {
     padding: 1rem;
   }
@@ -114,5 +170,11 @@
   .ucb-hero-slider .hero_slide_text_right .carousel-caption {
     padding-left: 5%;
     padding-right: 5%;
+  }
+}
+
+@media (max-width: 480px) {
+  .ucb-hero-slider .carousel {
+    aspect-ratio: 3/4;
   }
 }

--- a/js/block/hero-slider.js
+++ b/js/block/hero-slider.js
@@ -1,0 +1,66 @@
+/**
+ * @file
+ * Hero slider behaviors.
+ */
+(function (Drupal) {
+  'use strict';
+
+  Drupal.behaviors.heroSlider = {
+    attach: function (context, settings) {
+      context.querySelectorAll('.carousel').forEach(function(carouselElement) {
+        if (carouselElement.classList.contains('processed')) {
+          return;
+        }
+
+        const playPauseButton = carouselElement.querySelector('.carousel-control-playpause');
+        const restartButton = carouselElement.querySelector('.carousel-control-restart');
+        if (!playPauseButton || !restartButton) {
+          return;
+        }
+
+        // Initialize state
+        let isPlaying = true;
+        const carousel = new bootstrap.Carousel(carouselElement);
+        const visuallyHidden = playPauseButton.querySelector('.visually-hidden');
+
+        // Function to update button state
+        function updateButtonState(playing) {
+          const pauseIcon = playPauseButton.querySelector('.fa-pause');
+          const playIcon = playPauseButton.querySelector('.fa-play');
+          
+          if (playing) {
+            pauseIcon?.classList.remove('d-none');
+            playIcon?.classList.add('d-none');
+            visuallyHidden.textContent = 'Pause';
+          } else {
+            pauseIcon?.classList.add('d-none');
+            playIcon?.classList.remove('d-none');
+            visuallyHidden.textContent = 'Play';
+          }
+        }
+
+        // Handle play/pause click events
+        playPauseButton.addEventListener('click', function() {
+          if (isPlaying) {
+            carousel.pause();
+          } else {
+            carousel.cycle();
+          }
+          isPlaying = !isPlaying;
+          updateButtonState(isPlaying);
+        });
+
+        // Handle restart click events
+        restartButton.addEventListener('click', function() {
+          carousel.cycle();
+          isPlaying = true;
+          updateButtonState(isPlaying);
+        });
+
+        // Set initial state
+        updateButtonState(isPlaying);
+        carouselElement.classList.add('processed');
+      });
+    }
+  };
+})(Drupal); 

--- a/templates/block/block--ucb-hero-slider.html.twig
+++ b/templates/block/block--ucb-hero-slider.html.twig
@@ -25,7 +25,7 @@
             <h2{{title_attributes}}>{{ label }}</h2>
         {% endif %}
         {{ title_suffix }}
-        <div id="{{ id }}" class="carousel slide carousel-fade" data-bs-ride="carousel" data-bs-interval="{{ slide_duration }}" data-bs-pause="false">
+        <div id="{{ id }}" class="carousel slide carousel-fade" data-bs-ride="carousel" data-bs-interval="{{ slide_duration }}" data-bs-pause="false" data-bs-wrap="false">
             <div class="carousel-indicators">
                 {% for i in 1..content['#block_content'].field_hero_slides.value|length %}
                     <button{{create_attribute({type:'button','data-bs-target':'#'~id,'data-bs-slide-to':i-1,'aria-label':'Slide'~i}).addClass(loop.first?'active')}}></button>

--- a/templates/block/block--ucb-hero-slider.html.twig
+++ b/templates/block/block--ucb-hero-slider.html.twig
@@ -5,6 +5,7 @@
 #}
 {% set classes = [
   'block',
+  'bs-background-unstyled',
   'block-' ~ configuration.provider|clean_class,
   'block-' ~ plugin_id|clean_class,
   bundle ? 'block--type-' ~ bundle|clean_class,

--- a/templates/block/block--ucb-hero-slider.html.twig
+++ b/templates/block/block--ucb-hero-slider.html.twig
@@ -42,14 +42,17 @@
                     </div>
                 {% endfor %}
             </div>
-            <button class="carousel-control-prev" type="button" data-bs-target="#{{ id }}" data-bs-slide="prev">
-                <span class="carousel-control-prev-icon" aria-hidden="true"></span>
-                <span class="visually-hidden">Previous</span>
-            </button>
-            <button class="carousel-control-next" type="button" data-bs-target="#{{ id }}" data-bs-slide="next">
-                <span class="carousel-control-next-icon" aria-hidden="true"></span>
-                <span class="visually-hidden">Next</span>
-            </button>
+            <div class="carousel-controls">
+                <button class="carousel-control-restart" type="button" data-bs-target="#{{ id }}" data-bs-slide-to="0" aria-label="Restart slideshow">
+                    <i class="fa-solid fa-rotate" aria-hidden="true"></i>
+                    <span class="visually-hidden">Restart</span>
+                </button>
+                <button class="carousel-control-playpause" type="button" aria-label="Pause slideshow">
+                    <i class="fa-solid fa-pause" aria-hidden="true"></i>
+                    <i class="fa-solid fa-play d-none" aria-hidden="true"></i>
+                    <span class="visually-hidden">Pause</span>
+                </button>
+            </div>
         </div>
     </div>
 {% endblock %}

--- a/templates/field/field--paragraph--field-hero-slide-image-text.html.twig
+++ b/templates/field/field--paragraph--field-hero-slide-image-text.html.twig
@@ -1,0 +1,12 @@
+{#
+/**
+ * @file
+ * Theme override for field_hero_slide_image_text field.
+ *
+ * This template renders only the field value without wrapping HTML
+ * while maintaining proper Drupal sanitization.
+ */
+#}
+{% for item in items %}
+  {{- item.content -}}
+{% endfor %} 

--- a/templates/paragraphs/paragraph--hero-slider-image.html.twig
+++ b/templates/paragraphs/paragraph--hero-slider-image.html.twig
@@ -23,7 +23,7 @@
         <div class="carousel-caption d-md-block">
           <div class="hero-slider-image__content">
             <span class="hero-slider-image__text">
-              <p class="hero">{{ content.field_hero_slide_image_text|render|striptags|trim }}</p>
+              <p class="supersize">{{ content.field_hero_slide_image_text|render }}</p>
             </span>
           </div>
         </div>


### PR DESCRIPTION
Update the paragraph to not striptags and trim. Rather we create a new template for the field so that special characters aren't broken on render.

Add `data-bs-wrap="false"` to stop the looping of the slider

Replaced fixed 100vh height with responsive aspect-ratio (16/9 desktop, 4/3 tablet, 3/4 mobile). Set max-height: 100vh, used relative positioning, and ensured images scale properly with object-fit: cover.

Added restart and pause/play buttons

Add unstyled class so extra padding is removed.

Sister PR: https://github.com/CuBoulder/tiamat-custom-entities/pull/207

Resolves #1625 
