### PR TITLE
Vertical expandable content

### DIFF
--- a/css/ucb-accordion-styles.css
+++ b/css/ucb-accordion-styles.css
@@ -414,6 +414,11 @@
   overflow: auto;
 }
 
+.accordion-body .field_media_oembed_video {
+  min-width: 620px;
+  max-width: 100%;
+}
+
 @media (min-width: 768px) {
   .horizontal-tab-accordion .nav-tabs,
   .vertical-tab-accordion .vertical-tabs {


### PR DESCRIPTION
A min width is needed for accordion bodies with embedded videos.

Kevin was right, the content area is set to be 100% width of the content added into it, and the embeds are set to expand to 100% of the width of the content area. So a tab without any other content would technically be 0pxx0px and you wouldn't see the video. Easiest way to fix it was just by adding a mobile friendly min-width. I tested some screen resizing and it still scales automatically as needed.

Resolves #1756 