### PR TITLE
#1649 - Resolves Mega Menu cases for special characters and hidden icons

### DIFF
--- a/templates/navigation/menu--extras.html.twig
+++ b/templates/navigation/menu--extras.html.twig
@@ -49,7 +49,15 @@
             '#markup': '<i class="fa-solid fa-eye-slash"></i> ' ~ item.title|e ~ '<span class="visually-hidden">(Unpublished)</span>'
             } : item.title %}
             {% if item.content.field_display_mega_menu|render|striptags|trim == "On" %}
-              {%  set linkID = title|lower|trim|replace({' ': ''}) ~ item.content.field_mega_menu_select.0['#block_content'].id.value %}
+              {% set base_title = item.title is iterable ? item.title['#markup'] : item.title %}
+              {% set sanitized_title = base_title|lower
+                |replace({' ': '-', '&': 'and', '/': '-', '\\': '-'})
+                |replace({'"': '', "'": '', '.': '', ',': '', '!': '', '?': '', '(': '', ')': '',
+                          '[': '', ']': '', '{': '', '}': '', ':': '', ';': '', '#': '', '@': '',
+                          '%': '', '+': '', '=': '', '*': '', '^': '', '`': '', '~': '', '<': '',
+                          '>': '', '|': '', '$': ''})
+              %}
+              {% set linkID = sanitized_title ~ item.content.field_mega_menu_select.0['#block_content'].id.value %}
               {% set linkTargetID = "#" ~ linkID %}
               {% set linkAttr = create_attribute({  "data-bs-toggle" : "collapse", "data-bs-target": linkTargetID, "aria-expanded": "false", "aria-controls" : linkID }) %}
               {% set linkTitle = { '#markup': title|e ~ '<i class="fa fa-angle-down ucb-mega-menu-icon" aria-hidden="true"></i>'} %}

--- a/templates/navigation/menu--extras.html.twig
+++ b/templates/navigation/menu--extras.html.twig
@@ -45,11 +45,19 @@
               <span class="visually-hidden">{{ item.title }}</span>
             </a>
           {% else %}
-            {% set title = item.is_unpublished ? {
-            '#markup': '<i class="fa-solid fa-eye-slash"></i> ' ~ item.title|e ~ '<span class="visually-hidden">(Unpublished)</span>'
-            } : item.title %}
+            {% set title_string = item.title is iterable ? item.title['#markup'] : item.title %}
+            {% set title = item.is_unpublished
+              ? { '#markup': '<i class="fa-solid fa-eye-slash"></i> ' ~ title_string|e ~ ' <span class="visually-hidden">(Unpublished)</span>' }
+              : title_string
+            %}
             {% if item.content.field_display_mega_menu|render|striptags|trim == "On" %}
-              {%  set linkID = title|lower|trim|replace({' ': ''}) ~ item.content.field_mega_menu_select.0['#block_content'].id.value %}
+            {% set sanitized_title = title_string|lower|replace({
+              ' ': '-', "'": '', '"': '', '&': 'and', '/': '-', '\\': '-', '.': '', ',': '',
+              '!': '', '?': '', '(': '', ')': '', '[': '', ']': '', '{': '', '}': '',
+              ':': '', ';': '', '#': '', '@': '', '%': '', '+': '', '=': '', '*': '',
+              '^': '', '`': '', '~': ''
+            }) %}
+            {% set linkID = sanitized_title ~ item.content.field_mega_menu_select.0['#block_content'].id.value %}
               {% set linkTargetID = "#" ~ linkID %}
               {% set linkAttr = create_attribute({  "data-bs-toggle" : "collapse", "data-bs-target": linkTargetID, "aria-expanded": "false", "aria-controls" : linkID }) %}
               {% set linkTitle = { '#markup': title|e ~ '<i class="fa fa-angle-down ucb-mega-menu-icon" aria-hidden="true"></i>'} %}

--- a/templates/navigation/menu--extras.html.twig
+++ b/templates/navigation/menu--extras.html.twig
@@ -45,19 +45,11 @@
               <span class="visually-hidden">{{ item.title }}</span>
             </a>
           {% else %}
-            {% set title_string = item.title is iterable ? item.title['#markup'] : item.title %}
-            {% set title = item.is_unpublished
-              ? { '#markup': '<i class="fa-solid fa-eye-slash"></i> ' ~ title_string|e ~ ' <span class="visually-hidden">(Unpublished)</span>' }
-              : title_string
-            %}
+            {% set title = item.is_unpublished ? {
+            '#markup': '<i class="fa-solid fa-eye-slash"></i> ' ~ item.title|e ~ '<span class="visually-hidden">(Unpublished)</span>'
+            } : item.title %}
             {% if item.content.field_display_mega_menu|render|striptags|trim == "On" %}
-            {% set sanitized_title = title_string|lower|replace({
-              ' ': '-', "'": '', '"': '', '&': 'and', '/': '-', '\\': '-', '.': '', ',': '',
-              '!': '', '?': '', '(': '', ')': '', '[': '', ']': '', '{': '', '}': '',
-              ':': '', ';': '', '#': '', '@': '', '%': '', '+': '', '=': '', '*': '',
-              '^': '', '`': '', '~': ''
-            }) %}
-            {% set linkID = sanitized_title ~ item.content.field_mega_menu_select.0['#block_content'].id.value %}
+              {%  set linkID = title|lower|trim|replace({' ': ''}) ~ item.content.field_mega_menu_select.0['#block_content'].id.value %}
               {% set linkTargetID = "#" ~ linkID %}
               {% set linkAttr = create_attribute({  "data-bs-toggle" : "collapse", "data-bs-target": linkTargetID, "aria-expanded": "false", "aria-controls" : linkID }) %}
               {% set linkTitle = { '#markup': title|e ~ '<i class="fa fa-angle-down ucb-mega-menu-icon" aria-hidden="true"></i>'} %}

--- a/templates/navigation/menu.html.twig
+++ b/templates/navigation/menu.html.twig
@@ -38,18 +38,15 @@
           item.is_unpublished ? 'unpublished'
         ] %}
         <li{{ item.attributes.addClass(classes) }}>
-        {% set title_string = item.title is iterable ? item.title['#markup'] : item.title %}
-          {% if title_string|upper == 'HOME' %}
-              <a{{ create_attribute({ href: item.url|render, class: 'ucb-home-button nav-link', title: title_string }) }}>
+          {% if item.title|upper == 'HOME' %}
+            <a{{ create_attribute({ href: item.url|render, class: 'ucb-home-button nav-link', title: item.title }) }}>
               <i class="fa-solid fa-home"></i>
               <span class="visually-hidden">{{ item.title }}</span>
             </a>
           {% else %}
-            {% set title_string = item.title is iterable ? item.title['#markup'] : item.title %}
-            {% set title = item.is_unpublished
-              ? { '#markup': '<i class="fa-solid fa-eye-slash"></i> ' ~ title_string|e ~ ' <span class="visually-hidden">(Unpublished)</span>' }
-              : title_string
-            %}
+            {% set title = item.is_unpublished ? {
+                '#markup': '<i class="fa-solid fa-eye-slash"></i> ' ~ item.title|e ~ ' <span class="visually-hidden">(Unpublished)</span>'
+              } : item.title %}
             {{ link(title, item.url, create_attribute({ class: 'nav-link' })) }}
             {% if item.below %}
               {{ menus.menu_links(item.below, attributes, menu_level + 1) }}

--- a/templates/navigation/menu.html.twig
+++ b/templates/navigation/menu.html.twig
@@ -38,15 +38,18 @@
           item.is_unpublished ? 'unpublished'
         ] %}
         <li{{ item.attributes.addClass(classes) }}>
-          {% if item.title|upper == 'HOME' %}
-            <a{{ create_attribute({ href: item.url|render, class: 'ucb-home-button nav-link', title: item.title }) }}>
+        {% set title_string = item.title is iterable ? item.title['#markup'] : item.title %}
+          {% if title_string|upper == 'HOME' %}
+              <a{{ create_attribute({ href: item.url|render, class: 'ucb-home-button nav-link', title: title_string }) }}>
               <i class="fa-solid fa-home"></i>
               <span class="visually-hidden">{{ item.title }}</span>
             </a>
           {% else %}
-            {% set title = item.is_unpublished ? {
-                '#markup': '<i class="fa-solid fa-eye-slash"></i> ' ~ item.title|e ~ ' <span class="visually-hidden">(Unpublished)</span>'
-              } : item.title %}
+            {% set title_string = item.title is iterable ? item.title['#markup'] : item.title %}
+            {% set title = item.is_unpublished
+              ? { '#markup': '<i class="fa-solid fa-eye-slash"></i> ' ~ title_string|e ~ ' <span class="visually-hidden">(Unpublished)</span>' }
+              : title_string
+            %}
             {{ link(title, item.url, create_attribute({ class: 'nav-link' })) }}
             {% if item.below %}
               {{ menus.menu_links(item.below, attributes, menu_level + 1) }}


### PR DESCRIPTION
Previously adding special characters like apostrophes, ampersands, etc. to a Mega Menu item or disabling the page so the 'Hidden' icon would show for site editors could prevent the Mega Menu from functioning properly -- leading to WSOD errors or JavaScript errors. 

The logic for assembling these menus has been adjusted to handle these cases

Resolves #1649 