### PR TITLE
Issue/1795

### DIFF
--- a/css/ucb-article.css
+++ b/css/ucb-article.css
@@ -219,6 +219,12 @@ i.fa-regular.fa-calendar {
 }
 
 /* Advanced "Narrow" page style: shorter line length in Article Text paragraphs (article_content). */
+.ucb-page-style-narrow .ucb-article-body .paragraph--type--article-content .ucb-article-text {
+  line-height: 1.5;
+  padding-top: 40px;
+  padding-bottom: 40px;
+}
+
 @media (min-width: 768px) {
   .ucb-page-style-narrow .ucb-article-body .paragraph--type--article-content .ucb-article-text {
     font-size: 19px;

--- a/templates/paragraphs/paragraph--media.html.twig
+++ b/templates/paragraphs/paragraph--media.html.twig
@@ -42,12 +42,6 @@
         alt="{{ media.field_media_image.alt|e('html_attr') }}"
         loading="lazy"
       />
-      {% if media.field_media_image_caption.0 is not empty
-        and (media.field_media_image_caption.0.value|default('')|striptags|trim|length > 0) %}
-        <div class="ucb-paragraph-media__caption ucb-article-content-media__caption text-muted small">
-          {{ media.field_media_image_caption|render }}
-        </div>
-      {% endif %}
     </div>
   {% elseif content.field_media %}
     <div class="ucb-paragraph-media__video">


### PR DESCRIPTION
Fixes the bug of the article page breaking if an image with a caption is added to the secondary media.

Update spacing on the advanced `Narrow` style so that the text will have more breathing room.

Resolves #1795 
Resolves #1796 