### PR TITLE
Add homepage sticky menu

### DIFF
--- a/templates/includes/ucb-homepage-sticky-menu.html.twig
+++ b/templates/includes/ucb-homepage-sticky-menu.html.twig
@@ -1,0 +1,13 @@
+{{ attach_library('boulder_base/ucb-sticky-menu') }}
+<div hidden class="ucb-sticky-menu background-black">
+	<div class="container">
+		<div class="sticky-menu-inner">
+			<div class="sticky-menu-branding sticky-menu-site-name">
+			<a href="https://www.colorado.edu" class="ucb-home-link"><img class="ucb-logo" src="https://cdn.colorado.edu/static/brand-assets/live/images/cu-boulder-logo-text-white.svg" alt="University of Colorado Boulder"></a>
+			</div>
+			<div class="sticky-menu-menu">
+				{{ page.primary_menu.boulder_base_main_menu }}
+			</div>
+		</div>
+	</div>
+</div>

--- a/templates/layout/page.html.twig
+++ b/templates/layout/page.html.twig
@@ -111,8 +111,10 @@
       <rave-alert feed="https://www.getrave.com/rss/cuboulder/channel1" link="https://alerts.colorado.edu"></rave-alert>
     {% endif %}
 
-    {% if ucb_sticky_menu %}
+    {% if (ucb_sticky_menu and not ucb_homepage_header) %}
       {% include '@boulder_base/includes/ucb-sticky-menu.html.twig' %}
+    {% elseif ucb_sticky_menu and ucb_homepage_header %}
+      {% include '@boulder_base/includes/ucb-homepage-sticky-menu.html.twig' %}
     {% endif %}
 
     {{ page.header }}


### PR DESCRIPTION
Adding the homepage sticky menu options

To test:
> /admin/config/cu-boulder/appearance
> select "Show sticky menu"
> in advanced options select "Hide the normal header bar. For the CU Homepage only."

The navigation should show the logo and menu in the same bar

Resolves #1641 