### PR TITLE
Update ucb-content-sequence.css

### DIFF
--- a/css/block/ucb-content-sequence.css
+++ b/css/block/ucb-content-sequence.css
@@ -41,15 +41,15 @@
   font-size: 150%;
 }
 
-.ucb-content-sequence .vertical-timeline-card-title a {
+.vertical-timeline-card-header a, .vertical-timeline-card-body a {
   color: var(--ucb-link);
 }
 
-.ucb-content-sequence .vertical-timeline-card-title a:hover {
+.vertical-timeline-card-header a:hover, .vertical-timeline-card-body a:hover {
   color: var(--ucb-link-visited);
 } 
 
-.ucb-content-sequence .vertical-timeline-card-title a:visited {
+.vertical-timeline-card-header a:visited, .vertical-timeline-card-body a:visited {
   color: var(--ucb-link-visited);
 } 
 


### PR DESCRIPTION
This update makes the link colors use only our `ucb-link` colors for this block. 
The will block always have white backgrounds so the text needs to be blue.

Resolves #1658