### PR TITLE
People Lists: Fix linking of internal pages

### DIFF
--- a/js/ucb-people-list-block.js
+++ b/js/ucb-people-list-block.js
@@ -459,6 +459,13 @@
         if (thisPerson.primaryLinkURI.startsWith('internal:/')) {
           thisPerson.primaryLinkURI = this.getAttribute('site-base') + thisPerson.primaryLinkURI.replace('internal:/', '/');
         }
+
+        // This makes internal node references URLS
+        if (thisPerson.primaryLinkURI.startsWith('entity:node/')) {
+          const nodeId = thisPerson.primaryLinkURI.split('/')[1];
+          thisPerson.primaryLinkURI = this.getAttribute('site-base') + `/node/${nodeId}`;
+        }
+
         // needed to verify body exists on the Person page, if so, use that
         if (personAttributeData['body']) {
           // use summary if available

--- a/js/ucb-people-list.js
+++ b/js/ucb-people-list.js
@@ -553,6 +553,12 @@
         if (thisPerson.primaryLinkURI.startsWith('internal:/')) {
           thisPerson.primaryLinkURI = this.getAttribute('site-base') + thisPerson.primaryLinkURI.replace('internal:/', '/');
         }
+
+        // This makes internal node references URLS
+        if (thisPerson.primaryLinkURI.startsWith('entity:node/')) {
+          const nodeId = thisPerson.primaryLinkURI.split('/')[1];
+          thisPerson.primaryLinkURI = this.getAttribute('site-base') + `/node/${nodeId}`;
+        }
         // needed to verify body exists on the Person page, if so, use that
         if (personAttributeData['body']) {
           // use summary if available


### PR DESCRIPTION
Previously on the `Person Page` form, linking to an internal page or node for a Person's Primary Link could result in broken links depending on how the linked page was referenced -- either by internal url or entity node ID. Drupal would store this link either as `internal:/` or `entity:node:/`, depending on how it was input (such as`/home` versus `Home (1)` selected via autocomplete) and they would each be returned differently to the aggregators content types.

The `People List page` and `People List block` only correctly handled one of these two ways in the final render, but this has been corrected to handle both.

Resolves #1631 