### PR TITLE
Image Gallery Block - remove captions

### DIFF
--- a/templates/block/block--image-gallery.html.twig
+++ b/templates/block/block--image-gallery.html.twig
@@ -46,7 +46,7 @@
         {% else %}
           <div class="col gallery-item">
             <a href="{{ file_url(item.entity.field_media_image.entity.fileuri) }}" class="glightbox ucb-gallery-lightbox" data-gallery="{{ galleryID }}" data-glightbox="description: {{ photoDescription }} ">
-              {{ item|view }}
+              {{ item.entity.field_media_image|view }}
             </a>
           </div>
         {% endif %}

--- a/templates/paragraphs/paragraph--article-image-gallery.html.twig
+++ b/templates/paragraphs/paragraph--article-image-gallery.html.twig
@@ -49,7 +49,7 @@
                   {% else %}
                     <div class="col gallery-item">
                       <a href="{{ file_url(item.entity.field_media_image.entity.fileuri) }}" class="glightbox ucb-gallery-lightbox" data-gallery="{{ galleryID }}" data-glightbox="description: {{ photoDescription }} ">
-                        {{ item|view }}
+                        {{ item.entity.field_media_image|view }}
                       </a>
                     </div>
                   {% endif %}


### PR DESCRIPTION
Update item display entity so only the images show on the image gallery by default. Then when they're opened up the captions show in the lightbox as expected.

Resolves #1827