### PR TITLE
#1669 - Adds Link Processing to Intro Body for relative hrefs

### DIFF
--- a/templates/content/node--newsletter--email-html.html.twig
+++ b/templates/content/node--newsletter--email-html.html.twig
@@ -603,10 +603,12 @@
                                 </tr>
                                 {% endif %}
                                 {% if content.field_newsletter_intro_body|render %}
+                                  {% set intro_body = content.field_newsletter_intro_body|render %}
+                                  {% set updated_intro_body = intro_body|replace({'href="/': 'href="' ~ base_domain ~ '/'}) %}
                                 <tr>
                                     <td>
                                     <!-- Intro Text-->
-                                    <div id="newsletter-intro-body">{{ content.field_newsletter_intro_body }}</div>
+                                    <div id="newsletter-intro-body">{{ updated_intro_body|raw }}</div>
                                   </td>
                                 </tr>
                                 {% endif %}


### PR DESCRIPTION
Previously the 'Intro Text' field did not process relative urls for links created in the Intro Text WYSIWYG field. This would cause urls to show up in the Email HTML version as `colorado.edu/<your-relative-href>` instead of `colorado.edu/<subdomain>/<your-relative-rul>` , which led to broken links on most sites. The Newsletter has been adjusted to process these links as well. 

Resolves #1669 