### PR TITLE
#1743 - Article Grid: Adds spacing between all cards

### DIFF
--- a/css/block/ucb-article-grid-block.css
+++ b/css/block/ucb-article-grid-block.css
@@ -2,6 +2,10 @@
   text-align: center;
 }
 
+.ucb-article-grid-card {
+  margin: 0 0 20px 0; 
+}
+
 .ucb-article-grid-block-button-container a.ucb-article-grid-block-button {
   display: inline-block;
   padding: 5px 10px;
@@ -28,4 +32,5 @@
 
 .ucb-article-grid-summary {
   font-size: 85%;
+  margin: 0 0 0px 0; 
 }


### PR DESCRIPTION
This change fixes spacing between cards displayed in an `Article Grid` block so that all Articles rendered in the Grid have a uniform spacing. 

Previously, the spacing would only apply to Articles with a summary, as it would add the default spacing style to the text. However, Articles displayed in the Grid without a summary would receive no spacing. 

Resolves #1743 