### PR TITLE
#1718 - Adds Unpublished Indicator to Nodes

### DIFF
--- a/boulder_base.theme
+++ b/boulder_base.theme
@@ -63,6 +63,13 @@ function boulder_base_preprocess(&$variables, $hook) {
 function boulder_base_preprocess_html(array &$variables) {
   $variables['ucb_gtm_account'] = theme_get_setting('ucb_gtm_account');
   $variables['theme_path'] = base_path() . $variables['directory'];
+  // Adding `unpublished` class to Nodes
+  $route_match = \Drupal::routeMatch();
+  $node = $route_match->getParameter('node');
+  if ($node instanceof \Drupal\node\NodeInterface && !$node->isPublished()) {
+    $variables['attributes']['class'][] = 'unpublished';
+  }
+
   if (\Drupal::config('system.site')->get('name') != 'University of Colorado Boulder') {
     // Adds "University of Colorado Boulder" to the title of the page if the
     // site isn't already called that. Resolves tiamat-theme#1188.

--- a/css/style.css
+++ b/css/style.css
@@ -1173,6 +1173,16 @@ h2.clear-margin,h3.clear-margin,h4.clear-margin,h5.clear-margin,h6.clear-margin,
   display:none;
 }
 
+/* Unpublished message on Unpublished nodes */
+body.unpublished:before {
+  content: "This content is unpublished.";
+  padding: 10px;
+  text-align: center;
+  font-weight: bold;
+  background-color: pink;
+  color: black;
+  display: block;
+}
 
 /* Column List CSS */
 @media only screen and (min-width: 576px) {


### PR DESCRIPTION
Adds a unpublished indicator via adding a class through a `preprocess_html` hook, as `node` and subsequently `node.isPublished()` is not available in the `html.html.twig` template

Resolves #1718 