### PR TITLE
Remove aspect ratios from image css styling

### DIFF
--- a/css/block/ucb-article-feature-block.css
+++ b/css/block/ucb-article-feature-block.css
@@ -99,12 +99,10 @@
   object-fit: cover !important;
   max-height: 500px !important;
   height: auto;
-  aspect-ratio: 3/2;
   max-width: 100%;
 }
 
 .feature-img-wide{
-  aspect-ratio: 16 / 9;
   object-fit: cover;
 }
 

--- a/css/ucb-issue.css
+++ b/css/ucb-issue.css
@@ -59,8 +59,7 @@
   font-size: 75%;
 }
 
-.feature-article-thumbnail>div>div>div>img {
-  aspect-ratio: 2 / 1;
+.feature-article-thumbnail>div>div>img {
   object-fit: cover;
   margin-bottom: 10px;
 }


### PR DESCRIPTION
To better preserve Focal Point intent on images, this change removes the `aspect-ratio` css attribute present on the following images:
- Article Feature (Block)
- Issue (Content Type)

Also fixes a css logic bug on Issue (content type) where a set of styling wasn't being applied

Reviewing the change log, It seems to be required for js libraries responsible for slider behavior on the following blocks:
- Article Slider (block)
- Hero Slider (block)

Resolves #1818 
