### PR TITLE
#1771 - Secondary Menu increase padding between menu-items

### DIFF
--- a/css/menu-styles/tradition-styles.css
+++ b/css/menu-styles/tradition-styles.css
@@ -35,7 +35,7 @@
 
   .ucb-main-nav-container.ucb-secondary-menu-position-above .ucb-secondary-menu-region .menu.social-media .icon-bg,
   .ucb-main-nav-container.ucb-secondary-menu-position-above .ucb-secondary-menu-region li.menu-item a {
-    padding: 0 5px;
+    padding: 0 8px;
     color: #000;
     font-weight: 400;
   }


### PR DESCRIPTION
The padding on the menu items in the Secondary Menu increased from 5px to 8px to give a little more space between the items. 

The primary issue presented with the background color not applying to the entire menu, as shown below, is not present on new installs and on the site shown was corrected on the live site with a re-save of the secondary menu. 
<img width="2740" height="456" alt="image" src="https://github.com/user-attachments/assets/77700a0a-9f5b-42f8-8c0c-efdbe64ba353" />


Resolves #1771 