### PR TITLE
#1653 - Hamburger menu breakpoint takes effect sooner

### DIFF
--- a/css/ucb-menu.css
+++ b/css/ucb-menu.css
@@ -31,7 +31,7 @@
   width: 100%;
 }
 
-@media only screen and (max-width: 575px) {
+@media only screen and (max-width: 767px) {
   section.ucb-main-nav-section.ucb-header-black {
     color: #FFF;
     background-color: #000;


### PR DESCRIPTION
Adjusts the full -> mobile menu breakpoint triggering the hamburger menu to take effect at 767px instead of 575px widths, to prevent the main or secondary menus from wrapping. 

Resolves #1653 