### PR TITLE
Double left/right padding

### DIFF
--- a/css/block/content-grid.css
+++ b/css/block/content-grid.css
@@ -3,8 +3,8 @@
  */
 
 .content-grid-block .row {
-  --bs-gutter-x: 1.5em;
-  --bs-gutter-y: 1.5em;
+  --bs-gutter-x: 3em;
+  --bs-gutter-y: 3em;
 }
 
 .content-grid-block .grid-column .grid-image-container {

--- a/css/layout-builder-styles.css
+++ b/css/layout-builder-styles.css
@@ -373,7 +373,7 @@
 
 .ucb-contained-row .ucb-hero-unit-content {
   --bs-gutter-y: 1.5rem;
-  --bs-gutter-x: 1.5rem;
+  --bs-gutter-x: 3rem;
 }
 
 .ucb-contained-row .ucb-hero-outer-wrapper,

--- a/css/style.css
+++ b/css/style.css
@@ -24,6 +24,27 @@
   --ucb-alert-yellow: #FDD835;
 }
 
+/*
+ * Double the default Bootstrap horizontal gutter (1.5rem -> 3rem). Containers use
+ * padding-x: calc(var(--bs-gutter-x) * 0.5); rows use matching negative margins and
+ * columns use half-gutter padding, so all must share the same variable.
+ * Gutter utility classes are re-listed afterward so they still override .row (our rules
+ * load after bootstrap.min.css).
+ */
+.container,
+.container-fluid,
+.container-lg,
+.container-md,
+.container-sm,
+.container-xl,
+.container-xxl {
+  --bs-gutter-x: 3rem;
+}
+
+.row {
+  --bs-gutter-x: 3rem;
+}
+
 /* Needed for Font Awesome  */
  @font-face {
     font-family: 'Font Awesome 6 Free - Brands';


### PR DESCRIPTION
Updated base gutter x to be double the width so that padding on left/right of content is double and aligned.

Should be clean alignment across all section options, block styles, and block layout placements (hopefully)

Resolves #1777 