### PR TITLE
#1768 - Fixes 'strong' header not centering

### DIFF
--- a/css/block/block-styles.css
+++ b/css/block/block-styles.css
@@ -59,6 +59,7 @@
 /*** Heading Styles ***/
 .bs-heading-align-centered .block-title {
   text-align: center;
+  display: block;
 }
 
 /*** Background Color Settings ***/


### PR DESCRIPTION
Adds `display: block` to center-aligned block header (within block styles) to fix issue with `<strong>` styled headers not aligning correctly.

Resolves #1768 