### PR TITLE
Section Content Frame Padding

### DIFF
--- a/css/layout-builder-styles.css
+++ b/css/layout-builder-styles.css
@@ -304,14 +304,14 @@
   background: var(--ucb-black);
   color: var(--ucb-white);
   margin: 20px 0;
-  padding: 20px;
+  padding: 24px;
 }
 
 .content-frame-dark-gray .column {
   background: rgba(0, 0, 0, 0.75);
   color: var(--ucb-white);
   margin: 20px 0;
-  padding: 20px;
+  padding: 24px;
 }
 
 .content-frame-dark-gray a,

--- a/css/layout-builder-styles.css
+++ b/css/layout-builder-styles.css
@@ -282,12 +282,16 @@
   background: var(--ucb-white);
   color: var(--ucb-black);
   margin: 20px 0;
+  padding: 24px;
+
 }
 
 .content-frame-light-gray .column {
   background: rgba(255, 255, 255, 0.85);
   color: var(--ucb-black);
   margin: 20px 0;
+  padding: 24px;
+
 }
 
 .content-frame-light-gray a,

--- a/css/layout-builder-styles.css
+++ b/css/layout-builder-styles.css
@@ -304,12 +304,14 @@
   background: var(--ucb-black);
   color: var(--ucb-white);
   margin: 20px 0;
+  padding: 20px;
 }
 
 .content-frame-dark-gray .column {
   background: rgba(0, 0, 0, 0.75);
   color: var(--ucb-white);
   margin: 20px 0;
+  padding: 20px;
 }
 
 .content-frame-dark-gray a,


### PR DESCRIPTION
Previously Layout Builder sections with a Content Frame Color applied lacked padding - resulting in a very small frame applied to the inner content. This has been adjusted to create equal padding on all sides of the framed content.

Resolves #1667 