### PR TITLE
#1716 - People List Page image links re-added, but hidden for screen-readers

### DIFF
--- a/js/ucb-people-list.js
+++ b/js/ucb-people-list.js
@@ -641,7 +641,7 @@
                 personPhoto
                   ? `
                 <div aria-hidden="true" class="col-sm-12 col-md-3 ucb-person-card-img">
-                  ${personPhoto}
+                  <a role="presentation" aria-hidden="true" href="${personLink}">${personPhoto}</a>
                 </div>`
                   : ""
               }
@@ -706,7 +706,7 @@
           cardHTML = `
             <div class="col-sm mb-3">
               <div aria-hidden="true" class="col-sm-12 ucb-person-card-img-grid">
-                ${personPhoto}
+                <a role="presentation" aria-hidden="true" href="${personLink}">${personPhoto}</a>
               </div>
               <div>
                 <a href="${personLink}">
@@ -727,7 +727,7 @@
           cardElement = document.createElement('tr');
           cardHTML = `
             <td aria-hidden="true" class="ucb-people-list-table-photo">
-              ${personPhoto}
+              <a role="presentation" aria-hidden="true" href="${personLink}">${personPhoto}</a>
             </td>
             <td>
               <a href="${personLink}">


### PR DESCRIPTION
Partially reverts the change made via https://github.com/CuBoulder/tiamat-theme/issues/1702, which removed link-wrapping on Images. 

This update re-adds the link wrapper on People List page image thumbnails on List, Grid, Table, but hides them from screen-reader with `role="presentation" aria-hidden="true"` to make them more accesibile. 

Resolves #1716 