### PR TITLE
CSS updates for Alert Pink

### DIFF
--- a/css/block/block-styles.css
+++ b/css/block/block-styles.css
@@ -139,6 +139,12 @@
 
 }
 
+.block.bs-background-alert-pink {
+  background-color: var(--ucb-alert);
+  color: var(--ucb-black);
+
+}
+
 .block.bs-background-outline {
   background-color: transparent;
   color: inherit;
@@ -256,6 +262,12 @@
 
 .block.bs-background-alert-yellow a,
 .block.bs-background-alert-yellow a:hover {
+  color: var(--ucb-black);
+  text-decoration: underline;
+}
+
+.block.bs-background-alert-pink a,
+.block.bs-background-alert-pink a:hover {
   color: var(--ucb-black);
   text-decoration: underline;
 }

--- a/css/layout-builder-styles.css
+++ b/css/layout-builder-styles.css
@@ -119,6 +119,11 @@
   color: var(--ucb-black);
 }
 
+.ucb-bootstrap-layout__background-color--alert-pink {
+  background-color: var(--ucb-alert);
+  color: var(--ucb-black);
+}
+
 .ucb-bootstrap-layout__background-color--gold a {
   color: #111111;
   text-decoration: underline;
@@ -232,6 +237,12 @@
 
 .ucb-bootstrap-layout__background-color--alert-yellow a,
 .ucb-bootstrap-layout__background-color--alert-yellow a:hover {
+  color: var(--ucb-black);
+  text-decoration: underline;
+}
+
+.ucb-bootstrap-layout__background-color--alert-pink a,
+.ucb-bootstrap-layout__background-color--alert-pink a:hover {
   color: var(--ucb-black);
   text-decoration: underline;
 }

--- a/css/ucb-accordion-styles.css
+++ b/css/ucb-accordion-styles.css
@@ -187,9 +187,10 @@
   background-color: var(--ucb-black);
 }
 
-/* Alert Orange and Alert Yellow: same accordion styling as light green (section-light). */
+/* Alert Orange, Alert Yellow, and Alert Pink: same accordion styling as light green (section-light). */
 .ucb-bootstrap-layout__background-color--alert-orange .horizontal-tab-link.nav-link,
-.ucb-bootstrap-layout__background-color--alert-yellow .horizontal-tab-link.nav-link {
+.ucb-bootstrap-layout__background-color--alert-yellow .horizontal-tab-link.nav-link,
+.ucb-bootstrap-layout__background-color--alert-pink .horizontal-tab-link.nav-link {
   color: var(--ucb-black);
 }
 
@@ -229,9 +230,10 @@
   background-color: var(--ucb-black);
 }
 
-/* Block-level accordion: Alert Orange and Alert Yellow (like light green). */
+/* Block-level accordion: Alert Orange, Alert Yellow, and Alert Pink (like light green). */
 .block.bs-background-alert-orange .horizontal-tab-link.nav-link,
-.block.bs-background-alert-yellow .horizontal-tab-link.nav-link {
+.block.bs-background-alert-yellow .horizontal-tab-link.nav-link,
+.block.bs-background-alert-pink .horizontal-tab-link.nav-link {
   color: var(--ucb-black);
 }
 
@@ -257,6 +259,7 @@
 .ucb-bootstrap-layout__background-color--light-green .accordion-item,
 .ucb-bootstrap-layout__background-color--alert-orange .accordion-item,
 .ucb-bootstrap-layout__background-color--alert-yellow .accordion-item,
+.ucb-bootstrap-layout__background-color--alert-pink .accordion-item,
 .content-frame-light-gray .accordion-item {
   color: inherit;
   background-color: inherit;
@@ -282,7 +285,8 @@
 .block.bs-background-light-blue .accordion-item,
 .block.bs-background-light-green .accordion-item,
 .block.bs-background-alert-orange .accordion-item,
-.block.bs-background-alert-yellow .accordion-item {
+.block.bs-background-alert-yellow .accordion-item,
+.block.bs-background-alert-pink .accordion-item {
   color: inherit;
   background-color: inherit;
   border-bottom: 1px solid rgba(128, 128, 128, 33%);
@@ -341,6 +345,12 @@
 .ucb-bootstrap-layout__background-color--alert-yellow
   .block.bs-background-outline .accordion-item,
 .ucb-bootstrap-layout__background-color--alert-yellow
+  .block.bs-background-underline .accordion-item,
+.ucb-bootstrap-layout__background-color--alert-pink
+  .block.bs-background-none .accordion-item,
+.ucb-bootstrap-layout__background-color--alert-pink
+  .block.bs-background-outline .accordion-item,
+.ucb-bootstrap-layout__background-color--alert-pink
   .block.bs-background-underline .accordion-item,
 .content-frame-light-gray .block.bs-background-underline .accordion-item {
   color: inherit;


### PR DESCRIPTION
Added CSS updates for Alert Pink color. Uses the `--ucb-alert` variable color.

Testing a new site install should be easy. All color options should be available in the section backgrounds as well as block backgrounds.

Testing on a current site will require making sure Alert overrides and color options are showing up properly after a ddev `drush updb`

Sister PR: https://github.com/CuBoulder/ucb_styled_block/pull/6
Sister PR: https://github.com/CuBoulder/tiamat-custom-entities/pull/224
Sister PR: https://github.com/CuBoulder/ucb_bootstrap_layouts/pull/80

Resolves #1754 