### PR TITLE
#1713 - Remove header element from block in site footer

### DIFF
--- a/templates/block/block--site-info.html.twig
+++ b/templates/block/block--site-info.html.twig
@@ -30,9 +30,9 @@
 {% set icons_visible = data.icons_visible %}
 
 <div{{ attributes }}>
-  <h2 class="h5">
+  <span class="h5">
     <a href="{{ url('<front>') }}">{{ site_name }}</a>
-  </h2>
+  </span>
   {% block content %}
     <div class="ucb-site-contact-info-footer">
       {% if data.general_visible == '1' %}


### PR DESCRIPTION
This change removes the header element from the site info footer for accessibility purposes, but maintains the visual styling

Resolves #1713 