### PR TITLE
#1736 - Breadcrumb region display

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -53,11 +53,6 @@ body {
   padding: 10px 0;
 }
 
-/* Wrapper is only displayed if content exists (has children elements), needed for Twigs 'is not empty' check */
-.ucb-breadcrumb-region:empty {
-  display: none;
-}
-
 .ucb-content-wrapper {
   --bs-gutter-y: 3rem;
   margin-top: calc(var(--bs-gutter-y)* .5);

--- a/templates/layout/page.html.twig
+++ b/templates/layout/page.html.twig
@@ -227,7 +227,7 @@
   {# MAIN PAGE CONTENT #}
   <div{{ create_attribute({ class: ['ucb-page-content', ucb_heading_font == 'normal' ? 'ucb-heading-font-normal'] }) }}>
     {% block breadcrumb_region %}
-      {% if show_breadcrumb and page.breadcrumb is not empty %}
+      {% if show_breadcrumb and page.breadcrumb|render|striptags|trim|length > 0 %}
         <div class="ucb-breadcrumb-region">
           {{ page.breadcrumb }}
         </div>


### PR DESCRIPTION
Fixes an issue where the breadcrumb region would display a white bar under the navigation, even with no breadcrumb content. 
Resolves #1736 