### PR TITLE
Issue/1780

### DIFF
--- a/css/block/image-gallery.css
+++ b/css/block/image-gallery.css
@@ -3,16 +3,23 @@
   height: auto;
 }
 
+/*
+ * Block + article paragraph galleries: equal horizontal and vertical gaps between
+ * thumbnails. 1.5rem each axis (matches Bootstrap g-4).
+ * Do not zero out column margin-top here — Bootstrap rows rely on --bs-gutter-y for
+ * vertical spacing between wrapped rows.
+ */
+.row.gallery-div {
+  --ucb-gallery-thumb-gutter: 1.5rem;
+  --bs-gutter-x: var(--ucb-gallery-thumb-gutter);
+  --bs-gutter-y: var(--ucb-gallery-thumb-gutter);
+}
+
 .ucb-above-content .block-content--type--image-gallery,
 .ucb-below-content .block-content--type--image-gallery {
   padding: 1.5em;
 }
 
-.masonry-option-true,
-.masonry-option-true .gallery-item {
-margin-top: 0;
-padding-top: 5px;
-}
 .masonry-option-true .gallery-item a {
   position: relative;
   display: flex;
@@ -35,8 +42,8 @@ padding-top: 5px;
  * (.ucb-bootstrap-layout-section .column .block margin-bottom).
  */
 .ucb-article-body .paragraph--type--article-image-gallery {
-  --bs-gutter-y: 3rem;
-  margin-bottom: calc(var(--bs-gutter-y) * 0.5);
+  --ucb-article-block-spacing: 3rem;
+  margin-bottom: calc(var(--ucb-article-block-spacing) * 0.5);
 }
 
 /*

--- a/css/block/image-gallery.css
+++ b/css/block/image-gallery.css
@@ -31,6 +31,15 @@ padding-top: 5px;
 }
 
 /*
+ * Article body: match block vertical rhythm from layout-builder-styles.css
+ * (.ucb-bootstrap-layout-section .column .block margin-bottom).
+ */
+.ucb-article-body .paragraph--type--article-image-gallery {
+  --bs-gutter-y: 3rem;
+  margin-bottom: calc(var(--bs-gutter-y) * 0.5);
+}
+
+/*
  * Article secondary content: the article layout uses flex row + stretch, and
  * ucb-article.css applies max-height: 100% to all media images. That caps each
  * image to the column height and breaks multi-row galleries (rows collapse /

--- a/templates/block/block--image-gallery.html.twig
+++ b/templates/block/block--image-gallery.html.twig
@@ -18,8 +18,8 @@
 {% set galleryID = 'gallery'|clean_unique_id %}
 
 {% if masonryStyle == "True" %}
-  {% set totalColumns = content.field_masonry_columns[0]|render %}
-  {% if totalColumns == 2 %}
+  {% set totalColumns = content.field_masonry_columns[0]|render|striptags|trim %}
+  {% if totalColumns == '2' %}
     {% set tabletColumns = 2 %}
   {% endif %}
 {% endif %}

--- a/templates/block/block--image-gallery.html.twig
+++ b/templates/block/block--image-gallery.html.twig
@@ -27,7 +27,7 @@
 {% extends '@boulder_base/block/styled-block.html.twig' %}
 {% block content %}
   {{ attach_library('boulder_base/ucb-image-gallery') }}
-  <div class="row row-cols-lg-{{totalColumns}} row-cols-md-{{tabletColumns}} row-cols-2 g-4 gallery-div masonry-option-true" data-masonry='{"percentPosition": true }'>
+  <div class="row row-cols-lg-{{totalColumns}} row-cols-md-{{tabletColumns}} row-cols-2 gallery-div masonry-option-true" data-masonry='{"percentPosition": true }'>
     {% for key, item in content['#block_content'].field_image_gallery_photo  %}
       {% if key|first != '#' %}
         {% if item.entity.field_media_image_caption.value|render|striptags|trim %}

--- a/templates/paragraphs/paragraph--article-image-gallery.html.twig
+++ b/templates/paragraphs/paragraph--article-image-gallery.html.twig
@@ -49,7 +49,7 @@
                   {% else %}
                     <div class="col gallery-item">
                       <a href="{{ file_url(item.entity.field_media_image.entity.fileuri) }}" class="glightbox ucb-gallery-lightbox" data-gallery="{{ galleryID }}" data-glightbox="description: {{ photoDescription }} ">
-                        {{ item.entity|view }}
+                        {{ item|view }}
                       </a>
                     </div>
                   {% endif %}

--- a/templates/paragraphs/paragraph--article-image-gallery.html.twig
+++ b/templates/paragraphs/paragraph--article-image-gallery.html.twig
@@ -30,7 +30,7 @@
         <div class="ucb-article-row-subrow row">
           <div class="col-12">
             {{ attach_library('boulder_base/ucb-image-gallery') }}
-            <div class="row row-cols-lg-{{ totalColumns }} row-cols-md-{{ tabletColumns }} row-cols-2 g-4 gallery-div masonry-option-true" data-masonry='{"percentPosition": true }'>
+            <div class="row row-cols-lg-{{ totalColumns }} row-cols-md-{{ tabletColumns }} row-cols-2 gallery-div masonry-option-true" data-masonry='{"percentPosition": true }'>
               {% for key, item in paragraph.field_image_gallery_photo %}
                 {% if key|first != '#' %}
                   {% if item.entity.field_media_image_caption.value|render|striptags|trim %}


### PR DESCRIPTION
Fixed the image focal render issue for the article image gallery
Adjusted both margin and padding options for the article image gallery
- Padding changes required custom gutter settings for image gallery only they should not affect any other gutters
- Padding changes affect both article and block image galleries
Found and fixed a render php bug on the block image gallery when using masonry options.

Sister PR: https://github.com/CuBoulder/tiamat-custom-entities/pull/231

Resolves #1780 