### PR TITLE
Fixit: Survey Form Styling

### DIFF
--- a/boulder_base.libraries.yml
+++ b/boulder_base.libraries.yml
@@ -578,3 +578,9 @@ ucb-tos-acceptance:
   css:
     theme:
       css/ucb-tos-acceptance.css: { weight: 5 }
+
+ucb-fixit-survey:
+  version: 1.x
+  css: 
+    theme:
+      css/ucb-fixit-survey.css : { weight: 5}

--- a/css/ucb-fixit-survey.css
+++ b/css/ucb-fixit-survey.css
@@ -1,0 +1,50 @@
+/* This fixes the conditional post-Fixit survey rendered on the two form pages on Fixit sites. */
+/* This block is placed via Block Layout, and will be nested after the existing form, which creates a bunch of containers */
+#block-boulder-base-survey.container,
+#block-boulder-base-survey > .container,
+#block-boulder-base-survey .container.mb-4 {
+  max-width: none;
+  width: auto;
+  padding-left: 0;
+  padding-right: 0;
+  margin-left: 0;
+  margin-right: 0;
+}
+
+/* Remove bootstrap row gutters ONLY inside this block */
+#block-boulder-base-survey .row {
+  --bs-gutter-x: 0;
+  margin-left: 0;
+  margin-right: 0;
+}
+
+
+#block-boulder-base-fixitsurvey {
+  width: 100vw;
+  max-width: none;
+  margin-left: calc(50% - 50vw);
+  margin-right: calc(50% - 50vw);
+  padding-left: 0;
+  padding-right: 0;
+}
+
+/* Remove the extra Bootstrap container behavior inside this block */
+#block-boulder-base-fixitsurvey .container {
+  max-width: none;
+  width: auto;
+  padding-left: 0;
+  padding-right: 0;
+}
+
+/* Fix the font */
+.webform-submission-fix-it-survey-form,
+.webform-submission-fix-it-survey-form * {
+font-family: Roboto, "Helvetica Neue", Helvetica, Arial, sans-serif !important;
+  font-size: 16px;
+  line-height: 24px;
+}
+
+/* Emoji override */
+.webform-submission-fix-it-survey-form label.option {
+  font-family: "Apple Color Emoji", "Segoe UI Emoji", "Noto Color Emoji", sans-serif !important;
+}

--- a/templates/form/webform-submission-form--fix-it-survey.html.twig
+++ b/templates/form/webform-submission-form--fix-it-survey.html.twig
@@ -1,0 +1,4 @@
+{{ attach_library('boulder_base/ucb-fixit-survey') }}
+
+{# This file is just needed to fix style issues with nesting a block within the content of a Form Page, as Fixit does #}
+{{form}}


### PR DESCRIPTION
Adds in css for the Fixit's form, which is placed via Block Layout to appear after a form is completed on a Form node. This is setup to match current Fixit site behavior, however this method creates double or triple nested `.container` classes due to it being a block placed into a node, which results in odd padding.

This change only affects the `fix-it-survey` blocks. 