### PR TITLE
#1739 - Prevent null from being passed in preprocess hook

### DIFF
--- a/boulder_base.theme
+++ b/boulder_base.theme
@@ -316,14 +316,11 @@ function boulder_base_preprocess_node__ucb_article(array &$variables) {
   elseif ($route_name == 'entity.node.preview') {
     $node = \Drupal::routeMatch()->getParameter('node_preview');
   }
-
-  // Short circuit to prevent passing null
-  if (!$node) {
-    return;
+  else {
+    $node = $variables['node'];
   }
-
   // Get the media image positioning
-  if ($node->hasField('field_article_title_background') && $node->get('field_article_title_background')->entity) {
+  if ($node && $node->hasField('field_article_title_background') && $node->get('field_article_title_background')->entity) {
     $media_entity = $node->get('field_article_title_background')->entity;
     $fid = $media_entity->getSource()->getSourceFieldValue($media_entity);
     $file = \Drupal::entityTypeManager()->getStorage('file')->load($fid);


### PR DESCRIPTION
Due to a change in D11, it seems a `null` in a preprocess function is breaking Taxonomy views (Category List, Tag List, Newsletter Archive) -- Views seem to be partially broken or completely WSOD-ing and provide this error:

Error: Call to a member function hasField() on null in boulder_base_preprocess_node__ucb_article() (line 320 of /code/web/themes/custom/boulder_base/boulder_base.theme).

This change attempts to short circuit the hook if `null` is about to be passed.

Resolves #1739 