### PR TITLE
#1659 - Adds scroll margin offset for Sticky Menu

### DIFF
--- a/css/ucb-sticky-menu.css
+++ b/css/ucb-sticky-menu.css
@@ -9,6 +9,11 @@
 	padding: .5rem 0;
 }
 
+/* Jumping to anchor tag isn't hidden by Sticky Menu */
+a.ck-anchor{
+	scroll-margin-top: 100px;
+}
+
 @media only screen and (max-width: 960px) {
 	.ucb-sticky-menu {
 		display: none;


### PR DESCRIPTION
When using CK Editor Anchor tags on a site with a Sticky Menu, clicking the link to jump to the anchor tag would result in the Sticky Menu covering the actual anchor position, resulting in the need to scroll back up to find the intended destination. This change adds an offset to account for the menu and will jump to the correct position.

Resolves #1659 