### PR TITLE
Fix row media sizing problems

### DIFF
--- a/css/block/content-row.css
+++ b/css/block/content-row.css
@@ -16,19 +16,46 @@
 }
 
 .ucb-content-row-teaser {
-  border-bottom: 2px solid rgba(128, 128, 128, 0.333);
-  margin-bottom: 20px;
+  display: block;
+  margin-bottom: 0;
+  border-bottom: 1px solid rgba(128, 128, 128, 0.333);
+  padding: 20px 0 0 0;
 }
 
-.teaser-row{
-  flex-direction: row-reverse;
-  justify-content: flex-end;
+.ucb-content-row-teaser:first-child {
+  padding-top: 0;
 }
 
-.ucb-content-row-teaser{
+.ucb-content-row-teaser .teaser-row {
   display: flex;
-  flex-direction: column;
+  flex-direction: row;
+  align-items: flex-start;
+  margin-left: 0;
+  margin-right: 0;
+}
+
+.ucb-content-row-teaser .row-text-container {
+  flex: 1;
+  min-width: 0;
+  padding-left: 0;
+  padding-right: 0;
+}
+
+.ucb-content-row-teaser .row-image-container {
+  width: fit-content;
+  flex: 0 0 auto;
+  max-width: calc(100px + var(--bs-gutter-x));
   margin-bottom: 20px;
+  padding-left: 0;
+  padding-right: calc(var(--bs-gutter-x) * 0.5);
+}
+
+.ucb-content-row-teaser .row-image-container img,
+.ucb-content-row-teaser .row-image-container picture img {
+  max-width: 100px;
+  width: 100%;
+  height: auto;
+  display: block;
 }
 .row-text-container-tile{
   padding: 80px 40px
@@ -125,12 +152,6 @@
   flex-direction: row-reverse;
 }
 
-.row-image-container{
-  width: calc(100px + var(--bs-gutter-x));
-  height: auto;
-  margin-bottom: 20px;
-}
-
 .row-image-container-tile-even {
   padding-left: 0px;
   padding-right: calc(var(--bs-gutter-x) * .5);
@@ -171,9 +192,13 @@
   }
 }
 
-@media screen and (max-width: 975px) {
-  .teaser-row{
-    flex-direction: column-reverse;
+@media only screen and (max-width: 575px) {
+  .ucb-content-row-teaser .teaser-row {
+    flex-direction: column;
+  }
+
+  .ucb-content-row-teaser .row-image-container {
+    padding-right: 0;
   }
 }
 @media screen and (max-width: 576px) {

--- a/css/ucb-article-list.css
+++ b/css/ucb-article-list.css
@@ -47,9 +47,15 @@
 }
 
 .ucb-article-card-img {
-  width: calc(100px + var(--bs-gutter-x));
   height: auto;
   margin-bottom: 20px;
+}
+
+.ucb-article-card-img img {
+  max-width: 100px;
+  width: 100%;
+  height: auto;
+  display: block;
 }
 
 .ucb-article-card-more {

--- a/templates/block/block--content-row.html.twig
+++ b/templates/block/block--content-row.html.twig
@@ -23,7 +23,18 @@
       {% set rowLink = item.entity.field_row_layout_content_link.0.url|render %}
       <div class="row-content ucb-content-row-teaser">{% set image = item.entity.field_row_layout_content_image.0 %}
         <div class="row teaser-row">
-          <div class="{{ image ? 'col-sm-10 ' : 'col-sm-12' }} row-text-container">
+        {% if image %}
+          <div class="row-image-container">
+            {% if rowLink %}
+              <a role="presentation" aria-hidden="true" href="{{ rowLink }} ">
+                {{ image|view }}
+              </a>
+            {% else %}
+              {{ image|view }}
+            {% endif %}
+          </div>
+        {% endif %}
+          <div class="row-text-container">
             {% if rowLink %}
               <a href="{{ rowLink }} ">
                 <h3>{{ item.entity.field_row_layout_content_title.0.value }}</h3>
@@ -33,17 +44,6 @@
             {% endif %}
             {{ item.entity.field_row_layout_content_text|view }}
           </div>
-        {% if image %}
-        <div class="col-sm-2 row-image-container">
-          {% if rowLink %}
-            <a role="presentation" aria-hidden="true" href="{{ rowLink }} ">
-              {{ image|view }}
-            </a>
-          {% else %}
-            {{ image|view }}
-          {% endif %}
-        </div>
-        {% endif %}
         </div>
       </div>
     {% endfor %}


### PR DESCRIPTION
Updated content rows to size properly for `teaser` style. Now matches the layout of article/content lists. Also updated article lists to size properly if a block layout sidebar is being used alongside it.

Please test content row `teaser` style and `article list` pages + those with a sidebar

Resolves #1790 