### PR TITLE
Fix masonry options on image gallery.

### DIFF
--- a/templates/block/block--image-gallery.html.twig
+++ b/templates/block/block--image-gallery.html.twig
@@ -14,12 +14,12 @@
 
 {% set totalColumns = "6" %}
 {% set tabletColumns = "3" %}
-{% set masonryStyle = content.field_masonry_display[0]|render|striptags|trim %}
+{% set masonryOn = content['#block_content'].field_masonry_display.value %}
 {% set galleryID = 'gallery'|clean_unique_id %}
 
-{% if masonryStyle == "True" %}
-  {% set totalColumns = content.field_masonry_columns[0]|render|striptags|trim %}
-  {% if totalColumns == '2' %}
+{% if masonryOn %}
+  {% set totalColumns = content['#block_content'].field_masonry_columns.value %}
+  {% if totalColumns == 2 %}
     {% set tabletColumns = 2 %}
   {% endif %}
 {% endif %}
@@ -27,7 +27,7 @@
 {% extends '@boulder_base/block/styled-block.html.twig' %}
 {% block content %}
   {{ attach_library('boulder_base/ucb-image-gallery') }}
-  <div class="row row-cols-lg-{{totalColumns}} row-cols-md-{{tabletColumns}} row-cols-2 gallery-div masonry-option-true" data-masonry='{"percentPosition": true }'>
+  <div class="row row-cols-lg-{{ totalColumns }} row-cols-md-{{ tabletColumns }} row-cols-2 gallery-div{% if masonryOn %} masonry-option-true{% endif %}"{% if masonryOn %} data-masonry='{"percentPosition": true }'{% endif %}>
     {% for key, item in content['#block_content'].field_image_gallery_photo  %}
       {% if key|first != '#' %}
         {% if item.entity.field_media_image_caption.value|render|striptags|trim %}
@@ -35,7 +35,7 @@
         {% else %}
           {% set photoDescription = "" %}
         {% endif %}
-        {% if masonryStyle == "True" %}
+        {% if masonryOn %}
           <div class="col gallery-item">
             <a href="{{ file_url(item.entity.field_media_image.entity.fileuri) }}" class="glightbox ucb-gallery-lightbox" data-gallery="{{ galleryID }}" data-glightbox="description: {{ photoDescription }} ">
               <div class ="imageMediaStyle large_image_style">
@@ -46,7 +46,7 @@
         {% else %}
           <div class="col gallery-item">
             <a href="{{ file_url(item.entity.field_media_image.entity.fileuri) }}" class="glightbox ucb-gallery-lightbox" data-gallery="{{ galleryID }}" data-glightbox="description: {{ photoDescription }} ">
-              {{ item.entity.field_media_image|view }}
+              <img src="{{ item.entity.field_media_image.entity.fileuri|image_style('focal_image_square') }}" alt="{{ item.entity.field_media_image.alt|render }}" loading="lazy">
             </a>
           </div>
         {% endif %}

--- a/templates/paragraphs/paragraph--article-image-gallery.html.twig
+++ b/templates/paragraphs/paragraph--article-image-gallery.html.twig
@@ -30,7 +30,7 @@
         <div class="ucb-article-row-subrow row">
           <div class="col-12">
             {{ attach_library('boulder_base/ucb-image-gallery') }}
-            <div class="row row-cols-lg-{{ totalColumns }} row-cols-md-{{ tabletColumns }} row-cols-2 gallery-div masonry-option-true" data-masonry='{"percentPosition": true }'>
+            <div class="row row-cols-lg-{{ totalColumns }} row-cols-md-{{ tabletColumns }} row-cols-2 gallery-div{% if masonryOn %} masonry-option-true{% endif %}"{% if masonryOn %} data-masonry='{"percentPosition": true }'{% endif %}>
               {% for key, item in paragraph.field_image_gallery_photo %}
                 {% if key|first != '#' %}
                   {% if item.entity.field_media_image_caption.value|render|striptags|trim %}
@@ -49,7 +49,7 @@
                   {% else %}
                     <div class="col gallery-item">
                       <a href="{{ file_url(item.entity.field_media_image.entity.fileuri) }}" class="glightbox ucb-gallery-lightbox" data-gallery="{{ galleryID }}" data-glightbox="description: {{ photoDescription }} ">
-                        {{ item.entity.field_media_image|view }}
+                        <img src="{{ item.entity.field_media_image.entity.fileuri|image_style('focal_image_square') }}" alt="{{ item.entity.field_media_image.alt|render }}" loading="lazy">
                       </a>
                     </div>
                   {% endif %}


### PR DESCRIPTION
The image gallery defaults to having masonry on whether or not the block is set to it.

Fix boolean and logic to avoid breaking the block styles.
Also fix the non-masonry image style. Remove from logic check and add into the section itself.

Resolves #1839 