### PR TITLE
Update ucb-tos-acceptance.js

### DIFF
--- a/js/ucb-tos-acceptance.js
+++ b/js/ucb-tos-acceptance.js
@@ -229,6 +229,7 @@
         return fetch(acceptUrl, {
           method: 'POST',
           headers: {
+            'Accept': 'application/json',
             'Content-Type': 'application/json',
             'X-CSRF-Token': csrfToken,
           },
@@ -286,8 +287,14 @@
    * Gets the CSRF token from Drupal.
    */
   function getCsrfToken() {
-    // Fetch token from Drupal's session/token endpoint.
-    return fetch('/session/token', {
+    // Use base path + pathPrefix (Drupal.url) so subdirectory/multisite installs
+    // hit the real endpoint; a bare '/session/token' breaks on non-root sites.
+    const tokenUrl = (typeof Drupal !== 'undefined' && typeof Drupal.url === 'function')
+      ? Drupal.url('session/token')
+      : ((typeof drupalSettings !== 'undefined' && drupalSettings.path)
+        ? drupalSettings.path.baseUrl + (drupalSettings.path.pathPrefix || '') + 'session/token'
+        : '/session/token');
+    return fetch(tokenUrl, {
       method: 'GET',
       credentials: 'same-origin',
     })


### PR DESCRIPTION
Update accept type header as well as session token information to use base path on `colorado.edu` but also extend the token for sub directory paths like `colorado.edu/biden`

Resolves #1803 